### PR TITLE
fix(harness): resolve waiver reviewer from auth user

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 12358 nodes · 15207 edges · 2837 communities detected
+- 12359 nodes · 15208 edges · 2837 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3655,44 +3655,44 @@ Cohesion: 0.26
 Nodes (10): archivedProductNestedOrigin(), buildVariantSkuMoneyPayload(), createVariantSku(), decodeOriginValue(), deleteActiveProduct(), getArchivedProductRedirect(), modifyProduct(), onSubmit() (+2 more)
 
 ### Community 195 - "Community 195"
-Cohesion: 0.23
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 196 - "Community 196"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.22
 Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.31
 Nodes (12): captureRegisterCatalogRuntimePin(), chooseRegisterCatalogRuntimeOwnerId(), clearRegisterCatalogRuntimeActionGuard(), clearRegisterCatalogRuntimeSelection(), getRegisterCatalogRuntimeOwnerId(), hasRegisterCatalogRuntimeActionGuard(), keyForScope(), maintainOwnerClaim() (+4 more)
 
-### Community 199 - "Community 199"
+### Community 198 - "Community 198"
 Cohesion: 0.31
 Nodes (11): appendEvent(), beginPrintAttempt(), buildMetadata(), finalizePrintAttempt(), getPrintRejectionMetadata(), getReasonMessage(), isTargetTerminal(), mintAttemptId() (+3 more)
 
-### Community 200 - "Community 200"
+### Community 199 - "Community 199"
 Cohesion: 0.32
 Nodes (11): clearPosClientTelemetryBuffer(), enqueuePosClientEvent(), mintClientEventId(), normalizePosTelemetryError(), peekPosClientEventBatch(), posClientTelemetryBufferSize(), readBuffer(), removePosClientEvents() (+3 more)
 
-### Community 201 - "Community 201"
+### Community 200 - "Community 200"
 Cohesion: 0.19
 Nodes (5): buildCompletedSalePayload(), completedCustomerInfo(), hasCustomerDetails(), isPosPaymentMethod(), mapLocalPaymentToPayment()
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.22
 Nodes (9): findRegisterCloseoutReviewItem(), formatCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionCode(), getCloseoutCloudRegisterSessionId(), getLatestLocalRegisterLifecycleEvent(), getPendingLocalCashVoidApprovals(), getPendingLocalCloseoutRegisterSession(), readLocalSyncStatus() (+1 more)
 
-### Community 203 - "Community 203"
+### Community 202 - "Community 202"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.23
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.28
@@ -4167,12 +4167,12 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 323 - "Community 323"
-Cohesion: 0.39
-Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
-
-### Community 324 - "Community 324"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 324 - "Community 324"
+Cohesion: 0.39
+Nodes (8): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), resolveViewportBucket(), trackStorefrontEvent()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.22
@@ -5131,164 +5131,164 @@ Cohesion: 0.5
 Nodes (2): historicalCostLane(), materializeDeferredAdjustmentWithCtx()
 
 ### Community 564 - "Community 564"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 567 - "Community 567"
 Cohesion: 0.7
 Nodes (4): backfillStoreTimezoneAuthorityWithCtx(), buildRow(), listSchedulesForStore(), normalizeLimit()
 
-### Community 568 - "Community 568"
+### Community 567 - "Community 567"
 Cohesion: 0.5
 Nodes (2): recordNotificationFailureEventWithCtx(), recordTerminalDeliveryFailureEvent()
 
-### Community 569 - "Community 569"
+### Community 568 - "Community 568"
 Cohesion: 0.6
 Nodes (4): dedupeKey(), keyFor(), prepare(), stubCtx()
 
-### Community 570 - "Community 570"
+### Community 569 - "Community 569"
 Cohesion: 0.7
 Nodes (4): createNormalUserOperationAdapter(), createPublicOperationAdapter(), isAdmitted(), resolveOperationAdmission()
 
-### Community 571 - "Community 571"
+### Community 570 - "Community 570"
 Cohesion: 0.6
 Nodes (4): consumeApprovalRequesterChallengeWithCtx(), createApprovalRequesterChallengeWithCtx(), invalidApprovalRequesterChallengeResult(), toRequesterBinding()
 
-### Community 572 - "Community 572"
+### Community 571 - "Community 571"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 573 - "Community 573"
+### Community 572 - "Community 572"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 574 - "Community 574"
+### Community 573 - "Community 573"
 Cohesion: 0.6
 Nodes (3): listTransactionPayments(), transactionCashDelta(), transactionPaymentTotals()
 
-### Community 575 - "Community 575"
+### Community 574 - "Community 574"
 Cohesion: 0.5
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 576 - "Community 576"
+### Community 575 - "Community 575"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 577 - "Community 577"
+### Community 576 - "Community 576"
 Cohesion: 0.7
 Nodes (4): acknowledgeRegisterLifecycleAuthority(), equivalentAcknowledgement(), isRevision(), normalizeSafeMetadata()
 
-### Community 578 - "Community 578"
+### Community 577 - "Community 577"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 579 - "Community 579"
+### Community 578 - "Community 578"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 580 - "Community 580"
+### Community 579 - "Community 579"
 Cohesion: 0.5
 Nodes (2): baseInput(), buildRuntimeStatus()
 
-### Community 581 - "Community 581"
+### Community 580 - "Community 580"
 Cohesion: 0.6
 Nodes (4): buildCtx(), buildQueryCtx(), filterRows(), orderedRows()
 
-### Community 582 - "Community 582"
+### Community 581 - "Community 581"
 Cohesion: 0.6
 Nodes (4): requirePosCustomerAccessById(), requirePosCustomerReadAccessById(), requirePosCustomerStoreAccess(), requirePosCustomerStoreReadAccess()
+
+### Community 582 - "Community 582"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 583 - "Community 583"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 584 - "Community 584"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 585 - "Community 585"
 Cohesion: 0.5
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 586 - "Community 586"
+### Community 585 - "Community 585"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 587 - "Community 587"
+### Community 586 - "Community 586"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 588 - "Community 588"
+### Community 587 - "Community 587"
 Cohesion: 0.7
 Nodes (4): factFingerprint(), fingerprintPayload(), matchesStoredFingerprint(), stableStringHash()
 
-### Community 589 - "Community 589"
+### Community 588 - "Community 588"
 Cohesion: 0.6
 Nodes (3): fact(), receipt(), sale()
 
-### Community 590 - "Community 590"
+### Community 589 - "Community 589"
 Cohesion: 0.5
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 591 - "Community 591"
+### Community 590 - "Community 590"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 592 - "Community 592"
+### Community 591 - "Community 591"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 593 - "Community 593"
+### Community 592 - "Community 592"
 Cohesion: 0.6
 Nodes (3): isSharedDemoEnabled(), readRuntimeSharedDemoConfig(), readSharedDemoConfig()
 
-### Community 594 - "Community 594"
+### Community 593 - "Community 593"
 Cohesion: 0.8
 Nodes (4): buildSharedDemoOpeningBaseline(), buildSharedDemoStoreDayEvent(), rollSharedDemoOpeningBaselineWithCtx(), sharedDemoOperatingDateRange()
 
-### Community 595 - "Community 595"
+### Community 594 - "Community 594"
 Cohesion: 0.5
 Nodes (2): sharedDemoDenialError(), sharedDemoDenied()
 
-### Community 596 - "Community 596"
+### Community 595 - "Community 595"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
-### Community 597 - "Community 597"
+### Community 596 - "Community 596"
 Cohesion: 0.7
 Nodes (4): buildLookup(), buildOnlineOrderTraceSeed(), buildSafeExternalReferenceRef(), stableFingerprint()
 
-### Community 598 - "Community 598"
+### Community 597 - "Community 597"
 Cohesion: 0.5
 Nodes (2): createAdminTraceReadCtx(), createTestCtx()
+
+### Community 598 - "Community 598"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 599 - "Community 599"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 600 - "Community 600"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 601 - "Community 601"
 Cohesion: 0.5
 Nodes (2): cancel(), handleClick()
 
-### Community 602 - "Community 602"
+### Community 601 - "Community 601"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 603 - "Community 603"
+### Community 602 - "Community 602"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 603 - "Community 603"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 604 - "Community 604"
 Cohesion: 0.4
@@ -5299,12 +5299,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 606 - "Community 606"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 607 - "Community 607"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 607 - "Community 607"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 608 - "Community 608"
 Cohesion: 0.4
@@ -5343,72 +5343,72 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 617 - "Community 617"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 618 - "Community 618"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 619 - "Community 619"
+### Community 618 - "Community 618"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 620 - "Community 620"
+### Community 619 - "Community 619"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 621 - "Community 621"
+### Community 620 - "Community 620"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 622 - "Community 622"
+### Community 621 - "Community 621"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 623 - "Community 623"
+### Community 622 - "Community 622"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 624 - "Community 624"
+### Community 623 - "Community 623"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 625 - "Community 625"
+### Community 624 - "Community 624"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 626 - "Community 626"
+### Community 625 - "Community 625"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 627 - "Community 627"
+### Community 626 - "Community 626"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 628 - "Community 628"
+### Community 627 - "Community 627"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 629 - "Community 629"
+### Community 628 - "Community 628"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 630 - "Community 630"
+### Community 629 - "Community 629"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 631 - "Community 631"
+### Community 630 - "Community 630"
 Cohesion: 0.6
 Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
 
-### Community 632 - "Community 632"
+### Community 631 - "Community 631"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 633 - "Community 633"
+### Community 632 - "Community 632"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+
+### Community 633 - "Community 633"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 634 - "Community 634"
 Cohesion: 0.4
@@ -5423,40 +5423,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 637 - "Community 637"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 638 - "Community 638"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 639 - "Community 639"
+### Community 638 - "Community 638"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 640 - "Community 640"
+### Community 639 - "Community 639"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 641 - "Community 641"
+### Community 640 - "Community 640"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 642 - "Community 642"
+### Community 641 - "Community 641"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 643 - "Community 643"
+### Community 642 - "Community 642"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 644 - "Community 644"
+### Community 643 - "Community 643"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 645 - "Community 645"
+### Community 644 - "Community 644"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 645 - "Community 645"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 646 - "Community 646"
 Cohesion: 0.7
@@ -5679,40 +5679,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 701 - "Community 701"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 702 - "Community 702"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 703 - "Community 703"
+### Community 702 - "Community 702"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 704 - "Community 704"
+### Community 703 - "Community 703"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 705 - "Community 705"
+### Community 704 - "Community 704"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 706 - "Community 706"
+### Community 705 - "Community 705"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 707 - "Community 707"
+### Community 706 - "Community 706"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 708 - "Community 708"
+### Community 707 - "Community 707"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 709 - "Community 709"
+### Community 708 - "Community 708"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 709 - "Community 709"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 710 - "Community 710"
 Cohesion: 0.5
@@ -5724,7 +5724,7 @@ Nodes (0):
 
 ### Community 712 - "Community 712"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 713 - "Community 713"
 Cohesion: 0.5
@@ -9040,11 +9040,11 @@ Nodes (0):
 
 ### Community 1541 - "Community 1541"
 Cohesion: 1.0
-Nodes (1): FakeMessageChannel
+Nodes (0):
 
 ### Community 1542 - "Community 1542"
 Cohesion: 1.0
-Nodes (0):
+Nodes (1): FakeMessageChannel
 
 ### Community 1543 - "Community 1543"
 Cohesion: 1.0
@@ -14271,491 +14271,493 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1155`** (2 nodes): `WalkthroughRequestNotification.tsx`, `delinkUntrustedEmailText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (2 nodes): `registrationAuthorization.ts`, `required()`
+- **Thin community `Community 1156`** (2 nodes): `registrationAuthorization.test.ts`, `authenticatedTestUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1157`** (2 nodes): `registrationAuthorization.ts`, `required()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
+- **Thin community `Community 1158`** (2 nodes): `resolvePublicBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (2 nodes): `brokerEnv()`, `harnessWaivers.test.ts`
+- **Thin community `Community 1159`** (2 nodes): `readBoundedBody()`, `boundedBody.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 1160`** (2 nodes): `brokerEnv()`, `harnessWaivers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 1161`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 1162`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 1163`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 1164`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
+- **Thin community `Community 1165`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
+- **Thin community `Community 1166`** (2 nodes): `createFakeStructuredTextProvider()`, `fake.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
+- **Thin community `Community 1167`** (2 nodes): `isExpiredSharedDemoSessionError()`, `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 1168`** (2 nodes): `source()`, `athenaUserIdentityWriters.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
+- **Thin community `Community 1169`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 1170`** (2 nodes): `getHandler()`, `bannerMessage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
+- **Thin community `Community 1171`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 1172`** (2 nodes): `createCatalogSummaryCtx()`, `catalogSummary.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
+- **Thin community `Community 1173`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (2 nodes): `createWorkContext()`, `inventoryImportCostOverlayWork.test.ts`
+- **Thin community `Community 1174`** (2 nodes): `createFakeMutationCtx()`, `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 1175`** (2 nodes): `createWorkContext()`, `inventoryImportCostOverlayWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
+- **Thin community `Community 1176`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 1177`** (2 nodes): `productSku.ts`, `syncProductSkuSearchProjectionsByStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 1178`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (2 nodes): `context()`, `commerceEffects.test.ts`
+- **Thin community `Community 1179`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
+- **Thin community `Community 1180`** (2 nodes): `context()`, `commerceEffects.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (2 nodes): `scheduleWork.ts`, `scheduleReportingWorkBestEffort()`
+- **Thin community `Community 1181`** (2 nodes): `positionRevisions.ts`, `recordInventoryPositionRevisionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
+- **Thin community `Community 1182`** (2 nodes): `scheduleWork.ts`, `scheduleReportingWorkBestEffort()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 1183`** (2 nodes): `context()`, `athenaUserAuth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
+- **Thin community `Community 1184`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 1185`** (2 nodes): `storeMemberAccess.ts`, `requireStoreMemberAccessWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 1186`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 1187`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
+- **Thin community `Community 1188`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
+- **Thin community `Community 1189`** (2 nodes): `shouldExpireFunnelRecord()`, `landingFunnelRetention.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
+- **Thin community `Community 1190`** (2 nodes): `walkthroughBudgets.ts`, `consumeWalkthroughBudget()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (2 nodes): `createCtx()`, `backfillStoreTimezoneAuthority.test.ts`
+- **Thin community `Community 1191`** (2 nodes): `walkthroughRequestNotifications.test.ts`, `insertAttempt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
+- **Thin community `Community 1192`** (2 nodes): `createCtx()`, `backfillStoreTimezoneAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 1193`** (2 nodes): `createCtx()`, `migratePosAmountsToPesewas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (2 nodes): `sweeper.ts`, `terminalizeOrphanedDelivery()`
+- **Thin community `Community 1194`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (2 nodes): `transport.test.ts`, `stubFetch()`
+- **Thin community `Community 1195`** (2 nodes): `sweeper.ts`, `terminalizeOrphanedDelivery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (2 nodes): `transport.ts`, `sendNotificationEmail()`
+- **Thin community `Community 1196`** (2 nodes): `transport.test.ts`, `stubFetch()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (2 nodes): `declaresProtectedGateway()`, `effects.ts`
+- **Thin community `Community 1197`** (2 nodes): `transport.ts`, `sendNotificationEmail()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (2 nodes): `readAdapters.test.ts`, `demoCtx()`
+- **Thin community `Community 1198`** (2 nodes): `declaresProtectedGateway()`, `effects.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (2 nodes): `scopes.ts`, `resolveOperationScope()`
+- **Thin community `Community 1199`** (2 nodes): `readAdapters.test.ts`, `demoCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 1200`** (2 nodes): `scopes.ts`, `resolveOperationScope()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 1201`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 1202`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 1203`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 1204`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
+- **Thin community `Community 1205`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (2 nodes): `managerReportTopItemsFromMix()`, `managerReportTopItems.ts`
+- **Thin community `Community 1206`** (2 nodes): `workItem()`, `logicalOperationalWork.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 1207`** (2 nodes): `managerReportTopItemsFromMix()`, `managerReportTopItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (2 nodes): `fullWindow()`, `owedDailyCloseSweep.test.ts`
+- **Thin community `Community 1208`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
+- **Thin community `Community 1209`** (2 nodes): `fullWindow()`, `owedDailyCloseSweep.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
+- **Thin community `Community 1210`** (2 nodes): `paymentAllocationCallers.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
+- **Thin community `Community 1211`** (2 nodes): `registerCloseoutVarianceEmail.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 1212`** (2 nodes): `staffMessages.ts`, `requireStoreMember()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 1213`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 1214`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
+- **Thin community `Community 1215`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 1216`** (2 nodes): `redactSensitiveDiagnosticText()`, `diagnosticRedaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 1217`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (2 nodes): `recordLocalSyncDeadLetter()`, `deadLetter.ts`
+- **Thin community `Community 1218`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
+- **Thin community `Community 1219`** (2 nodes): `recordLocalSyncDeadLetter()`, `deadLetter.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
+- **Thin community `Community 1220`** (2 nodes): `projectionPolicies.test.ts`, `saleItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
+- **Thin community `Community 1221`** (2 nodes): `registerCatalogRevision.test.ts`, `createRevisionCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 1222`** (2 nodes): `resolveLocalSyncReview.test.ts`, `createFakeRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 1223`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
+- **Thin community `Community 1224`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
+- **Thin community `Community 1225`** (2 nodes): `posLifecycleJournal.test.ts`, `createCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 1226`** (2 nodes): `posLifecycleJournal.ts`, `appendPosLifecycleJournalWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 1227`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 1228`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
+- **Thin community `Community 1229`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
+- **Thin community `Community 1230`** (2 nodes): `registerLifecycleAuthorityRepository.ts`, `createRegisterLifecycleAuthorityRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 1231`** (2 nodes): `registerSessionRepository.test.ts`, `createRegisterSessionQueryCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 1232`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 1233`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
+- **Thin community `Community 1234`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1235`** (2 nodes): `remoteAssistRepository.ts`, `createRemoteAssistRepository()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 1236`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 1237`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 1238`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (2 nodes): `context()`, `access.test.ts`
+- **Thin community `Community 1239`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (2 nodes): `requireReportsStoreAccess()`, `access.ts`
+- **Thin community `Community 1240`** (2 nodes): `context()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (2 nodes): `fact()`, `fingerprint.test.ts`
+- **Thin community `Community 1241`** (2 nodes): `requireReportsStoreAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (2 nodes): `markDirty()`, `marks.ts`
+- **Thin community `Community 1242`** (2 nodes): `fact()`, `fingerprint.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (2 nodes): `transactionCounts.ts`, `transactionCountFromCloseSummary()`
+- **Thin community `Community 1243`** (2 nodes): `markDirty()`, `marks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (2 nodes): `weeklyInventory.test.ts`, `inventoryReview()`
+- **Thin community `Community 1244`** (2 nodes): `transactionCounts.ts`, `transactionCountFromCloseSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (2 nodes): `weeklyPeriods.test.ts`, `schedule()`
+- **Thin community `Community 1245`** (2 nodes): `weeklyInventory.test.ts`, `inventoryReview()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (2 nodes): `weeklyRepair.test.ts`, `ledgerIdentity()`
+- **Thin community `Community 1246`** (2 nodes): `weeklyPeriods.test.ts`, `schedule()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (2 nodes): `weeklyRepair.ts`, `repairCurrentWeeklyProjectionWithCtx()`
+- **Thin community `Community 1247`** (2 nodes): `weeklyRepair.test.ts`, `ledgerIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
+- **Thin community `Community 1248`** (2 nodes): `weeklyRepair.ts`, `repairCurrentWeeklyProjectionWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 1249`** (2 nodes): `posLocalSyncContractValidators.ts`, `unionFromValidators()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
+- **Thin community `Community 1250`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (2 nodes): `contextFor()`, `actor.test.ts`
+- **Thin community `Community 1251`** (2 nodes): `serviceCaseTracing.test.ts`, `buildServiceCase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (2 nodes): `invoke()`, `enforcement.test.ts`
+- **Thin community `Community 1252`** (2 nodes): `contextFor()`, `actor.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (2 nodes): `demoCtx()`, `operationAdapter.test.ts`
+- **Thin community `Community 1253`** (2 nodes): `invoke()`, `enforcement.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
+- **Thin community `Community 1254`** (2 nodes): `demoCtx()`, `operationAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
+- **Thin community `Community 1255`** (2 nodes): `posStoreReadAccessCoverage.test.ts`, `source()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (2 nodes): `provision.test.ts`, `seedDemoRegisterFoundation()`
+- **Thin community `Community 1256`** (2 nodes): `providerEnforcement.test.ts`, `invoke()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (2 nodes): `registerBaseline.test.ts`, `seedStoreWithRegister()`
+- **Thin community `Community 1257`** (2 nodes): `provision.test.ts`, `seedDemoRegisterFoundation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
+- **Thin community `Community 1258`** (2 nodes): `registerBaseline.test.ts`, `seedStoreWithRegister()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (2 nodes): `scheduledRestore.test.ts`, `keyAt()`
+- **Thin community `Community 1259`** (2 nodes): `restore.test.ts`, `restoreStateContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 1260`** (2 nodes): `scheduledRestore.test.ts`, `keyAt()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 1261`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
+- **Thin community `Community 1262`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 1263`** (2 nodes): `purchaseOrderTracing.test.ts`, `createWorkflowTraceCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 1264`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 1265`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 1266`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 1267`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
+- **Thin community `Community 1268`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (2 nodes): `payment.test.ts`, `getHandler()`
+- **Thin community `Community 1269`** (2 nodes): `sku()`, `homepageSnapshot.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 1270`** (2 nodes): `payment.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 1271`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 1272`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 1273`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 1274`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 1275`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 1276`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (2 nodes): `createCtx()`, `ensureTimezoneAuthority.test.ts`
+- **Thin community `Community 1277`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
+- **Thin community `Community 1278`** (2 nodes): `createCtx()`, `ensureTimezoneAuthority.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 1279`** (2 nodes): `schedule()`, `operatingPeriods.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
+- **Thin community `Community 1280`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
+- **Thin community `Community 1281`** (2 nodes): `buildOrder()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 1282`** (2 nodes): `buildOrder()`, `orderReturnExchange.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 1283`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 1284`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
+- **Thin community `Community 1285`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
+- **Thin community `Community 1286`** (2 nodes): `isAthenaIntelligenceCapability()`, `capabilityTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
+- **Thin community `Community 1287`** (2 nodes): `createContextTracker()`, `contextTracking.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (2 nodes): `productDisplayName.ts`, `formatProductDisplayName()`
+- **Thin community `Community 1288`** (2 nodes): `posTerminalRegistrationError.ts`, `isPosRegisterNumberConflict()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
+- **Thin community `Community 1289`** (2 nodes): `productDisplayName.ts`, `formatProductDisplayName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 1290`** (2 nodes): `reviewReasonFormatter.ts`, `formatStoredReviewReason()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
+- **Thin community `Community 1291`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (2 nodes): `sharedDemoRegisterError.ts`, `isSharedDemoRegisterUnavailableError()`
+- **Thin community `Community 1292`** (2 nodes): `sharedDemoActionError.ts`, `isSharedDemoActionDeniedData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (2 nodes): `textCase.ts`, `capitalizeWords()`
+- **Thin community `Community 1293`** (2 nodes): `sharedDemoRegisterError.ts`, `isSharedDemoRegisterUnavailableError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 1294`** (2 nodes): `textCase.ts`, `capitalizeWords()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 1295`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 1296`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 1297`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 1298`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 1299`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 1300`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 1301`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 1302`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 1303`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 1304`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 1305`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 1306`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 1307`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 1308`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 1309`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
+- **Thin community `Community 1310`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 1311`** (2 nodes): `buildCopyImagesSkuUpdate()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
+- **Thin community `Community 1312`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 1313`** (2 nodes): `taxonomySelectLabels.ts`, `formatTaxonomySelectOptionLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 1314`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 1315`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 1316`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 1317`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 1318`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1319`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 1320`** (2 nodes): `StoreInsights.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 1321`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 1322`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 1323`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 1324`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 1325`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (2 nodes): `cn()`, `AppMessageHost.tsx`
+- **Thin community `Community 1326`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 1327`** (2 nodes): `cn()`, `AppMessageHost.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 1328`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
+- **Thin community `Community 1329`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
+- **Thin community `Community 1330`** (2 nodes): `isEmailNotApprovedError()`, `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 1331`** (2 nodes): `expectPendingAuthSyncRedirect()`, `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 1332`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 1333`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 1334`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 1335`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 1336`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 1337`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 1338`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (2 nodes): `AnimatedDataState()`, `AnimatedDataState.tsx`
+- **Thin community `Community 1339`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (2 nodes): `AnimatedHeight()`, `AnimatedHeight.tsx`
+- **Thin community `Community 1340`** (2 nodes): `AnimatedDataState()`, `AnimatedDataState.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 1341`** (2 nodes): `AnimatedHeight()`, `AnimatedHeight.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (2 nodes): `animatedProperties()`, `FlipNumber.test.tsx`
+- **Thin community `Community 1342`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
+- **Thin community `Community 1343`** (2 nodes): `animatedProperties()`, `FlipNumber.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
+- **Thin community `Community 1344`** (2 nodes): `RegisterSessionIdentity.tsx`, `RegisterSessionIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (2 nodes): `DocsMarkdown()`, `DocsMarkdown.tsx`
+- **Thin community `Community 1345`** (2 nodes): `registerSessionIdentityPresentation.ts`, `formatRegisterHeaderName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (2 nodes): `answer()`, `DocsReportQuiz.test.tsx`
+- **Thin community `Community 1346`** (2 nodes): `DocsMarkdown()`, `DocsMarkdown.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (2 nodes): `reset()`, `DocsReportQuiz.tsx`
+- **Thin community `Community 1347`** (2 nodes): `answer()`, `DocsReportQuiz.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (2 nodes): `DocsTexture()`, `DocsTexture.tsx`
+- **Thin community `Community 1348`** (2 nodes): `reset()`, `DocsReportQuiz.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 1349`** (2 nodes): `DocsTexture()`, `DocsTexture.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
+- **Thin community `Community 1350`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 1351`** (2 nodes): `BestSellersDialog()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 1352`** (2 nodes): `FeaturedSectionDialog()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
+- **Thin community `Community 1353`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
+- **Thin community `Community 1354`** (2 nodes): `ShopLookDialog.tsx`, `ShopLookDialog()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 1355`** (2 nodes): `ReadoutSupport.tsx`, `ReadoutTrustMetadata()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (2 nodes): `LandingGrain()`, `LandingGrain.tsx`
+- **Thin community `Community 1356`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
+- **Thin community `Community 1357`** (2 nodes): `LandingGrain()`, `LandingGrain.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
+- **Thin community `Community 1358`** (2 nodes): `AutomationRevealScene()`, `AutomationRevealScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (2 nodes): `LandingWorkspaceVideo()`, `LandingWorkspaceVideo.tsx`
+- **Thin community `Community 1359`** (2 nodes): `CashControlsScene()`, `CashControlsScene.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (2 nodes): `PosHubRoleSwitcher.tsx`, `PosHubRoleSwitcher()`
+- **Thin community `Community 1360`** (2 nodes): `LandingWorkspaceVideo()`, `LandingWorkspaceVideo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
+- **Thin community `Community 1361`** (2 nodes): `PosHubRoleSwitcher.tsx`, `PosHubRoleSwitcher()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
+- **Thin community `Community 1362`** (2 nodes): `SyncBridgeScene.tsx`, `SyncBridgeScene()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
+- **Thin community `Community 1363`** (2 nodes): `formatDemoMoney()`, `demoDay.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (2 nodes): `useLandingTheme.ts`, `useLandingTheme()`
+- **Thin community `Community 1364`** (2 nodes): `storyTime()`, `demoDayFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (2 nodes): `renderWorkspace()`, `InventoryCostOverlayView.test.tsx`
+- **Thin community `Community 1365`** (2 nodes): `useLandingTheme.ts`, `useLandingTheme()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 1366`** (2 nodes): `renderWorkspace()`, `InventoryCostOverlayView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 1367`** (2 nodes): `OperationReviewItemCard()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
+- **Thin community `Community 1368`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 1369`** (2 nodes): `toApprovalRequesterBindingArg()`, `approvalRequesterBinding.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 1370`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (2 nodes): `Orders()`, `Orders.tsx`
+- **Thin community `Community 1371`** (2 nodes): `handleTimeRangeChange()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
+- **Thin community `Community 1372`** (2 nodes): `Orders()`, `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 1373`** (2 nodes): `OrdersView()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 1374`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
+- **Thin community `Community 1375`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 1376`** (2 nodes): `OrderCustomerCell()`, `OrderCustomerCell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 1377`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 1378`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 1379`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 1380`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 1381`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 1382`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
+- **Thin community `Community 1383`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 1384`** (2 nodes): `PosClientTelemetryHost.tsx`, `PosClientTelemetryHost()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 1385`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 1386`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 1387`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 1388`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 1389`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 1390`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 1391`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 1392`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 1393`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 1394`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
+- **Thin community `Community 1395`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 1396`** (2 nodes): `RegisterDrawerGate.tsx`, `if()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+- **Thin community `Community 1397`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
+- **Thin community `Community 1398`** (2 nodes): `POSSalesPulseView.tsx`, `POSStorePulseSection()`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1399`** (2 nodes): `POSTerminalHealthView.test.tsx`, `[
           {
             ...baseSummary,
             attentionReasons: [
@@ -14791,859 +14793,857 @@ Nodes (0):
           },
         ]()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 1400`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
+- **Thin community `Community 1401`** (2 nodes): `PosClientErrorsPanel.test.tsx`, `buildEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 1402`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 1403`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 1404`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 1405`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 1406`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
+- **Thin community `Community 1407`** (2 nodes): `ProductDetailView.tsx`, `ProductDetailViewHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (2 nodes): `ProductOperationalTimeline.tsx`, `formatEventType()`
+- **Thin community `Community 1408`** (2 nodes): `ProductOperationalTimeline.tsx`, `formatEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 1409`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
+- **Thin community `Community 1410`** (2 nodes): `productStockPresentation.ts`, `productStockTextClass()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 1411`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
+- **Thin community `Community 1412`** (2 nodes): `ArchivedProductsToolbar()`, `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 1413`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 1414`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 1415`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 1416`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 1417`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 1418`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 1419`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 1420`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 1421`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 1422`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 1423`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 1424`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 1425`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 1426`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 1427`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 1428`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 1429`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (2 nodes): `ReportBackLink.tsx`, `ReportBackLink()`
+- **Thin community `Community 1430`** (2 nodes): `ReportBackLink.tsx`, `ReportBackLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (2 nodes): `ReportMetricComparisonCrossfade.tsx`, `ReportMetricComparisonCrossfade()`
+- **Thin community `Community 1431`** (2 nodes): `ReportMetricComparisonCrossfade.tsx`, `ReportMetricComparisonCrossfade()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (2 nodes): `ReportTrendChart.test.tsx`, `labelFormatter()`
+- **Thin community `Community 1432`** (2 nodes): `ReportTrendChart.test.tsx`, `labelFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (2 nodes): `ReportTrustStrip.tsx`, `ReportTrustStrip()`
+- **Thin community `Community 1433`** (2 nodes): `ReportTrustStrip.tsx`, `ReportTrustStrip()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (2 nodes): `ReportsCatalogLookup.test.tsx`, `result()`
+- **Thin community `Community 1434`** (2 nodes): `ReportsCatalogLookup.test.tsx`, `result()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (2 nodes): `ReportsItemsTable.tsx`, `ReportsItemsTable()`
+- **Thin community `Community 1435`** (2 nodes): `ReportsItemsTable.tsx`, `ReportsItemsTable()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (2 nodes): `ReportsItemsView.test.tsx`, `isoDateOffset()`
+- **Thin community `Community 1436`** (2 nodes): `ReportsItemsView.test.tsx`, `isoDateOffset()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (2 nodes): `ReportsItemsView.tsx`, `handlePageChange()`
+- **Thin community `Community 1437`** (2 nodes): `ReportsItemsView.tsx`, `handlePageChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (2 nodes): `ReportsLayout.test.tsx`, `search()`
+- **Thin community `Community 1438`** (2 nodes): `ReportsLayout.test.tsx`, `search()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (2 nodes): `ReportsLayout.tsx`, `cn()`
+- **Thin community `Community 1439`** (2 nodes): `ReportsLayout.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (2 nodes): `ReportsSkuDetailView.test.tsx`, `isoDateOffset()`
+- **Thin community `Community 1440`** (2 nodes): `ReportsSkuDetailView.test.tsx`, `isoDateOffset()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (2 nodes): `ReportsSkuDetailView.tsx`, `cn()`
+- **Thin community `Community 1441`** (2 nodes): `ReportsSkuDetailView.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (2 nodes): `useStableReportQuery.ts`, `useStableReportQuery()`
+- **Thin community `Community 1442`** (2 nodes): `useStableReportQuery.ts`, `useStableReportQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 1443`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1444`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1445`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1446`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
+- **Thin community `Community 1447`** (2 nodes): `ServiceWorkspaceDemoNotice.tsx`, `ServiceWorkspaceDemoNotice()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 1448`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (2 nodes): `DemoNotice()`, `DemoNotice.tsx`
+- **Thin community `Community 1449`** (2 nodes): `DemoNotice()`, `DemoNotice.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
+- **Thin community `Community 1450`** (2 nodes): `SharedDemoManagerSignInGuidance.tsx`, `SharedDemoManagerSignInGuidance()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (2 nodes): `SharedDemoOwnerHome.tsx`, `SharedDemoOwnerHome()`
+- **Thin community `Community 1451`** (2 nodes): `SharedDemoOwnerHome.tsx`, `SharedDemoOwnerHome()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
+- **Thin community `Community 1452`** (2 nodes): `SharedDemoRestrictedSurface.tsx`, `SharedDemoRestrictedSurface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
+- **Thin community `Community 1453`** (2 nodes): `SharedDemoRuntime.test.tsx`, `ProviderStatusProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
+- **Thin community `Community 1454`** (2 nodes): `SharedDemoStatusBar.tsx`, `normalizePathname()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (2 nodes): `sharedDemoActivityTracking.test.ts`, `storage()`
+- **Thin community `Community 1455`** (2 nodes): `sharedDemoActivityTracking.test.ts`, `storage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
+- **Thin community `Community 1456`** (2 nodes): `sharedDemoProviderStatus.ts`, `resolveSharedDemoProvidedBootstrapStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
+- **Thin community `Community 1457`** (2 nodes): `sharedDemoRestoreOverlayModel.ts`, `resolveSharedDemoRestoreOverlayPhase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
+- **Thin community `Community 1458`** (2 nodes): `sharedDemoRestrictions.ts`, `isSharedDemoRestrictedPath()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
+- **Thin community `Community 1459`** (2 nodes): `sharedDemoRoutes.ts`, `getSharedDemoRoutes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
+- **Thin community `Community 1460`** (2 nodes): `sharedDemoRuntimeCoordinator.test.ts`, `deferred()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
+- **Thin community `Community 1461`** (2 nodes): `StaffMessagesView.tsx`, `submit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 1462`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 1463`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 1464`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 1465`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 1466`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 1467`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 1468`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 1469`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 1470`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (2 nodes): `async()`, `NotificationsView.tsx`
+- **Thin community `Community 1471`** (2 nodes): `async()`, `NotificationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (2 nodes): `StoreHoursView.test.tsx`, `changeAnchorAndSave()`
+- **Thin community `Community 1472`** (2 nodes): `StoreHoursView.test.tsx`, `changeAnchorAndSave()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 1473`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (2 nodes): `useNotificationSubscriptions.test.tsx`, `emptyList()`
+- **Thin community `Community 1474`** (2 nodes): `useNotificationSubscriptions.test.tsx`, `emptyList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 1475`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
+- **Thin community `Community 1476`** (2 nodes): `useStoreScheduleUpdate.ts`, `useStoreScheduleUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 1477`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (2 nodes): `WorkflowTraceView.tsx`, `formatTraceLabel()`
+- **Thin community `Community 1478`** (2 nodes): `WorkflowTraceView.tsx`, `formatTraceLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 1479`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 1480`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 1481`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 1482`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 1483`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 1484`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 1485`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 1486`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 1487`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (2 nodes): `relative-timestamp.test.tsx`, `freezeClock()`
+- **Thin community `Community 1488`** (2 nodes): `relative-timestamp.test.tsx`, `freezeClock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (2 nodes): `relative-timestamp.tsx`, `RelativeTimestamp()`
+- **Thin community `Community 1489`** (2 nodes): `relative-timestamp.tsx`, `RelativeTimestamp()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 1490`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
+- **Thin community `Community 1491`** (2 nodes): `sidebar.test.tsx`, `SidebarToggleProbe()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 1492`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 1493`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 1494`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 1495`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 1496`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 1497`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 1498`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 1499`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
+- **Thin community `Community 1500`** (2 nodes): `UserInsightsSection.test.tsx`, `renderWithQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 1501`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 1502`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 1503`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 1504`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 1505`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
+- **Thin community `Community 1506`** (2 nodes): `buildAthenaWebappContextEvent()`, `athenaWebappContextEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (2 nodes): `useDocsWorkspaceTracking.ts`, `useDocsWorkspaceTracking()`
+- **Thin community `Community 1507`** (2 nodes): `useDocsWorkspaceTracking.ts`, `useDocsWorkspaceTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 1508`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (2 nodes): `SessionOrderProbe()`, `OnlineOrderContext.test.tsx`
+- **Thin community `Community 1509`** (2 nodes): `SessionOrderProbe()`, `OnlineOrderContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
+- **Thin community `Community 1510`** (2 nodes): `ProductContext.test.tsx`, `buildProductSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (2 nodes): `screenRedactExtension.test.ts`, `runScreenRedactExtension()`
+- **Thin community `Community 1511`** (2 nodes): `screenRedactExtension.test.ts`, `runScreenRedactExtension()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 1512`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 1513`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 1514`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 1515`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 1516`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 1517`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 1518`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 1519`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 1520`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 1521`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 1522`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 1523`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 1524`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 1525`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 1526`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 1527`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 1528`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 1529`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 1530`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 1531`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 1532`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 1533`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 1534`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (2 nodes): `useSheetReturnPosition.ts`, `useSheetReturnPosition()`
+- **Thin community `Community 1535`** (2 nodes): `useSheetReturnPosition.ts`, `useSheetReturnPosition()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 1536`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 1537`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 1538`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
+- **Thin community `Community 1539`** (2 nodes): `useAppActionBlocker.test.tsx`, `wrapper()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
+- **Thin community `Community 1540`** (2 nodes): `UpdateCoordinatorProvider.tsx`, `UpdateCoordinatorProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
+- **Thin community `Community 1541`** (2 nodes): `createFakeWindow()`, `appUpdateReload.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
+- **Thin community `Community 1542`** (2 nodes): `updateAssetStaging.test.ts`, `FakeMessageChannel`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
+- **Thin community `Community 1543`** (2 nodes): `updateCommunicationPreference.tsx`, `UpdateCommunicationPreferenceProvider()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
+- **Thin community `Community 1544`** (2 nodes): `updateDetectionSequencer.test.ts`, `createDeferredStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
+- **Thin community `Community 1545`** (2 nodes): `updateDetectionSequencer.ts`, `createUpdateDetectionSequencer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
+- **Thin community `Community 1546`** (2 nodes): `useUpdateApplyBlocker.ts`, `useUpdateApplyBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 1547`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 1548`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (2 nodes): `sharedDemoDenialObserver.test.ts`, `demoDenial()`
+- **Thin community `Community 1549`** (2 nodes): `sharedDemoDenialObserver.test.ts`, `demoDenial()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
+- **Thin community `Community 1550`** (2 nodes): `storeEntryRoute.ts`, `getStoreEntryRouteForRole()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
+- **Thin community `Community 1551`** (2 nodes): `posLocalStoreTypes.ts`, `canUploadPosLocalEventType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 1552`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 1553`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 1554`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 1555`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 1556`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 1557`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
+- **Thin community `Community 1558`** (2 nodes): `scope()`, `expenseLocalCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
+- **Thin community `Community 1559`** (2 nodes): `posLocalLedgerPolicy.ts`, `assessPosLocalLedgerRetention()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
+- **Thin community `Community 1560`** (2 nodes): `posLocalStorageBoundary.test.ts`, `collectProductionSources()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
+- **Thin community `Community 1561`** (2 nodes): `posLocalStorageRuntimeContext.test.tsx`, `RuntimeStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
+- **Thin community `Community 1562`** (2 nodes): `posLocalStoreErrorTaxonomy.test.ts`, `failingAdapter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
+- **Thin community `Community 1563`** (2 nodes): `posLocalStoreMigrationCoordinator.test.ts`, `createLogicalFixtureEngine()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
+- **Thin community `Community 1564`** (2 nodes): `posLocalStoreMigrationCoordinator.ts`, `createTestOnlyPosLocalStoreMigrationCoordinator()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
+- **Thin community `Community 1565`** (2 nodes): `posLocalStoreMigrations.ts`, `runPosLocalStoreMigrations()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
+- **Thin community `Community 1566`** (2 nodes): `posLocalStoreSnapshot.ts`, `validatePosLocalStoreSnapshotShape()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
+- **Thin community `Community 1567`** (2 nodes): `posLocalStoreVersions.ts`, `comparePosLocalStoreVersion()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 1568`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 1569`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
+- **Thin community `Community 1570`** (2 nodes): `registerLifecycleAuthorityReconciliation.test.ts`, `versioned()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 1571`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 1572`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
+- **Thin community `Community 1573`** (2 nodes): `registerSessionAuthorityBootstrap.ts`, `seedRegisterSessionAuthorityBootstrap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (2 nodes): `syncGapDiagnosis.ts`, `diagnoseHeldSyncBlocker()`
+- **Thin community `Community 1574`** (2 nodes): `syncGapDiagnosis.ts`, `diagnoseHeldSyncBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 1575`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 1576`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 1577`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
+- **Thin community `Community 1578`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
+- **Thin community `Community 1579`** (2 nodes): `toMetadataRecord()`, `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (2 nodes): `usePosClientTelemetryDrain.test.ts`, `dispatchUnhandledRejection()`
+- **Thin community `Community 1580`** (2 nodes): `usePosClientTelemetryDrain.test.ts`, `dispatchUnhandledRejection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
+- **Thin community `Community 1581`** (2 nodes): `usePosClientTelemetryDrain.ts`, `usePosClientTelemetryDrain()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 1582`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
+- **Thin community `Community 1583`** (2 nodes): `useRegisterCheckoutDraftState.ts`, `useRegisterCheckoutDraftState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
+- **Thin community `Community 1584`** (2 nodes): `useRegisterLocalRuntime.test.ts`, `renderRuntime()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
+- **Thin community `Community 1585`** (2 nodes): `registerSessionCode.ts`, `formatRegisterSessionCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 1586`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 1587`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 1588`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 1589`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 1590`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 1591`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
+- **Thin community `Community 1592`** (2 nodes): `productSkuSearchAdapters.test.ts`, `buildResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 1593`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
+- **Thin community `Community 1594`** (2 nodes): `AuthenticatedLayout()`, `-authenticated-layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
+- **Thin community `Community 1595`** (2 nodes): `getSharedDemoEntryPresentation()`, `-demo-presentation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (2 nodes): `-public-layout.tsx`, `onScroll()`
+- **Thin community `Community 1596`** (2 nodes): `-public-layout.tsx`, `onScroll()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (2 nodes): `waiver-passkey.tsx`, `enroll()`
+- **Thin community `Community 1597`** (2 nodes): `waiver-passkey.tsx`, `enroll()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 1598`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1599`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1600`** (2 nodes): `registers.$sessionId.activity.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 1601`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 1602`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (2 nodes): `InventoryImportRoute()`, `-inventory-import-route.tsx`
+- **Thin community `Community 1603`** (2 nodes): `InventoryImportRoute()`, `-inventory-import-route.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 1604`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 1605`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 1606`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
+- **Thin community `Community 1607`** (2 nodes): `DailyOperationsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 1608`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 1609`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 1610`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 1611`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
+- **Thin community `Community 1612`** (2 nodes): `PointOfSaleRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
+- **Thin community `Community 1613`** (2 nodes): `settings.index.tsx`, `SettingsNotFoundComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 1614`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1615`** (2 nodes): `ComplimentaryProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
+- **Thin community `Community 1616`** (2 nodes): `ProductsNotFoundComponent()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
+- **Thin community `Community 1617`** (2 nodes): `ReportsItemsRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 1618`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
+- **Thin community `Community 1619`** (2 nodes): `shared-demo.tsx`, `SharedDemoHomeRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (2 nodes): `_authed.route.test.tsx`, `_authed.tsx`
+- **Thin community `Community 1620`** (2 nodes): `_authed.route.test.tsx`, `_authed.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (2 nodes): `setQuery()`, `docs.reports.index.tsx`
+- **Thin community `Community 1621`** (2 nodes): `setQuery()`, `docs.reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (2 nodes): `SolutionDocContent()`, `docs.solutions.$category.$slug.tsx`
+- **Thin community `Community 1622`** (2 nodes): `SolutionDocContent()`, `docs.solutions.$category.$slug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
+- **Thin community `Community 1623`** (2 nodes): `AthenaLoginReadyView()`, `-login-ready-view.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
+- **Thin community `Community 1624`** (2 nodes): `activeHandoff()`, `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (2 nodes): `waiver.approve.tsx`, `approve()`
+- **Thin community `Community 1625`** (2 nodes): `waiver.approve.tsx`, `approve()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 1626`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1627`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 1628`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 1629`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 1630`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 1631`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1632`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 1633`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 1634`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 1635`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 1636`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (2 nodes): `wedAt()`, `dailyOperationsFixtures.ts`
+- **Thin community `Community 1637`** (2 nodes): `wedAt()`, `dailyOperationsFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (2 nodes): `wedAt()`, `openingHandoffFixtures.ts`
+- **Thin community `Community 1638`** (2 nodes): `wedAt()`, `openingHandoffFixtures.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
+- **Thin community `Community 1639`** (2 nodes): `momentAt()`, `operationsFixtureContext.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (2 nodes): `posHubFixtures.ts`, `buildTrend()`
+- **Thin community `Community 1640`** (2 nodes): `posHubFixtures.ts`, `buildTrend()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 1641`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 1642`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 1643`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 1644`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 1645`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 1646`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
+- **Thin community `Community 1647`** (2 nodes): `trackingEvents.ts`, `postTrackingEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 1648`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 1649`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 1650`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 1651`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 1652`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 1653`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 1654`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 1655`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 1656`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 1657`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 1658`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 1659`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 1660`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 1661`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 1662`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 1663`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 1664`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 1665`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 1666`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 1667`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 1668`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 1669`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 1670`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 1671`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 1672`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 1673`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 1674`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 1675`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 1676`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 1677`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 1678`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 1679`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 1680`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 1681`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 1682`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 1683`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 1684`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 1685`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 1686`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 1687`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 1688`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 1689`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 1690`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 1691`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 1692`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 1693`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 1694`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1695`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1696`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1697`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1698`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1699`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1700`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1701`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1702`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1703`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1704`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1705`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1706`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1707`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1708`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1709`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1710`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1711`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1712`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1713`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1714`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1715`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1716`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1717`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1718`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1719`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1720`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1721`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1722`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1723`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1724`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1725`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1726`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1727`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1728`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
+- **Thin community `Community 1729`** (2 nodes): `useHomepageSnapshotQueries()`, `homepageSnapshot.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1730`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1731`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1732`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1733`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1734`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1735`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1736`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1737`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1738`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1739`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1740`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1741`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1742`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (2 nodes): `App()`, `main.tsx`
+- **Thin community `Community 1743`** (2 nodes): `App()`, `main.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1744`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1745`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1746`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1747`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1748`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1749`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1750`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1751`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1752`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1753`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1754`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1755`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1756`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1757`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1758`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1759`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1760`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1761`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (2 nodes): `fixture()`, `docs-solution-link-check.test.ts`
+- **Thin community `Community 1762`** (2 nodes): `fixture()`, `docs-solution-link-check.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (2 nodes): `requestJson()`, `documentation-waiver-attestation.test.ts`
+- **Thin community `Community 1763`** (2 nodes): `requestJson()`, `documentation-waiver-attestation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (2 nodes): `workflow()`, `documentation-waiver-workflows.test.ts`
+- **Thin community `Community 1764`** (2 nodes): `workflow()`, `documentation-waiver-workflows.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (2 nodes): `withoutGitRepositoryContext()`, `git-environment.ts`
+- **Thin community `Community 1765`** (2 nodes): `withoutGitRepositoryContext()`, `git-environment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1766`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1767`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1768`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1769`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
+- **Thin community `Community 1770`** (2 nodes): `readRepoFile()`, `pr-athena-guidance-contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1771`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1772`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `api.js`
+- **Thin community `Community 1773`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1774`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1775`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `server.js`
+- **Thin community `Community 1776`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `app.ts`
+- **Thin community `Community 1777`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1779`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `SharedDemoTicket.test.ts`
+- **Thin community `Community 1780`** (1 nodes): `SharedDemoTicket.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1781`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `auth.ts`
+- **Thin community `Community 1783`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1785`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `countries.ts`
+- **Thin community `Community 1787`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `email.ts`
+- **Thin community `Community 1788`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1789`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `payment.ts`
+- **Thin community `Community 1790`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `athenaWebappEvents.test.ts`
+- **Thin community `Community 1791`** (1 nodes): `athenaWebappEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `sharedDemoActionCapture.test.ts`
+- **Thin community `Community 1792`** (1 nodes): `sharedDemoActionCapture.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `types.ts`
+- **Thin community `Community 1793`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `convex.config.ts`
+- **Thin community `Community 1794`** (1 nodes): `convex.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1795`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `crons.ts`
+- **Thin community `Community 1796`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `internal.ts`
+- **Thin community `Community 1798`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1803`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `ApprovalRequestPending.test.tsx`
+- **Thin community `Community 1804`** (1 nodes): `ApprovalRequestPending.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `DailyManagerReport.test.tsx`
+- **Thin community `Community 1805`** (1 nodes): `DailyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
+- **Thin community `Community 1806`** (1 nodes): `DailyManagerReportComparisonPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1807`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1808`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `NewOrderAdmin.test.tsx`
+- **Thin community `Community 1809`** (1 nodes): `NewOrderAdmin.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `OrderEmail.test.tsx`
+- **Thin community `Community 1810`** (1 nodes): `OrderEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1811`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1812`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `PosTerminalHealthAlert.test.tsx`
+- **Thin community `Community 1813`** (1 nodes): `PosTerminalHealthAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
+- **Thin community `Community 1814`** (1 nodes): `RegisterCloseoutVarianceAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `ReportVerificationAlert.test.tsx`
+- **Thin community `Community 1815`** (1 nodes): `ReportVerificationAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `ReportVerificationAlert.tsx`
+- **Thin community `Community 1816`** (1 nodes): `ReportVerificationAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `StaleDailyCloseAlert.test.tsx`
+- **Thin community `Community 1817`** (1 nodes): `StaleDailyCloseAlert.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `StaleDailyCloseAlert.tsx`
+- **Thin community `Community 1818`** (1 nodes): `StaleDailyCloseAlert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
+- **Thin community `Community 1819`** (1 nodes): `WalkthroughRequestNotification.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `WeeklyManagerReport.test.tsx`
+- **Thin community `Community 1820`** (1 nodes): `WeeklyManagerReport.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `emailOperationalCtaStyles.ts`
+- **Thin community `Community 1821`** (1 nodes): `emailOperationalCtaStyles.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `env.ts`
+- **Thin community `Community 1822`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `passkeyPolicy.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `passkeyPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `passkeys.integration.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `passkeys.integration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `passkeys.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `registrationAuthorization.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `passkeys.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1826`** (1 nodes): `storage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -38404,6 +38404,18 @@
       "weight": 1
     },
     {
+      "_src": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_test_ts",
+      "_tgt": "registrationauthorization_test_authenticatedtestuser",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_test_ts",
+      "source_file": "packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.test.ts",
+      "source_location": "L74",
+      "target": "registrationauthorization_test_authenticatedtestuser",
+      "weight": 1
+    },
+    {
       "_src": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_ts",
       "_tgt": "registrationauthorization_required",
       "confidence": "EXTRACTED",
@@ -38411,7 +38423,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_ts",
       "source_file": "packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.ts",
-      "source_location": "L11",
+      "source_location": "L12",
       "target": "registrationauthorization_required",
       "weight": 1
     },
@@ -191925,6 +191937,24 @@
     {
       "community": 1156,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_test_ts",
+      "label": "registrationAuthorization.test.ts",
+      "norm_label": "registrationauthorization.test.ts",
+      "source_file": "packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1156,
+      "file_type": "code",
+      "id": "registrationauthorization_test_authenticatedtestuser",
+      "label": "authenticatedTestUser()",
+      "norm_label": "authenticatedtestuser()",
+      "source_file": "packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.test.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 1157,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_ts",
       "label": "registrationAuthorization.ts",
       "norm_label": "registrationauthorization.ts",
@@ -191932,16 +191962,16 @@
       "source_location": "L1"
     },
     {
-      "community": 1156,
+      "community": 1157,
       "file_type": "code",
       "id": "registrationauthorization_required",
       "label": "required()",
       "norm_label": "required()",
       "source_file": "packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.ts",
-      "source_location": "L11"
+      "source_location": "L12"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "bannermessage_resolvepublicbannermessage",
       "label": "resolvePublicBannerMessage()",
@@ -191950,7 +191980,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1157,
+      "community": 1158,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -191959,7 +191989,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "boundedbody_readboundedbody",
       "label": "readBoundedBody()",
@@ -191968,30 +191998,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1158,
+      "community": 1159,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_boundedbody_ts",
       "label": "boundedBody.ts",
       "norm_label": "boundedbody.ts",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/boundedBody.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "harnesswaivers_test_brokerenv",
-      "label": "brokerEnv()",
-      "norm_label": "brokerenv()",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/harnessWaivers.test.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 1159,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_core_routes_harnesswaivers_test_ts",
-      "label": "harnessWaivers.test.ts",
-      "norm_label": "harnesswaivers.test.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/harnessWaivers.test.ts",
       "source_location": "L1"
     },
     {
@@ -192159,6 +192171,24 @@
     {
       "community": 1160,
       "file_type": "code",
+      "id": "harnesswaivers_test_brokerenv",
+      "label": "brokerEnv()",
+      "norm_label": "brokerenv()",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/harnessWaivers.test.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 1160,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_core_routes_harnesswaivers_test_ts",
+      "label": "harnessWaivers.test.ts",
+      "norm_label": "harnesswaivers.test.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/core/routes/harnessWaivers.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1161,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_subcategories_ts",
       "label": "subcategories.ts",
       "norm_label": "subcategories.ts",
@@ -192166,7 +192196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1160,
+      "community": 1161,
       "file_type": "code",
       "id": "subcategories_removestorefronthiddensubcategorylist",
       "label": "removeStorefrontHiddenSubcategoryList()",
@@ -192175,7 +192205,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_storefrontcors_test_ts",
       "label": "storefrontCors.test.ts",
@@ -192184,7 +192214,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1161,
+      "community": 1162,
       "file_type": "code",
       "id": "storefrontcors_test_readroutefile",
       "label": "readRouteFile()",
@@ -192193,7 +192223,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customermessaging_routes_whatsapp_ts",
       "label": "whatsapp.ts",
@@ -192202,7 +192232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1162,
+      "community": 1163,
       "file_type": "code",
       "id": "whatsapp_mapwebhookstatus",
       "label": "mapWebhookStatus()",
@@ -192211,7 +192241,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "mtnmomo_handlecollectionnotification",
       "label": "handleCollectionNotification()",
@@ -192220,7 +192250,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1163,
+      "community": 1164,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_moneymovement_routes_mtnmomo_ts",
       "label": "mtnMomo.ts",
@@ -192229,7 +192259,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_routercomposition_test_ts",
       "label": "routerComposition.test.ts",
@@ -192238,7 +192268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1164,
+      "community": 1165,
       "file_type": "code",
       "id": "routercomposition_test_readprojectfile",
       "label": "readProjectFile()",
@@ -192247,7 +192277,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "fake_createfakestructuredtextprovider",
       "label": "createFakeStructuredTextProvider()",
@@ -192256,7 +192286,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1165,
+      "community": 1166,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_intelligence_providers_fake_ts",
       "label": "fake.ts",
@@ -192265,7 +192295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "athenauser_isexpiredshareddemosessionerror",
       "label": "isExpiredSharedDemoSessionError()",
@@ -192274,7 +192304,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1166,
+      "community": 1167,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauser_ts",
       "label": "athenaUser.ts",
@@ -192283,7 +192313,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "athenauseridentitywriters_test_source",
       "label": "source()",
@@ -192292,7 +192322,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1167,
+      "community": 1168,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_athenauseridentitywriters_test_ts",
       "label": "athenaUserIdentityWriters.test.ts",
@@ -192301,7 +192331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "auth_mapathenaauthsyncerror",
       "label": "mapAthenaAuthSyncError()",
@@ -192310,30 +192340,12 @@
       "source_location": "L114"
     },
     {
-      "community": 1168,
+      "community": 1169,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_auth_ts",
       "label": "auth.ts",
       "norm_label": "auth.ts",
       "source_file": "packages/athena-webapp/convex/inventory/auth.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "bannermessage_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.test.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 1169,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_bannermessage_test_ts",
-      "label": "bannerMessage.test.ts",
-      "norm_label": "bannermessage.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.test.ts",
       "source_location": "L1"
     },
     {
@@ -192501,6 +192513,24 @@
     {
       "community": 1170,
       "file_type": "code",
+      "id": "bannermessage_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.test.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 1170,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventory_bannermessage_test_ts",
+      "label": "bannerMessage.test.ts",
+      "norm_label": "bannermessage.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/bannerMessage.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1171,
+      "file_type": "code",
       "id": "bestseller_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
@@ -192508,7 +192538,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1170,
+      "community": 1171,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_bestseller_test_ts",
       "label": "bestSeller.test.ts",
@@ -192517,7 +192547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "catalogsummary_test_createcatalogsummaryctx",
       "label": "createCatalogSummaryCtx()",
@@ -192526,7 +192556,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1171,
+      "community": 1172,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogsummary_test_ts",
       "label": "catalogSummary.test.ts",
@@ -192535,7 +192565,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "expensesessionitems_usererrorfromexpenseitemcommandfailure",
       "label": "userErrorFromExpenseItemCommandFailure()",
@@ -192544,7 +192574,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1172,
+      "community": 1173,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessionitems_ts",
       "label": "expenseSessionItems.ts",
@@ -192553,7 +192583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "expensetransactions_test_createfakemutationctx",
       "label": "createFakeMutationCtx()",
@@ -192562,7 +192592,7 @@
       "source_location": "L339"
     },
     {
-      "community": 1173,
+      "community": 1174,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensetransactions_test_ts",
       "label": "expenseTransactions.test.ts",
@@ -192571,7 +192601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "inventoryimportcostoverlaywork_test_createworkcontext",
       "label": "createWorkContext()",
@@ -192580,7 +192610,7 @@
       "source_location": "L65"
     },
     {
-      "community": 1174,
+      "community": 1175,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_inventoryimportcostoverlaywork_test_ts",
       "label": "inventoryImportCostOverlayWork.test.ts",
@@ -192589,7 +192619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_posquerycleanup_test_ts",
       "label": "posQueryCleanup.test.ts",
@@ -192598,7 +192628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1175,
+      "community": 1176,
       "file_type": "code",
       "id": "posquerycleanup_test_readprojectfile",
       "label": "readProjectFile()",
@@ -192607,7 +192637,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productsku_ts",
       "label": "productSku.ts",
@@ -192616,7 +192646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1176,
+      "community": 1177,
       "file_type": "code",
       "id": "productsku_syncproductskusearchprojectionsbystore",
       "label": "syncProductSkuSearchProjectionsByStore()",
@@ -192625,7 +192655,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_productutil_ts",
       "label": "productUtil.ts",
@@ -192634,7 +192664,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1177,
+      "community": 1178,
       "file_type": "code",
       "id": "productutil_buildallproductscachekey",
       "label": "buildAllProductsCacheKey()",
@@ -192643,7 +192673,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_promocode_ts",
       "label": "promoCode.ts",
@@ -192652,31 +192682,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1178,
+      "community": 1179,
       "file_type": "code",
       "id": "promocode_calculateselectedproductpromodiscount",
       "label": "calculateSelectedProductPromoDiscount()",
       "norm_label": "calculateselectedproductpromodiscount()",
       "source_file": "packages/athena-webapp/convex/inventory/promoCode.ts",
       "source_location": "L16"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "commerceeffects_test_context",
-      "label": "context()",
-      "norm_label": "context()",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/commerceEffects.test.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 1179,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_test_ts",
-      "label": "commerceEffects.test.ts",
-      "norm_label": "commerceeffects.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventoryLedger/commerceEffects.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 118,
@@ -192843,6 +192855,24 @@
     {
       "community": 1180,
       "file_type": "code",
+      "id": "commerceeffects_test_context",
+      "label": "context()",
+      "norm_label": "context()",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/commerceEffects.test.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 1180,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_inventoryledger_commerceeffects_test_ts",
+      "label": "commerceEffects.test.ts",
+      "norm_label": "commerceeffects.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventoryLedger/commerceEffects.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1181,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_positionrevisions_ts",
       "label": "positionRevisions.ts",
       "norm_label": "positionrevisions.ts",
@@ -192850,7 +192880,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1180,
+      "community": 1181,
       "file_type": "code",
       "id": "positionrevisions_recordinventorypositionrevisionwithctx",
       "label": "recordInventoryPositionRevisionWithCtx()",
@@ -192859,7 +192889,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_schedulework_ts",
       "label": "scheduleWork.ts",
@@ -192868,7 +192898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1181,
+      "community": 1182,
       "file_type": "code",
       "id": "schedulework_schedulereportingworkbesteffort",
       "label": "scheduleReportingWorkBestEffort()",
@@ -192877,7 +192907,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "athenauserauth_test_context",
       "label": "context()",
@@ -192886,7 +192916,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1182,
+      "community": 1183,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_athenauserauth_test_ts",
       "label": "athenaUserAuth.test.ts",
@@ -192895,7 +192925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "commandresultvalidators_commandresultvalidator",
       "label": "commandResultValidator()",
@@ -192904,7 +192934,7 @@
       "source_location": "L80"
     },
     {
-      "community": 1183,
+      "community": 1184,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_commandresultvalidators_ts",
       "label": "commandResultValidators.ts",
@@ -192913,7 +192943,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_lib_storememberaccess_ts",
       "label": "storeMemberAccess.ts",
@@ -192922,7 +192952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1184,
+      "community": 1185,
       "file_type": "code",
       "id": "storememberaccess_requirestorememberaccesswithctx",
       "label": "requireStoreMemberAccessWithCtx()",
@@ -192931,7 +192961,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "callllmprovider_callllmprovider",
       "label": "callLlmProvider()",
@@ -192940,7 +192970,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1185,
+      "community": 1186,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_callllmprovider_ts",
       "label": "callLlmProvider.ts",
@@ -192949,7 +192979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "anthropic_callanthropic",
       "label": "callAnthropic()",
@@ -192958,7 +192988,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1186,
+      "community": 1187,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_anthropic_ts",
       "label": "anthropic.ts",
@@ -192967,7 +192997,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "openai_callopenai",
       "label": "callOpenAi()",
@@ -192976,7 +193006,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1187,
+      "community": 1188,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_llm_providers_openai_ts",
       "label": "openai.ts",
@@ -192985,7 +193015,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "landingfunnelretention_shouldexpirefunnelrecord",
       "label": "shouldExpireFunnelRecord()",
@@ -192994,31 +193024,13 @@
       "source_location": "L5"
     },
     {
-      "community": 1188,
+      "community": 1189,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_landingfunnelretention_ts",
       "label": "landingFunnelRetention.ts",
       "norm_label": "landingfunnelretention.ts",
       "source_file": "packages/athena-webapp/convex/marketing/landingFunnelRetention.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughbudgets_ts",
-      "label": "walkthroughBudgets.ts",
-      "norm_label": "walkthroughbudgets.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughBudgets.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1189,
-      "file_type": "code",
-      "id": "walkthroughbudgets_consumewalkthroughbudget",
-      "label": "consumeWalkthroughBudget()",
-      "norm_label": "consumewalkthroughbudget()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughBudgets.ts",
-      "source_location": "L3"
     },
     {
       "community": 119,
@@ -193185,6 +193197,24 @@
     {
       "community": 1190,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughbudgets_ts",
+      "label": "walkthroughBudgets.ts",
+      "norm_label": "walkthroughbudgets.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughBudgets.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1190,
+      "file_type": "code",
+      "id": "walkthroughbudgets_consumewalkthroughbudget",
+      "label": "consumeWalkthroughBudget()",
+      "norm_label": "consumewalkthroughbudget()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughBudgets.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 1191,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_test_ts",
       "label": "walkthroughRequestNotifications.test.ts",
       "norm_label": "walkthroughrequestnotifications.test.ts",
@@ -193192,7 +193222,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1190,
+      "community": 1191,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_test_insertattempt",
       "label": "insertAttempt()",
@@ -193201,7 +193231,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_test_createctx",
       "label": "createCtx()",
@@ -193210,7 +193240,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1191,
+      "community": 1192,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_test_ts",
       "label": "backfillStoreTimezoneAuthority.test.ts",
@@ -193219,7 +193249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "migrateposamountstopesewas_test_createctx",
       "label": "createCtx()",
@@ -193228,7 +193258,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1192,
+      "community": 1193,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_migrateposamountstopesewas_test_ts",
       "label": "migratePosAmountsToPesewas.test.ts",
@@ -193237,7 +193267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "foundation_test_readprojectfile",
       "label": "readProjectFile()",
@@ -193246,7 +193276,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1193,
+      "community": 1194,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_mtn_foundation_test_ts",
       "label": "foundation.test.ts",
@@ -193255,7 +193285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_sweeper_ts",
       "label": "sweeper.ts",
@@ -193264,7 +193294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1194,
+      "community": 1195,
       "file_type": "code",
       "id": "sweeper_terminalizeorphaneddelivery",
       "label": "terminalizeOrphanedDelivery()",
@@ -193273,7 +193303,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_transport_test_ts",
       "label": "transport.test.ts",
@@ -193282,7 +193312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1195,
+      "community": 1196,
       "file_type": "code",
       "id": "transport_test_stubfetch",
       "label": "stubFetch()",
@@ -193291,7 +193321,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_transport_ts",
       "label": "transport.ts",
@@ -193300,7 +193330,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1196,
+      "community": 1197,
       "file_type": "code",
       "id": "transport_sendnotificationemail",
       "label": "sendNotificationEmail()",
@@ -193309,7 +193339,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "effects_declaresprotectedgateway",
       "label": "declaresProtectedGateway()",
@@ -193318,7 +193348,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1197,
+      "community": 1198,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_effects_ts",
       "label": "effects.ts",
@@ -193327,7 +193357,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_readadapters_test_ts",
       "label": "readAdapters.test.ts",
@@ -193336,31 +193366,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1198,
+      "community": 1199,
       "file_type": "code",
       "id": "readadapters_test_democtx",
       "label": "demoCtx()",
       "norm_label": "democtx()",
       "source_file": "packages/athena-webapp/convex/operationAdmission/readAdapters.test.ts",
       "source_location": "L138"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_scopes_ts",
-      "label": "scopes.ts",
-      "norm_label": "scopes.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1199,
-      "file_type": "code",
-      "id": "scopes_resolveoperationscope",
-      "label": "resolveOperationScope()",
-      "norm_label": "resolveoperationscope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
-      "source_location": "L9"
     },
     {
       "community": 12,
@@ -193959,6 +193971,24 @@
     {
       "community": 1200,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_scopes_ts",
+      "label": "scopes.ts",
+      "norm_label": "scopes.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1200,
+      "file_type": "code",
+      "id": "scopes_resolveoperationscope",
+      "label": "resolveOperationScope()",
+      "norm_label": "resolveoperationscope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/scopes.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 1201,
+      "file_type": "code",
       "id": "approvalactions_consumecommandapprovalproofwithctx",
       "label": "consumeCommandApprovalProofWithCtx()",
       "norm_label": "consumecommandapprovalproofwithctx()",
@@ -193966,7 +193996,7 @@
       "source_location": "L62"
     },
     {
-      "community": 1200,
+      "community": 1201,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalactions_ts",
       "label": "approvalActions.ts",
@@ -193975,7 +194005,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "approvalauditevents_test_createoperationaleventctx",
       "label": "createOperationalEventCtx()",
@@ -193984,7 +194014,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1201,
+      "community": 1202,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalauditevents_test_ts",
       "label": "approvalAuditEvents.test.ts",
@@ -193993,7 +194023,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "approvalproofs_test_createapprovalproofmutationctx",
       "label": "createApprovalProofMutationCtx()",
@@ -194002,7 +194032,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1202,
+      "community": 1203,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_test_ts",
       "label": "approvalProofs.test.ts",
@@ -194011,7 +194041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "approvalrequests_test_createapprovalrequestmutationctx",
       "label": "createApprovalRequestMutationCtx()",
@@ -194020,7 +194050,7 @@
       "source_location": "L45"
     },
     {
-      "community": 1203,
+      "community": 1204,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequests_test_ts",
       "label": "approvalRequests.test.ts",
@@ -194029,7 +194059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "inventorymovements_test_createinventorymovementctx",
       "label": "createInventoryMovementCtx()",
@@ -194038,7 +194068,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1204,
+      "community": 1205,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_test_ts",
       "label": "inventoryMovements.test.ts",
@@ -194047,7 +194077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "logicaloperationalwork_test_workitem",
       "label": "workItem()",
@@ -194056,7 +194086,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1205,
+      "community": 1206,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_logicaloperationalwork_test_ts",
       "label": "logicalOperationalWork.test.ts",
@@ -194065,7 +194095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "managerreporttopitems_managerreporttopitemsfrommix",
       "label": "managerReportTopItemsFromMix()",
@@ -194074,7 +194104,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1206,
+      "community": 1207,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_managerreporttopitems_ts",
       "label": "managerReportTopItems.ts",
@@ -194083,7 +194113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "operationalevents_test_createctx",
       "label": "createCtx()",
@@ -194092,7 +194122,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1207,
+      "community": 1208,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalevents_test_ts",
       "label": "operationalEvents.test.ts",
@@ -194101,7 +194131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "oweddailyclosesweep_test_fullwindow",
       "label": "fullWindow()",
@@ -194110,31 +194140,13 @@
       "source_location": "L14"
     },
     {
-      "community": 1208,
+      "community": 1209,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_oweddailyclosesweep_test_ts",
       "label": "owedDailyCloseSweep.test.ts",
       "norm_label": "oweddailyclosesweep.test.ts",
       "source_file": "packages/athena-webapp/convex/operations/owedDailyCloseSweep.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_paymentallocationcallers_test_ts",
-      "label": "paymentAllocationCallers.test.ts",
-      "norm_label": "paymentallocationcallers.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1209,
-      "file_type": "code",
-      "id": "paymentallocationcallers_test_source",
-      "label": "source()",
-      "norm_label": "source()",
-      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
-      "source_location": "L4"
     },
     {
       "community": 121,
@@ -194292,6 +194304,24 @@
     {
       "community": 1210,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_paymentallocationcallers_test_ts",
+      "label": "paymentAllocationCallers.test.ts",
+      "norm_label": "paymentallocationcallers.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1210,
+      "file_type": "code",
+      "id": "paymentallocationcallers_test_source",
+      "label": "source()",
+      "norm_label": "source()",
+      "source_file": "packages/athena-webapp/convex/operations/paymentAllocationCallers.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 1211,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registercloseoutvarianceemail_test_ts",
       "label": "registerCloseoutVarianceEmail.test.ts",
       "norm_label": "registercloseoutvarianceemail.test.ts",
@@ -194299,7 +194329,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1210,
+      "community": 1211,
       "file_type": "code",
       "id": "registercloseoutvarianceemail_test_gethandler",
       "label": "getHandler()",
@@ -194308,7 +194338,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffmessages_ts",
       "label": "staffMessages.ts",
@@ -194317,7 +194347,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1211,
+      "community": 1212,
       "file_type": "code",
       "id": "staffmessages_requirestoremember",
       "label": "requireStoreMember()",
@@ -194326,7 +194356,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "createorreusependingcheckoutitem_test_creatependingcheckoutctx",
       "label": "createPendingCheckoutCtx()",
@@ -194335,7 +194365,7 @@
       "source_location": "L37"
     },
     {
-      "community": 1212,
+      "community": 1213,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_createorreusependingcheckoutitem_test_ts",
       "label": "createOrReusePendingCheckoutItem.test.ts",
@@ -194344,7 +194374,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_quickaddcatalogitem_test_ts",
       "label": "quickAddCatalogItem.test.ts",
@@ -194353,7 +194383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1213,
+      "community": 1214,
       "file_type": "code",
       "id": "quickaddcatalogitem_test_createquickaddctx",
       "label": "createQuickAddCtx()",
@@ -194362,7 +194392,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "correctionevents_buildcorrectionoperationalevent",
       "label": "buildCorrectionOperationalEvent()",
@@ -194371,7 +194401,7 @@
       "source_location": "L35"
     },
     {
-      "community": 1214,
+      "community": 1215,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionevents_ts",
       "label": "correctionEvents.ts",
@@ -194380,7 +194410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "diagnosticredaction_redactsensitivediagnostictext",
       "label": "redactSensitiveDiagnosticText()",
@@ -194389,7 +194419,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1215,
+      "community": 1216,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_diagnosticredaction_ts",
       "label": "diagnosticRedaction.ts",
@@ -194398,7 +194428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "gettransactions_test_mockcorrectionhistorydb",
       "label": "mockCorrectionHistoryDb()",
@@ -194407,7 +194437,7 @@
       "source_location": "L56"
     },
     {
-      "community": 1216,
+      "community": 1217,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_gettransactions_test_ts",
       "label": "getTransactions.test.ts",
@@ -194416,7 +194446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "listregistercatalog_test_createregistercatalogctx",
       "label": "createRegisterCatalogCtx()",
@@ -194425,7 +194455,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1217,
+      "community": 1218,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_listregistercatalog_test_ts",
       "label": "listRegisterCatalog.test.ts",
@@ -194434,7 +194464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "deadletter_recordlocalsyncdeadletter",
       "label": "recordLocalSyncDeadLetter()",
@@ -194443,31 +194473,13 @@
       "source_location": "L34"
     },
     {
-      "community": 1218,
+      "community": 1219,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_deadletter_ts",
       "label": "deadLetter.ts",
       "norm_label": "deadletter.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/deadLetter.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_projectionpolicies_test_ts",
-      "label": "projectionPolicies.test.ts",
-      "norm_label": "projectionpolicies.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectionPolicies.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1219,
-      "file_type": "code",
-      "id": "projectionpolicies_test_saleitem",
-      "label": "saleItem()",
-      "norm_label": "saleitem()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectionPolicies.test.ts",
-      "source_location": "L295"
     },
     {
       "community": 122,
@@ -194625,6 +194637,24 @@
     {
       "community": 1220,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_sync_projectionpolicies_test_ts",
+      "label": "projectionPolicies.test.ts",
+      "norm_label": "projectionpolicies.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectionPolicies.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1220,
+      "file_type": "code",
+      "id": "projectionpolicies_test_saleitem",
+      "label": "saleItem()",
+      "norm_label": "saleitem()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/projectionPolicies.test.ts",
+      "source_location": "L295"
+    },
+    {
+      "community": 1221,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_test_ts",
       "label": "registerCatalogRevision.test.ts",
       "norm_label": "registercatalogrevision.test.ts",
@@ -194632,7 +194662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1220,
+      "community": 1221,
       "file_type": "code",
       "id": "registercatalogrevision_test_createrevisionctx",
       "label": "createRevisionCtx()",
@@ -194641,7 +194671,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_resolvelocalsyncreview_test_ts",
       "label": "resolveLocalSyncReview.test.ts",
@@ -194650,7 +194680,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1221,
+      "community": 1222,
       "file_type": "code",
       "id": "resolvelocalsyncreview_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -194659,7 +194689,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproofvalidation_ts",
       "label": "staffProofValidation.ts",
@@ -194668,7 +194698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1222,
+      "community": 1223,
       "file_type": "code",
       "id": "staffproofvalidation_validateposlocalstaffproofwithctx",
       "label": "validatePosLocalStaffProofWithCtx()",
@@ -194677,7 +194707,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_transactionadjustmentplanner_test_ts",
       "label": "transactionAdjustmentPlanner.test.ts",
@@ -194686,7 +194716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1223,
+      "community": 1224,
       "file_type": "code",
       "id": "transactionadjustmentplanner_test_baseinput",
       "label": "baseInput()",
@@ -194695,7 +194725,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_poslifecyclejournal_test_ts",
       "label": "posLifecycleJournal.test.ts",
@@ -194704,7 +194734,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1224,
+      "community": 1225,
       "file_type": "code",
       "id": "poslifecyclejournal_test_createctx",
       "label": "createCtx()",
@@ -194713,7 +194743,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_poslifecyclejournal_ts",
       "label": "posLifecycleJournal.ts",
@@ -194722,7 +194752,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1225,
+      "community": 1226,
       "file_type": "code",
       "id": "poslifecyclejournal_appendposlifecyclejournalwithctx",
       "label": "appendPosLifecycleJournalWithCtx()",
@@ -194731,7 +194761,7 @@
       "source_location": "L58"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "cashierrepository_getcashierforregisterstate",
       "label": "getCashierForRegisterState()",
@@ -194740,7 +194770,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1226,
+      "community": 1227,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_cashierrepository_ts",
       "label": "cashierRepository.ts",
@@ -194749,7 +194779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "expensesessioncommandrepository_createexpensesessioncommandrepository",
       "label": "createExpenseSessionCommandRepository()",
@@ -194758,7 +194788,7 @@
       "source_location": "L72"
     },
     {
-      "community": 1227,
+      "community": 1228,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_expensesessioncommandrepository_ts",
       "label": "expenseSessionCommandRepository.ts",
@@ -194767,7 +194797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "localsyncrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -194776,31 +194806,13 @@
       "source_location": "L6"
     },
     {
-      "community": 1228,
+      "community": 1229,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_test_ts",
       "label": "localSyncRepository.test.ts",
       "norm_label": "localsyncrepository.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthorityrepository_ts",
-      "label": "registerLifecycleAuthorityRepository.ts",
-      "norm_label": "registerlifecycleauthorityrepository.ts",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerLifecycleAuthorityRepository.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1229,
-      "file_type": "code",
-      "id": "registerlifecycleauthorityrepository_createregisterlifecycleauthorityrepository",
-      "label": "createRegisterLifecycleAuthorityRepository()",
-      "norm_label": "createregisterlifecycleauthorityrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerLifecycleAuthorityRepository.ts",
-      "source_location": "L25"
     },
     {
       "community": 123,
@@ -194958,6 +194970,24 @@
     {
       "community": 1230,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registerlifecycleauthorityrepository_ts",
+      "label": "registerLifecycleAuthorityRepository.ts",
+      "norm_label": "registerlifecycleauthorityrepository.ts",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerLifecycleAuthorityRepository.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1230,
+      "file_type": "code",
+      "id": "registerlifecycleauthorityrepository_createregisterlifecycleauthorityrepository",
+      "label": "createRegisterLifecycleAuthorityRepository()",
+      "norm_label": "createregisterlifecycleauthorityrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/registerLifecycleAuthorityRepository.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 1231,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_registersessionrepository_test_ts",
       "label": "registerSessionRepository.test.ts",
       "norm_label": "registersessionrepository.test.ts",
@@ -194965,7 +194995,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1230,
+      "community": 1231,
       "file_type": "code",
       "id": "registersessionrepository_test_createregistersessionqueryctx",
       "label": "createRegisterSessionQueryCtx()",
@@ -194974,7 +195004,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_test_ts",
       "label": "sessionCommandRepository.test.ts",
@@ -194983,7 +195013,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1231,
+      "community": 1232,
       "file_type": "code",
       "id": "sessioncommandrepository_test_readprojectfile",
       "label": "readProjectFile()",
@@ -194992,7 +195022,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessionrepository_test_ts",
       "label": "sessionRepository.test.ts",
@@ -195001,7 +195031,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1232,
+      "community": 1233,
       "file_type": "code",
       "id": "sessionrepository_test_buildsession",
       "label": "buildSession()",
@@ -195010,7 +195040,7 @@
       "source_location": "L88"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_posruntimeadapter_ts",
       "label": "posRuntimeAdapter.ts",
@@ -195019,7 +195049,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1233,
+      "community": 1234,
       "file_type": "code",
       "id": "posruntimeadapter_buildposremoteassistclientpresence",
       "label": "buildPosRemoteAssistClientPresence()",
@@ -195028,7 +195058,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistrepository_ts",
       "label": "remoteAssistRepository.ts",
@@ -195037,7 +195067,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1234,
+      "community": 1235,
       "file_type": "code",
       "id": "remoteassistrepository_createremoteassistrepository",
       "label": "createRemoteAssistRepository()",
@@ -195046,7 +195076,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "livekitremoteassisttransportprovider_test_buildcontext",
       "label": "buildContext()",
@@ -195055,7 +195085,7 @@
       "source_location": "L131"
     },
     {
-      "community": 1235,
+      "community": 1236,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_livekitremoteassisttransportprovider_test_ts",
       "label": "LiveKitRemoteAssistTransportProvider.test.ts",
@@ -195064,7 +195094,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "createremoteassisttransportprovider_createremoteassisttransportprovider",
       "label": "createRemoteAssistTransportProvider()",
@@ -195073,7 +195103,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1236,
+      "community": 1237,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_transport_createremoteassisttransportprovider_ts",
       "label": "createRemoteAssistTransportProvider.ts",
@@ -195082,7 +195112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_public_ts",
       "label": "public.ts",
@@ -195091,7 +195121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1237,
+      "community": 1238,
       "file_type": "code",
       "id": "public_toremoteassistsessionreturn",
       "label": "toRemoteAssistSessionReturn()",
@@ -195100,7 +195130,7 @@
       "source_location": "L211"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_transport_ts",
       "label": "transport.ts",
@@ -195109,31 +195139,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1238,
+      "community": 1239,
       "file_type": "code",
       "id": "transport_issuecredential",
       "label": "issueCredential()",
       "norm_label": "issuecredential()",
       "source_file": "packages/athena-webapp/convex/remoteAssist/transport.ts",
       "source_location": "L94"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "access_test_context",
-      "label": "context()",
-      "norm_label": "context()",
-      "source_file": "packages/athena-webapp/convex/reports/access.test.ts",
-      "source_location": "L20"
-    },
-    {
-      "community": 1239,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_access_test_ts",
-      "label": "access.test.ts",
-      "norm_label": "access.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/access.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 124,
@@ -195291,6 +195303,24 @@
     {
       "community": 1240,
       "file_type": "code",
+      "id": "access_test_context",
+      "label": "context()",
+      "norm_label": "context()",
+      "source_file": "packages/athena-webapp/convex/reports/access.test.ts",
+      "source_location": "L20"
+    },
+    {
+      "community": 1240,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_access_test_ts",
+      "label": "access.test.ts",
+      "norm_label": "access.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/access.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1241,
+      "file_type": "code",
       "id": "access_requirereportsstoreaccess",
       "label": "requireReportsStoreAccess()",
       "norm_label": "requirereportsstoreaccess()",
@@ -195298,7 +195328,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1240,
+      "community": 1241,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_access_ts",
       "label": "access.ts",
@@ -195307,7 +195337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "fingerprint_test_fact",
       "label": "fact()",
@@ -195316,7 +195346,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1241,
+      "community": 1242,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_test_ts",
       "label": "fingerprint.test.ts",
@@ -195325,7 +195355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "marks_markdirty",
       "label": "markDirty()",
@@ -195334,7 +195364,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1242,
+      "community": 1243,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_marks_ts",
       "label": "marks.ts",
@@ -195343,7 +195373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_transactioncounts_ts",
       "label": "transactionCounts.ts",
@@ -195352,7 +195382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1243,
+      "community": 1244,
       "file_type": "code",
       "id": "transactioncounts_transactioncountfromclosesummary",
       "label": "transactionCountFromCloseSummary()",
@@ -195361,7 +195391,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyinventory_test_ts",
       "label": "weeklyInventory.test.ts",
@@ -195370,7 +195400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1244,
+      "community": 1245,
       "file_type": "code",
       "id": "weeklyinventory_test_inventoryreview",
       "label": "inventoryReview()",
@@ -195379,7 +195409,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyperiods_test_ts",
       "label": "weeklyPeriods.test.ts",
@@ -195388,7 +195418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1245,
+      "community": 1246,
       "file_type": "code",
       "id": "weeklyperiods_test_schedule",
       "label": "schedule()",
@@ -195397,7 +195427,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyrepair_test_ts",
       "label": "weeklyRepair.test.ts",
@@ -195406,7 +195436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1246,
+      "community": 1247,
       "file_type": "code",
       "id": "weeklyrepair_test_ledgeridentity",
       "label": "ledgerIdentity()",
@@ -195415,7 +195445,7 @@
       "source_location": "L115"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyrepair_ts",
       "label": "weeklyRepair.ts",
@@ -195424,7 +195454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1247,
+      "community": 1248,
       "file_type": "code",
       "id": "weeklyrepair_repaircurrentweeklyprojectionwithctx",
       "label": "repairCurrentWeeklyProjectionWithCtx()",
@@ -195433,7 +195463,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_schemas_pos_poslocalsynccontractvalidators_ts",
       "label": "posLocalSyncContractValidators.ts",
@@ -195442,31 +195472,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1248,
+      "community": 1249,
       "file_type": "code",
       "id": "poslocalsynccontractvalidators_unionfromvalidators",
       "label": "unionFromValidators()",
       "norm_label": "unionfromvalidators()",
       "source_file": "packages/athena-webapp/convex/schemas/pos/posLocalSyncContractValidators.ts",
       "source_location": "L10"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "modulewiring_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 1249,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
-      "label": "moduleWiring.test.ts",
-      "norm_label": "modulewiring.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
-      "source_location": "L1"
     },
     {
       "community": 125,
@@ -195624,6 +195636,24 @@
     {
       "community": 1250,
       "file_type": "code",
+      "id": "modulewiring_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 1250,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_modulewiring_test_ts",
+      "label": "moduleWiring.test.ts",
+      "norm_label": "modulewiring.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/moduleWiring.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1251,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_servicecasetracing_test_ts",
       "label": "serviceCaseTracing.test.ts",
       "norm_label": "servicecasetracing.test.ts",
@@ -195631,7 +195661,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1250,
+      "community": 1251,
       "file_type": "code",
       "id": "servicecasetracing_test_buildservicecase",
       "label": "buildServiceCase()",
@@ -195640,7 +195670,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "actor_test_contextfor",
       "label": "contextFor()",
@@ -195649,7 +195679,7 @@
       "source_location": "L99"
     },
     {
-      "community": 1251,
+      "community": 1252,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_actor_test_ts",
       "label": "actor.test.ts",
@@ -195658,7 +195688,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "enforcement_test_invoke",
       "label": "invoke()",
@@ -195667,7 +195697,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1252,
+      "community": 1253,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_enforcement_test_ts",
       "label": "enforcement.test.ts",
@@ -195676,7 +195706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "operationadapter_test_democtx",
       "label": "demoCtx()",
@@ -195685,7 +195715,7 @@
       "source_location": "L288"
     },
     {
-      "community": 1253,
+      "community": 1254,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_test_ts",
       "label": "operationAdapter.test.ts",
@@ -195694,7 +195724,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_posstorereadaccesscoverage_test_ts",
       "label": "posStoreReadAccessCoverage.test.ts",
@@ -195703,7 +195733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1254,
+      "community": 1255,
       "file_type": "code",
       "id": "posstorereadaccesscoverage_test_source",
       "label": "source()",
@@ -195712,7 +195742,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_providerenforcement_test_ts",
       "label": "providerEnforcement.test.ts",
@@ -195721,7 +195751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1255,
+      "community": 1256,
       "file_type": "code",
       "id": "providerenforcement_test_invoke",
       "label": "invoke()",
@@ -195730,7 +195760,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_provision_test_ts",
       "label": "provision.test.ts",
@@ -195739,7 +195769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1256,
+      "community": 1257,
       "file_type": "code",
       "id": "provision_test_seeddemoregisterfoundation",
       "label": "seedDemoRegisterFoundation()",
@@ -195748,7 +195778,7 @@
       "source_location": "L54"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_registerbaseline_test_ts",
       "label": "registerBaseline.test.ts",
@@ -195757,7 +195787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1257,
+      "community": 1258,
       "file_type": "code",
       "id": "registerbaseline_test_seedstorewithregister",
       "label": "seedStoreWithRegister()",
@@ -195766,7 +195796,7 @@
       "source_location": "L147"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_restore_test_ts",
       "label": "restore.test.ts",
@@ -195775,31 +195805,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1258,
+      "community": 1259,
       "file_type": "code",
       "id": "restore_test_restorestatecontext",
       "label": "restoreStateContext()",
       "norm_label": "restorestatecontext()",
       "source_file": "packages/athena-webapp/convex/sharedDemo/restore.test.ts",
       "source_location": "L325"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_scheduledrestore_test_ts",
-      "label": "scheduledRestore.test.ts",
-      "norm_label": "scheduledrestore.test.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/scheduledRestore.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1259,
-      "file_type": "code",
-      "id": "scheduledrestore_test_keyat",
-      "label": "keyAt()",
-      "norm_label": "keyat()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/scheduledRestore.test.ts",
-      "source_location": "L112"
     },
     {
       "community": 126,
@@ -195957,6 +195969,24 @@
     {
       "community": 1260,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_shareddemo_scheduledrestore_test_ts",
+      "label": "scheduledRestore.test.ts",
+      "norm_label": "scheduledrestore.test.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/scheduledRestore.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1260,
+      "file_type": "code",
+      "id": "scheduledrestore_test_keyat",
+      "label": "keyAt()",
+      "norm_label": "keyat()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/scheduledRestore.test.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 1261,
+      "file_type": "code",
       "id": "access_test_createstockopsaccessqueryctx",
       "label": "createStockOpsAccessQueryCtx()",
       "norm_label": "createstockopsaccessqueryctx()",
@@ -195964,7 +195994,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1260,
+      "community": 1261,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_test_ts",
       "label": "access.test.ts",
@@ -195973,7 +196003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "access_requirestorefulladminaccess",
       "label": "requireStoreFullAdminAccess()",
@@ -195982,7 +196012,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1261,
+      "community": 1262,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_access_ts",
       "label": "access.ts",
@@ -195991,7 +196021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_purchaseordertracing_test_ts",
       "label": "purchaseOrderTracing.test.ts",
@@ -196000,7 +196030,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1262,
+      "community": 1263,
       "file_type": "code",
       "id": "purchaseordertracing_test_createworkflowtracectx",
       "label": "createWorkflowTraceCtx()",
@@ -196009,7 +196039,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "auth_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -196018,7 +196048,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1263,
+      "community": 1264,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_auth_ts",
       "label": "auth.ts",
@@ -196027,7 +196057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "customerbehaviortimeline_test_createqueryctx",
       "label": "createQueryCtx()",
@@ -196036,7 +196066,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1264,
+      "community": 1265,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerbehaviortimeline_test_ts",
       "label": "customerBehaviorTimeline.test.ts",
@@ -196045,7 +196075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "customerobservabilitytimeline_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -196054,7 +196084,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1265,
+      "community": 1266,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_customerobservabilitytimeline_test_ts",
       "label": "customerObservabilityTimeline.test.ts",
@@ -196063,7 +196093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "helperorchestration_test_readprojectfile",
       "label": "readProjectFile()",
@@ -196072,7 +196102,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1266,
+      "community": 1267,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helperorchestration_test_ts",
       "label": "helperOrchestration.test.ts",
@@ -196081,7 +196111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "customerengagementevents_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -196090,7 +196120,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1267,
+      "community": 1268,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_customerengagementevents_test_ts",
       "label": "customerEngagementEvents.test.ts",
@@ -196099,7 +196129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "homepagesnapshot_test_sku",
       "label": "sku()",
@@ -196108,31 +196138,13 @@
       "source_location": "L50"
     },
     {
-      "community": 1268,
+      "community": 1269,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_homepagesnapshot_test_ts",
       "label": "homepageSnapshot.test.ts",
       "norm_label": "homepagesnapshot.test.ts",
       "source_file": "packages/athena-webapp/convex/storeFront/homepageSnapshot.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
-      "label": "payment.test.ts",
-      "norm_label": "payment.test.ts",
-      "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1269,
-      "file_type": "code",
-      "id": "payment_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
-      "source_location": "L38"
     },
     {
       "community": 127,
@@ -196290,6 +196302,24 @@
     {
       "community": 1270,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_storefront_payment_test_ts",
+      "label": "payment.test.ts",
+      "norm_label": "payment.test.ts",
+      "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1270,
+      "file_type": "code",
+      "id": "payment_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 1271,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_reviews_ts",
       "label": "reviews.ts",
       "norm_label": "reviews.ts",
@@ -196297,7 +196327,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1270,
+      "community": 1271,
       "file_type": "code",
       "id": "reviews_getstorefrontactorbyid",
       "label": "getStoreFrontActorById()",
@@ -196306,7 +196336,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_rewards_ts",
       "label": "rewards.ts",
@@ -196315,7 +196345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1271,
+      "community": 1272,
       "file_type": "code",
       "id": "rewards_formatpointslabel",
       "label": "formatPointsLabel()",
@@ -196324,7 +196354,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_savedbag_ts",
       "label": "savedBag.ts",
@@ -196333,7 +196363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1272,
+      "community": 1273,
       "file_type": "code",
       "id": "savedbag_listsavedbagitems",
       "label": "listSavedBagItems()",
@@ -196342,7 +196372,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_test_ts",
       "label": "storefrontObservabilityReport.test.ts",
@@ -196351,7 +196381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1273,
+      "community": 1274,
       "file_type": "code",
       "id": "storefrontobservabilityreport_test_createanalyticsevent",
       "label": "createAnalyticsEvent()",
@@ -196360,7 +196390,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_syntheticmonitor_ts",
       "label": "syntheticMonitor.ts",
@@ -196369,7 +196399,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1274,
+      "community": 1275,
       "file_type": "code",
       "id": "syntheticmonitor_issyntheticmonitororigin",
       "label": "isSyntheticMonitorOrigin()",
@@ -196378,7 +196408,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_timequeryrefactors_test_ts",
       "label": "timeQueryRefactors.test.ts",
@@ -196387,7 +196417,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1275,
+      "community": 1276,
       "file_type": "code",
       "id": "timequeryrefactors_test_readsource",
       "label": "readSource()",
@@ -196396,7 +196426,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_useroffers_ts",
       "label": "userOffers.ts",
@@ -196405,7 +196435,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1276,
+      "community": 1277,
       "file_type": "code",
       "id": "useroffers_determineoffereligibility",
       "label": "determineOfferEligibility()",
@@ -196414,7 +196444,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "ensuretimezoneauthority_test_createctx",
       "label": "createCtx()",
@@ -196423,7 +196453,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1277,
+      "community": 1278,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_ensuretimezoneauthority_test_ts",
       "label": "ensureTimezoneAuthority.test.ts",
@@ -196432,7 +196462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "operatingperiods_test_schedule",
       "label": "schedule()",
@@ -196441,30 +196471,12 @@
       "source_location": "L15"
     },
     {
-      "community": 1278,
+      "community": 1279,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_operatingperiods_test_ts",
       "label": "operatingPeriods.test.ts",
       "norm_label": "operatingperiods.test.ts",
       "source_file": "packages/athena-webapp/convex/storeTime/operatingPeriods.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "expensesession_buildexpensesessiontraceseed",
-      "label": "buildExpenseSessionTraceSeed()",
-      "norm_label": "buildexpensesessiontraceseed()",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/expenseSession.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 1279,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
-      "label": "expenseSession.ts",
-      "norm_label": "expensesession.ts",
-      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/expenseSession.ts",
       "source_location": "L1"
     },
     {
@@ -196623,6 +196635,24 @@
     {
       "community": 1280,
       "file_type": "code",
+      "id": "expensesession_buildexpensesessiontraceseed",
+      "label": "buildExpenseSessionTraceSeed()",
+      "norm_label": "buildexpensesessiontraceseed()",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/expenseSession.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 1280,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_workflowtraces_adapters_expensesession_ts",
+      "label": "expenseSession.ts",
+      "norm_label": "expensesession.ts",
+      "source_file": "packages/athena-webapp/convex/workflowTraces/adapters/expenseSession.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1281,
+      "file_type": "code",
       "id": "onlineorder_test_buildorder",
       "label": "buildOrder()",
       "norm_label": "buildorder()",
@@ -196630,7 +196660,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1280,
+      "community": 1281,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -196639,7 +196669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "orderreturnexchange_test_buildorder",
       "label": "buildOrder()",
@@ -196648,7 +196678,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1281,
+      "community": 1282,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_orderreturnexchange_test_ts",
       "label": "orderReturnExchange.test.ts",
@@ -196657,7 +196687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_possession_ts",
       "label": "posSession.ts",
@@ -196666,7 +196696,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1282,
+      "community": 1283,
       "file_type": "code",
       "id": "possession_buildpossessiontraceseed",
       "label": "buildPosSessionTraceSeed()",
@@ -196675,7 +196705,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_presentation_ts",
       "label": "presentation.ts",
@@ -196684,7 +196714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1283,
+      "community": 1284,
       "file_type": "code",
       "id": "presentation_buildworkflowtraceviewmodel",
       "label": "buildWorkflowTraceViewModel()",
@@ -196693,7 +196723,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_schemaindexes_test_ts",
       "label": "schemaIndexes.test.ts",
@@ -196702,7 +196732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1284,
+      "community": 1285,
       "file_type": "code",
       "id": "schemaindexes_test_gettableindexes",
       "label": "getTableIndexes()",
@@ -196711,7 +196741,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "capabilitytypes_isathenaintelligencecapability",
       "label": "isAthenaIntelligenceCapability()",
@@ -196720,7 +196750,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1285,
+      "community": 1286,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_capabilitytypes_ts",
       "label": "capabilityTypes.ts",
@@ -196729,7 +196759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "contexttracking_createcontexttracker",
       "label": "createContextTracker()",
@@ -196738,7 +196768,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1286,
+      "community": 1287,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_intelligence_contexttracking_ts",
       "label": "contextTracking.ts",
@@ -196747,7 +196777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_posterminalregistrationerror_ts",
       "label": "posTerminalRegistrationError.ts",
@@ -196756,7 +196786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1287,
+      "community": 1288,
       "file_type": "code",
       "id": "posterminalregistrationerror_isposregisternumberconflict",
       "label": "isPosRegisterNumberConflict()",
@@ -196765,7 +196795,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_productdisplayname_ts",
       "label": "productDisplayName.ts",
@@ -196774,31 +196804,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1288,
+      "community": 1289,
       "file_type": "code",
       "id": "productdisplayname_formatproductdisplayname",
       "label": "formatProductDisplayName()",
       "norm_label": "formatproductdisplayname()",
       "source_file": "packages/athena-webapp/shared/productDisplayName.ts",
       "source_location": "L11"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_reviewreasonformatter_ts",
-      "label": "reviewReasonFormatter.ts",
-      "norm_label": "reviewreasonformatter.ts",
-      "source_file": "packages/athena-webapp/shared/reviewReasonFormatter.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1289,
-      "file_type": "code",
-      "id": "reviewreasonformatter_formatstoredreviewreason",
-      "label": "formatStoredReviewReason()",
-      "norm_label": "formatstoredreviewreason()",
-      "source_file": "packages/athena-webapp/shared/reviewReasonFormatter.ts",
-      "source_location": "L3"
     },
     {
       "community": 129,
@@ -196956,6 +196968,24 @@
     {
       "community": 1290,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_reviewreasonformatter_ts",
+      "label": "reviewReasonFormatter.ts",
+      "norm_label": "reviewreasonformatter.ts",
+      "source_file": "packages/athena-webapp/shared/reviewReasonFormatter.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1290,
+      "file_type": "code",
+      "id": "reviewreasonformatter_formatstoredreviewreason",
+      "label": "formatStoredReviewReason()",
+      "norm_label": "formatstoredreviewreason()",
+      "source_file": "packages/athena-webapp/shared/reviewReasonFormatter.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 1291,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_serviceintake_ts",
       "label": "serviceIntake.ts",
       "norm_label": "serviceintake.ts",
@@ -196963,7 +196993,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1290,
+      "community": 1291,
       "file_type": "code",
       "id": "serviceintake_validateserviceintakeinput",
       "label": "validateServiceIntakeInput()",
@@ -196972,7 +197002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemoactionerror_ts",
       "label": "sharedDemoActionError.ts",
@@ -196981,7 +197011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1291,
+      "community": 1292,
       "file_type": "code",
       "id": "shareddemoactionerror_isshareddemoactiondenieddata",
       "label": "isSharedDemoActionDeniedData()",
@@ -196990,7 +197020,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_shareddemoregistererror_ts",
       "label": "sharedDemoRegisterError.ts",
@@ -196999,7 +197029,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1292,
+      "community": 1293,
       "file_type": "code",
       "id": "shareddemoregistererror_isshareddemoregisterunavailableerror",
       "label": "isSharedDemoRegisterUnavailableError()",
@@ -197008,7 +197038,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_textcase_ts",
       "label": "textCase.ts",
@@ -197017,7 +197047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1293,
+      "community": 1294,
       "file_type": "code",
       "id": "textcase_capitalizewords",
       "label": "capitalizeWords()",
@@ -197026,7 +197056,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "convexauthurl_removeconvexauthcodeparamfromurl",
       "label": "removeConvexAuthCodeParamFromUrl()",
@@ -197035,7 +197065,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1294,
+      "community": 1295,
       "file_type": "code",
       "id": "packages_athena_webapp_src_auth_convexauthurl_ts",
       "label": "convexAuthUrl.ts",
@@ -197044,7 +197074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "organizationview_navigation",
       "label": "Navigation()",
@@ -197053,7 +197083,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1295,
+      "community": 1296,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationview_tsx",
       "label": "OrganizationView.tsx",
@@ -197062,7 +197092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "organizationsview_navigation",
       "label": "Navigation()",
@@ -197071,7 +197101,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1296,
+      "community": 1297,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organizationsview_tsx",
       "label": "OrganizationsView.tsx",
@@ -197080,7 +197110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_permissiongate_tsx",
       "label": "PermissionGate.tsx",
@@ -197089,7 +197119,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1297,
+      "community": 1298,
       "file_type": "code",
       "id": "permissiongate_permissiongate",
       "label": "PermissionGate()",
@@ -197098,7 +197128,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_protectedroute_tsx",
       "label": "ProtectedRoute.tsx",
@@ -197107,31 +197137,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1298,
+      "community": 1299,
       "file_type": "code",
       "id": "protectedroute_protectedroute",
       "label": "ProtectedRoute()",
       "norm_label": "protectedroute()",
       "source_file": "packages/athena-webapp/src/components/ProtectedRoute.tsx",
       "source_location": "L11"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_settingsview_tsx",
-      "label": "SettingsView.tsx",
-      "norm_label": "settingsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1299,
-      "file_type": "code",
-      "id": "settingsview_settingsview",
-      "label": "SettingsView()",
-      "norm_label": "settingsview()",
-      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
-      "source_location": "L3"
     },
     {
       "community": 13,
@@ -197712,6 +197724,24 @@
     {
       "community": 1300,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_settingsview_tsx",
+      "label": "SettingsView.tsx",
+      "norm_label": "settingsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1300,
+      "file_type": "code",
+      "id": "settingsview_settingsview",
+      "label": "SettingsView()",
+      "norm_label": "settingsview()",
+      "source_file": "packages/athena-webapp/src/components/SettingsView.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 1301,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeactions_tsx",
       "label": "StoreActions.tsx",
       "norm_label": "storeactions.tsx",
@@ -197719,7 +197749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1300,
+      "community": 1301,
       "file_type": "code",
       "id": "storeactions_storeactions",
       "label": "StoreActions()",
@@ -197728,7 +197758,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storedropdown_tsx",
       "label": "StoreDropdown.tsx",
@@ -197737,7 +197767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1301,
+      "community": 1302,
       "file_type": "code",
       "id": "storedropdown_storedropdown",
       "label": "StoreDropdown()",
@@ -197746,7 +197776,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storeview_tsx",
       "label": "StoreView.tsx",
@@ -197755,7 +197785,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1302,
+      "community": 1303,
       "file_type": "code",
       "id": "storeview_navigation",
       "label": "Navigation()",
@@ -197764,7 +197794,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_storesdropdown_tsx",
       "label": "StoresDropdown.tsx",
@@ -197773,7 +197803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1303,
+      "community": 1304,
       "file_type": "code",
       "id": "storesdropdown_storesdropdown",
       "label": "StoresDropdown()",
@@ -197782,7 +197812,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "barcodeqrviewer_handleprint",
       "label": "handlePrint()",
@@ -197791,7 +197821,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1304,
+      "community": 1305,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_barcodeqrviewer_tsx",
       "label": "BarcodeQRViewer.tsx",
@@ -197800,7 +197830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_processingfees_tsx",
       "label": "ProcessingFees.tsx",
@@ -197809,7 +197839,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1305,
+      "community": 1306,
       "file_type": "code",
       "id": "processingfees_processingfeesview",
       "label": "ProcessingFeesView()",
@@ -197818,7 +197848,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productavailabilitytogglegroup_tsx",
       "label": "ProductAvailabilityToggleGroup.tsx",
@@ -197827,7 +197857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1306,
+      "community": 1307,
       "file_type": "code",
       "id": "productavailabilitytogglegroup_productavailabilitytogglegroup",
       "label": "ProductAvailabilityToggleGroup()",
@@ -197836,7 +197866,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productdetails_tsx",
       "label": "ProductDetails.tsx",
@@ -197845,7 +197875,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1307,
+      "community": 1308,
       "file_type": "code",
       "id": "productdetails_handlenamechange",
       "label": "handleNameChange()",
@@ -197854,7 +197884,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productimages_tsx",
       "label": "ProductImages.tsx",
@@ -197863,31 +197893,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1308,
+      "community": 1309,
       "file_type": "code",
       "id": "productimages_header",
       "label": "Header()",
       "norm_label": "header()",
       "source_file": "packages/athena-webapp/src/components/add-product/ProductImages.tsx",
       "source_location": "L14"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
-      "label": "ProductPage.tsx",
-      "norm_label": "productpage.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1309,
-      "file_type": "code",
-      "id": "productpage_productpage",
-      "label": "ProductPage()",
-      "norm_label": "productpage()",
-      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
-      "source_location": "L13"
     },
     {
       "community": 131,
@@ -198045,6 +198057,24 @@
     {
       "community": 1310,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_productpage_tsx",
+      "label": "ProductPage.tsx",
+      "norm_label": "productpage.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1310,
+      "file_type": "code",
+      "id": "productpage_productpage",
+      "label": "ProductPage()",
+      "norm_label": "productpage()",
+      "source_file": "packages/athena-webapp/src/components/add-product/ProductPage.tsx",
+      "source_location": "L13"
+    },
+    {
+      "community": 1311,
+      "file_type": "code",
       "id": "copyimagesview_buildcopyimagesskuupdate",
       "label": "buildCopyImagesSkuUpdate()",
       "norm_label": "buildcopyimagesskuupdate()",
@@ -198052,7 +198082,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1310,
+      "community": 1311,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_copyimagesview_tsx",
       "label": "CopyImagesView.tsx",
@@ -198061,7 +198091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_product_variant_columns_tsx",
       "label": "product-variant-columns.tsx",
@@ -198070,7 +198100,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1311,
+      "community": 1312,
       "file_type": "code",
       "id": "product_variant_columns_setsourcevariant",
       "label": "setSourceVariant()",
@@ -198079,7 +198109,7 @@
       "source_location": "L47"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_taxonomyselectlabels_ts",
       "label": "taxonomySelectLabels.ts",
@@ -198088,7 +198118,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1312,
+      "community": 1313,
       "file_type": "code",
       "id": "taxonomyselectlabels_formattaxonomyselectoptionlabel",
       "label": "formatTaxonomySelectOptionLabel()",
@@ -198097,7 +198127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "activitytimeline_capitalizefirstletter",
       "label": "capitalizeFirstLetter()",
@@ -198106,7 +198136,7 @@
       "source_location": "L149"
     },
     {
-      "community": 1313,
+      "community": 1314,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_activitytimeline_tsx",
       "label": "ActivityTimeline.tsx",
@@ -198115,7 +198145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "analyticscombinedusers_analyticscombinedusers",
       "label": "AnalyticsCombinedUsers()",
@@ -198124,7 +198154,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1314,
+      "community": 1315,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticscombinedusers_tsx",
       "label": "AnalyticsCombinedUsers.tsx",
@@ -198133,7 +198163,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "analyticsitems_analyticsitems",
       "label": "AnalyticsItems()",
@@ -198142,7 +198172,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1315,
+      "community": 1316,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsitems_tsx",
       "label": "AnalyticsItems.tsx",
@@ -198151,7 +198181,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "analyticsproducts_analyticsproducts",
       "label": "AnalyticsProducts()",
@@ -198160,7 +198190,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1316,
+      "community": 1317,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsproducts_tsx",
       "label": "AnalyticsProducts.tsx",
@@ -198169,7 +198199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "analyticsusers_analyticsusers",
       "label": "AnalyticsUsers()",
@@ -198178,7 +198208,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1317,
+      "community": 1318,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsusers_tsx",
       "label": "AnalyticsUsers.tsx",
@@ -198187,7 +198217,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "enhancedanalyticsview_getdaterangemilliseconds",
       "label": "getDateRangeMilliseconds()",
@@ -198196,31 +198226,13 @@
       "source_location": "L42"
     },
     {
-      "community": 1318,
+      "community": 1319,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_enhancedanalyticsview_tsx",
       "label": "EnhancedAnalyticsView.tsx",
       "norm_label": "enhancedanalyticsview.tsx",
       "source_file": "packages/athena-webapp/src/components/analytics/EnhancedAnalyticsView.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_storeinsights_test_tsx",
-      "label": "StoreInsights.test.tsx",
-      "norm_label": "storeinsights.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1319,
-      "file_type": "code",
-      "id": "storeinsights_test_renderwithqueries",
-      "label": "renderWithQueries()",
-      "norm_label": "renderwithqueries()",
-      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.test.tsx",
-      "source_location": "L26"
     },
     {
       "community": 132,
@@ -198378,6 +198390,24 @@
     {
       "community": 1320,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_analytics_storeinsights_test_tsx",
+      "label": "StoreInsights.test.tsx",
+      "norm_label": "storeinsights.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1320,
+      "file_type": "code",
+      "id": "storeinsights_test_renderwithqueries",
+      "label": "renderWithQueries()",
+      "norm_label": "renderwithqueries()",
+      "source_file": "packages/athena-webapp/src/components/analytics/StoreInsights.test.tsx",
+      "source_location": "L26"
+    },
+    {
+      "community": 1321,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_visitorchart_tsx",
       "label": "VisitorChart.tsx",
       "norm_label": "visitorchart.tsx",
@@ -198385,7 +198415,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1320,
+      "community": 1321,
       "file_type": "code",
       "id": "visitorchart_formathour",
       "label": "formatHour()",
@@ -198394,7 +198424,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "analyticsworkspaceefficiency_test_readsource",
       "label": "readSource()",
@@ -198403,7 +198433,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1321,
+      "community": 1322,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analyticsworkspaceefficiency_test_ts",
       "label": "analyticsWorkspaceEfficiency.test.ts",
@@ -198412,7 +198442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "logitems_logitems",
       "label": "LogItems()",
@@ -198421,7 +198451,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1322,
+      "community": 1323,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logitems_tsx",
       "label": "LogItems.tsx",
@@ -198430,7 +198460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "logview_header",
       "label": "Header()",
@@ -198439,7 +198469,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1323,
+      "community": 1324,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logview_tsx",
       "label": "LogView.tsx",
@@ -198448,7 +198478,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "logsview_navigation",
       "label": "Navigation()",
@@ -198457,7 +198487,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1324,
+      "community": 1325,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_logsview_tsx",
       "label": "LogsView.tsx",
@@ -198466,7 +198496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_logs_hooks_useloadlogitems_ts",
       "label": "useLoadLogItems.ts",
@@ -198475,7 +198505,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1325,
+      "community": 1326,
       "file_type": "code",
       "id": "useloadlogitems_useloadlogitems",
       "label": "useLoadLogItems()",
@@ -198484,7 +198514,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "appmessagehost_cn",
       "label": "cn()",
@@ -198493,7 +198523,7 @@
       "source_location": "L99"
     },
     {
-      "community": 1326,
+      "community": 1327,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_messages_appmessagehost_tsx",
       "label": "AppMessageHost.tsx",
@@ -198502,7 +198532,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "auth_auth",
       "label": "Auth()",
@@ -198511,7 +198541,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1327,
+      "community": 1328,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_auth_tsx",
       "label": "Auth.tsx",
@@ -198520,7 +198550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "inputotp_test_resolvesignin",
       "label": "resolveSignIn()",
@@ -198529,30 +198559,12 @@
       "source_location": "L123"
     },
     {
-      "community": 1328,
+      "community": 1329,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_inputotp_test_tsx",
       "label": "InputOTP.test.tsx",
       "norm_label": "inputotp.test.tsx",
       "source_file": "packages/athena-webapp/src/components/auth/Login/InputOTP.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "loginform_isemailnotapprovederror",
-      "label": "isEmailNotApprovedError()",
-      "norm_label": "isemailnotapprovederror()",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 1329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
-      "label": "LoginForm.tsx",
-      "norm_label": "loginform.tsx",
-      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
       "source_location": "L1"
     },
     {
@@ -198702,6 +198714,24 @@
     {
       "community": 1330,
       "file_type": "code",
+      "id": "loginform_isemailnotapprovederror",
+      "label": "isEmailNotApprovedError()",
+      "norm_label": "isemailnotapprovederror()",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 1330,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_auth_login_loginform_tsx",
+      "label": "LoginForm.tsx",
+      "norm_label": "loginform.tsx",
+      "source_file": "packages/athena-webapp/src/components/auth/Login/LoginForm.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1331,
+      "file_type": "code",
       "id": "index_test_expectpendingauthsyncredirect",
       "label": "expectPendingAuthSyncRedirect()",
       "norm_label": "expectpendingauthsyncredirect()",
@@ -198709,7 +198739,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1330,
+      "community": 1331,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_auth_login_index_test_tsx",
       "label": "index.test.tsx",
@@ -198718,7 +198748,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "data_table_column_header_datatablecolumnheader",
       "label": "DataTableColumnHeader()",
@@ -198727,7 +198757,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1331,
+      "community": 1332,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_column_header_tsx",
       "label": "data-table-column-header.tsx",
@@ -198736,7 +198766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "bulkoperationsfilters_handleloadproducts",
       "label": "handleLoadProducts()",
@@ -198745,7 +198775,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1332,
+      "community": 1333,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationsfilters_tsx",
       "label": "BulkOperationsFilters.tsx",
@@ -198754,7 +198784,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "bulkoperationspreview_test_makerow",
       "label": "makeRow()",
@@ -198763,7 +198793,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1333,
+      "community": 1334,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_test_tsx",
       "label": "BulkOperationsPreview.test.tsx",
@@ -198772,7 +198802,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "bulkoperationspreview_formatprice",
       "label": "formatPrice()",
@@ -198781,7 +198811,7 @@
       "source_location": "L50"
     },
     {
-      "community": 1334,
+      "community": 1335,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_bulk_operations_bulkoperationspreview_tsx",
       "label": "BulkOperationsPreview.tsx",
@@ -198790,7 +198820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "formatreviewreason_formatreviewreason",
       "label": "formatReviewReason()",
@@ -198799,7 +198829,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1335,
+      "community": 1336,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_formatreviewreason_ts",
       "label": "formatReviewReason.ts",
@@ -198808,7 +198838,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_cash_controls_registersessioncolumns_tsx",
       "label": "registerSessionColumns.tsx",
@@ -198817,7 +198847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1336,
+      "community": 1337,
       "file_type": "code",
       "id": "registersessioncolumns_registersessionlink",
       "label": "RegisterSessionLink()",
@@ -198826,7 +198856,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "checkoutsessionstable_checkoutsessionstable",
       "label": "CheckoutSessionsTable()",
@@ -198835,7 +198865,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1337,
+      "community": 1338,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsessionstable_tsx",
       "label": "CheckoutSessionsTable.tsx",
@@ -198844,7 +198874,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "checkoutsesssionsview_navigation",
       "label": "Navigation()",
@@ -198853,30 +198883,12 @@
       "source_location": "L11"
     },
     {
-      "community": 1338,
+      "community": 1339,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_checkout_sessions_checkoutsesssionsview_tsx",
       "label": "CheckoutSesssionsView.tsx",
       "norm_label": "checkoutsesssionsview.tsx",
       "source_file": "packages/athena-webapp/src/components/checkout-sessions/CheckoutSesssionsView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "animateddatastate_animateddatastate",
-      "label": "AnimatedDataState()",
-      "norm_label": "animateddatastate()",
-      "source_file": "packages/athena-webapp/src/components/common/AnimatedDataState.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 1339,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_common_animateddatastate_tsx",
-      "label": "AnimatedDataState.tsx",
-      "norm_label": "animateddatastate.tsx",
-      "source_file": "packages/athena-webapp/src/components/common/AnimatedDataState.tsx",
       "source_location": "L1"
     },
     {
@@ -199026,6 +199038,24 @@
     {
       "community": 1340,
       "file_type": "code",
+      "id": "animateddatastate_animateddatastate",
+      "label": "AnimatedDataState()",
+      "norm_label": "animateddatastate()",
+      "source_file": "packages/athena-webapp/src/components/common/AnimatedDataState.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 1340,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_common_animateddatastate_tsx",
+      "label": "AnimatedDataState.tsx",
+      "norm_label": "animateddatastate.tsx",
+      "source_file": "packages/athena-webapp/src/components/common/AnimatedDataState.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1341,
+      "file_type": "code",
       "id": "animatedheight_animatedheight",
       "label": "AnimatedHeight()",
       "norm_label": "animatedheight()",
@@ -199033,7 +199063,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1340,
+      "community": 1341,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_animatedheight_tsx",
       "label": "AnimatedHeight.tsx",
@@ -199042,7 +199072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "financialvalue_financialvalue",
       "label": "FinancialValue()",
@@ -199051,7 +199081,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1341,
+      "community": 1342,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_financialvalue_tsx",
       "label": "FinancialValue.tsx",
@@ -199060,7 +199090,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "flipnumber_test_animatedproperties",
       "label": "animatedProperties()",
@@ -199069,7 +199099,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1342,
+      "community": 1343,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_flipnumber_test_tsx",
       "label": "FlipNumber.test.tsx",
@@ -199078,7 +199108,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_registersessionidentity_tsx",
       "label": "RegisterSessionIdentity.tsx",
@@ -199087,7 +199117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1343,
+      "community": 1344,
       "file_type": "code",
       "id": "registersessionidentity_registersessionidentity",
       "label": "RegisterSessionIdentity()",
@@ -199096,7 +199126,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_registersessionidentitypresentation_ts",
       "label": "registerSessionIdentityPresentation.ts",
@@ -199105,7 +199135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1344,
+      "community": 1345,
       "file_type": "code",
       "id": "registersessionidentitypresentation_formatregisterheadername",
       "label": "formatRegisterHeaderName()",
@@ -199114,7 +199144,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "docsmarkdown_docsmarkdown",
       "label": "DocsMarkdown()",
@@ -199123,7 +199153,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1345,
+      "community": 1346,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsmarkdown_tsx",
       "label": "DocsMarkdown.tsx",
@@ -199132,7 +199162,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "docsreportquiz_test_answer",
       "label": "answer()",
@@ -199141,7 +199171,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1346,
+      "community": 1347,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsreportquiz_test_tsx",
       "label": "DocsReportQuiz.test.tsx",
@@ -199150,7 +199180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "docsreportquiz_reset",
       "label": "reset()",
@@ -199159,7 +199189,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1347,
+      "community": 1348,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsreportquiz_tsx",
       "label": "DocsReportQuiz.tsx",
@@ -199168,7 +199198,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "docstexture_docstexture",
       "label": "DocsTexture()",
@@ -199177,30 +199207,12 @@
       "source_location": "L9"
     },
     {
-      "community": 1348,
+      "community": 1349,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docstexture_tsx",
       "label": "DocsTexture.tsx",
       "norm_label": "docstexture.tsx",
       "source_file": "packages/athena-webapp/src/components/docs/DocsTexture.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "expenseview_expenseview",
-      "label": "ExpenseView()",
-      "norm_label": "expenseview()",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 1349,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
-      "label": "ExpenseView.tsx",
-      "norm_label": "expenseview.tsx",
-      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
       "source_location": "L1"
     },
     {
@@ -199350,6 +199362,24 @@
     {
       "community": 1350,
       "file_type": "code",
+      "id": "expenseview_expenseview",
+      "label": "ExpenseView()",
+      "norm_label": "expenseview()",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 1350,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_expense_expenseview_tsx",
+      "label": "ExpenseView.tsx",
+      "norm_label": "expenseview.tsx",
+      "source_file": "packages/athena-webapp/src/components/expense/ExpenseView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1351,
+      "file_type": "code",
       "id": "bestsellersdialog_bestsellersdialog",
       "label": "BestSellersDialog()",
       "norm_label": "bestsellersdialog()",
@@ -199357,7 +199387,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1350,
+      "community": 1351,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellersdialog_tsx",
       "label": "BestSellersDialog.tsx",
@@ -199366,7 +199396,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "featuredsectiondialog_featuredsectiondialog",
       "label": "FeaturedSectionDialog()",
@@ -199375,7 +199405,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1351,
+      "community": 1352,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsectiondialog_tsx",
       "label": "FeaturedSectionDialog.tsx",
@@ -199384,7 +199414,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "landingpagereelversion_handleupdateconfig",
       "label": "handleUpdateConfig()",
@@ -199393,7 +199423,7 @@
       "source_location": "L83"
     },
     {
-      "community": 1352,
+      "community": 1353,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_landingpagereelversion_tsx",
       "label": "LandingPageReelVersion.tsx",
@@ -199402,7 +199432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_shoplookdialog_tsx",
       "label": "ShopLookDialog.tsx",
@@ -199411,7 +199441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1353,
+      "community": 1354,
       "file_type": "code",
       "id": "shoplookdialog_shoplookdialog",
       "label": "ShopLookDialog()",
@@ -199420,7 +199450,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_intelligence_readoutsupport_tsx",
       "label": "ReadoutSupport.tsx",
@@ -199429,7 +199459,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1354,
+      "community": 1355,
       "file_type": "code",
       "id": "readoutsupport_readouttrustmetadata",
       "label": "ReadoutTrustMetadata()",
@@ -199438,7 +199468,7 @@
       "source_location": "L90"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "index_jointeam",
       "label": "JoinTeam()",
@@ -199447,7 +199477,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1355,
+      "community": 1356,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_join_team_index_tsx",
       "label": "index.tsx",
@@ -199456,7 +199486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "landinggrain_landinggrain",
       "label": "LandingGrain()",
@@ -199465,7 +199495,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1356,
+      "community": 1357,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_landinggrain_tsx",
       "label": "LandingGrain.tsx",
@@ -199474,7 +199504,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "automationrevealscene_automationrevealscene",
       "label": "AutomationRevealScene()",
@@ -199483,7 +199513,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1357,
+      "community": 1358,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_automationrevealscene_tsx",
       "label": "AutomationRevealScene.tsx",
@@ -199492,7 +199522,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "cashcontrolsscene_cashcontrolsscene",
       "label": "CashControlsScene()",
@@ -199501,30 +199531,12 @@
       "source_location": "L15"
     },
     {
-      "community": 1358,
+      "community": 1359,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_cashcontrolsscene_tsx",
       "label": "CashControlsScene.tsx",
       "norm_label": "cashcontrolsscene.tsx",
       "source_file": "packages/athena-webapp/src/components/landing/story/CashControlsScene.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "landingworkspacevideo_landingworkspacevideo",
-      "label": "LandingWorkspaceVideo()",
-      "norm_label": "landingworkspacevideo()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/LandingWorkspaceVideo.tsx",
-      "source_location": "L10"
-    },
-    {
-      "community": 1359,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_landing_story_landingworkspacevideo_tsx",
-      "label": "LandingWorkspaceVideo.tsx",
-      "norm_label": "landingworkspacevideo.tsx",
-      "source_file": "packages/athena-webapp/src/components/landing/story/LandingWorkspaceVideo.tsx",
       "source_location": "L1"
     },
     {
@@ -199674,6 +199686,24 @@
     {
       "community": 1360,
       "file_type": "code",
+      "id": "landingworkspacevideo_landingworkspacevideo",
+      "label": "LandingWorkspaceVideo()",
+      "norm_label": "landingworkspacevideo()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/LandingWorkspaceVideo.tsx",
+      "source_location": "L10"
+    },
+    {
+      "community": 1360,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_landing_story_landingworkspacevideo_tsx",
+      "label": "LandingWorkspaceVideo.tsx",
+      "norm_label": "landingworkspacevideo.tsx",
+      "source_file": "packages/athena-webapp/src/components/landing/story/LandingWorkspaceVideo.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1361,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_poshubroleswitcher_tsx",
       "label": "PosHubRoleSwitcher.tsx",
       "norm_label": "poshubroleswitcher.tsx",
@@ -199681,7 +199711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1360,
+      "community": 1361,
       "file_type": "code",
       "id": "poshubroleswitcher_poshubroleswitcher",
       "label": "PosHubRoleSwitcher()",
@@ -199690,7 +199720,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_syncbridgescene_tsx",
       "label": "SyncBridgeScene.tsx",
@@ -199699,7 +199729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1361,
+      "community": 1362,
       "file_type": "code",
       "id": "syncbridgescene_syncbridgescene",
       "label": "SyncBridgeScene()",
@@ -199708,7 +199738,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "demoday_formatdemomoney",
       "label": "formatDemoMoney()",
@@ -199717,7 +199747,7 @@
       "source_location": "L127"
     },
     {
-      "community": 1362,
+      "community": 1363,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_demoday_ts",
       "label": "demoDay.ts",
@@ -199726,7 +199756,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "demodayfixtures_storytime",
       "label": "storyTime()",
@@ -199735,7 +199765,7 @@
       "source_location": "L47"
     },
     {
-      "community": 1363,
+      "community": 1364,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_demodayfixtures_ts",
       "label": "demoDayFixtures.ts",
@@ -199744,7 +199774,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_landing_story_uselandingtheme_ts",
       "label": "useLandingTheme.ts",
@@ -199753,7 +199783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1364,
+      "community": 1365,
       "file_type": "code",
       "id": "uselandingtheme_uselandingtheme",
       "label": "useLandingTheme()",
@@ -199762,7 +199792,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "inventorycostoverlayview_test_renderworkspace",
       "label": "renderWorkspace()",
@@ -199771,7 +199801,7 @@
       "source_location": "L226"
     },
     {
-      "community": 1365,
+      "community": 1366,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_inventorycostoverlayview_test_tsx",
       "label": "InventoryCostOverlayView.test.tsx",
@@ -199780,7 +199810,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "operationreviewitemcard_operationreviewitemcard",
       "label": "OperationReviewItemCard()",
@@ -199789,7 +199819,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1366,
+      "community": 1367,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationreviewitemcard_tsx",
       "label": "OperationReviewItemCard.tsx",
@@ -199798,7 +199828,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "operationssummarymetric_buildparams",
       "label": "buildParams()",
@@ -199807,7 +199837,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1367,
+      "community": 1368,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_operationssummarymetric_tsx",
       "label": "OperationsSummaryMetric.tsx",
@@ -199816,7 +199846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "approvalrequesterbinding_toapprovalrequesterbindingarg",
       "label": "toApprovalRequesterBindingArg()",
@@ -199825,30 +199855,12 @@
       "source_location": "L4"
     },
     {
-      "community": 1368,
+      "community": 1369,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_approvalrequesterbinding_ts",
       "label": "approvalRequesterBinding.ts",
       "norm_label": "approvalrequesterbinding.ts",
       "source_file": "packages/athena-webapp/src/components/operations/approvalRequesterBinding.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "emailstatusview_handlesendorderemail",
-      "label": "handleSendOrderEmail()",
-      "norm_label": "handlesendorderemail()",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 1369,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
-      "label": "EmailStatusView.tsx",
-      "norm_label": "emailstatusview.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
       "source_location": "L1"
     },
     {
@@ -199998,6 +200010,24 @@
     {
       "community": 1370,
       "file_type": "code",
+      "id": "emailstatusview_handlesendorderemail",
+      "label": "handleSendOrderEmail()",
+      "norm_label": "handlesendorderemail()",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 1370,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_orders_emailstatusview_tsx",
+      "label": "EmailStatusView.tsx",
+      "norm_label": "emailstatusview.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/EmailStatusView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1371,
+      "file_type": "code",
       "id": "ordermetricspanel_handletimerangechange",
       "label": "handleTimeRangeChange()",
       "norm_label": "handletimerangechange()",
@@ -200005,7 +200035,7 @@
       "source_location": "L41"
     },
     {
-      "community": 1370,
+      "community": 1371,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordermetricspanel_tsx",
       "label": "OrderMetricsPanel.tsx",
@@ -200014,7 +200044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "orders_orders",
       "label": "Orders()",
@@ -200023,7 +200053,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1371,
+      "community": 1372,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_tsx",
       "label": "Orders.tsx",
@@ -200032,7 +200062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "ordersview_ordersview",
       "label": "OrdersView()",
@@ -200041,7 +200071,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1372,
+      "community": 1373,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_ordersview_tsx",
       "label": "OrdersView.tsx",
@@ -200050,7 +200080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_refundsview_tsx",
       "label": "RefundsView.tsx",
@@ -200059,7 +200089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1373,
+      "community": 1374,
       "file_type": "code",
       "id": "refundsview_handlerefundorder",
       "label": "handleRefundOrder()",
@@ -200068,7 +200098,7 @@
       "source_location": "L81"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_hooks_usegetactiveonlineorder_ts",
       "label": "useGetActiveOnlineOrder.ts",
@@ -200077,7 +200107,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1374,
+      "community": 1375,
       "file_type": "code",
       "id": "usegetactiveonlineorder_usegetactiveonlineorder",
       "label": "useGetActiveOnlineOrder()",
@@ -200086,7 +200116,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "ordercustomercell_ordercustomercell",
       "label": "OrderCustomerCell()",
@@ -200095,7 +200125,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1375,
+      "community": 1376,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercustomercell_tsx",
       "label": "OrderCustomerCell.tsx",
@@ -200104,7 +200134,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "data_table_toolbar_handleclearfilters",
       "label": "handleClearFilters()",
@@ -200113,7 +200143,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1376,
+      "community": 1377,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -200122,7 +200152,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "ordercolumns_if",
       "label": "if()",
@@ -200131,7 +200161,7 @@
       "source_location": "L87"
     },
     {
-      "community": 1377,
+      "community": 1378,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orders_table_components_ordercolumns_tsx",
       "label": "orderColumns.tsx",
@@ -200140,7 +200170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "organization_switcher_organizationswitcher",
       "label": "OrganizationSwitcher()",
@@ -200149,30 +200179,12 @@
       "source_location": "L33"
     },
     {
-      "community": 1378,
+      "community": 1379,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_organization_switcher_tsx",
       "label": "organization-switcher.tsx",
       "norm_label": "organization-switcher.tsx",
       "source_file": "packages/athena-webapp/src/components/organization-switcher.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "cartitems_test_buildserviceline",
-      "label": "buildServiceLine()",
-      "norm_label": "buildserviceline()",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.test.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 1379,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_cartitems_test_tsx",
-      "label": "CartItems.test.tsx",
-      "norm_label": "cartitems.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/CartItems.test.tsx",
       "source_location": "L1"
     },
     {
@@ -200322,6 +200334,24 @@
     {
       "community": 1380,
       "file_type": "code",
+      "id": "cartitems_test_buildserviceline",
+      "label": "buildServiceLine()",
+      "norm_label": "buildserviceline()",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.test.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 1380,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_cartitems_test_tsx",
+      "label": "CartItems.test.tsx",
+      "norm_label": "cartitems.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/CartItems.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1381,
+      "file_type": "code",
       "id": "debugproducts_debugproducts",
       "label": "DebugProducts()",
       "norm_label": "debugproducts()",
@@ -200329,7 +200359,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1380,
+      "community": 1381,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_debugproducts_tsx",
       "label": "DebugProducts.tsx",
@@ -200338,7 +200368,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "noresultsmessage_noresultsmessage",
       "label": "NoResultsMessage()",
@@ -200347,7 +200377,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1381,
+      "community": 1382,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_noresultsmessage_tsx",
       "label": "NoResultsMessage.tsx",
@@ -200356,7 +200386,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pininput_tsx",
       "label": "PinInput.tsx",
@@ -200365,7 +200395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1382,
+      "community": 1383,
       "file_type": "code",
       "id": "pininput_pininput",
       "label": "PinInput()",
@@ -200374,7 +200404,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_posclienttelemetryhost_tsx",
       "label": "PosClientTelemetryHost.tsx",
@@ -200383,7 +200413,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1383,
+      "community": 1384,
       "file_type": "code",
       "id": "posclienttelemetryhost_posclienttelemetryhost",
       "label": "PosClientTelemetryHost()",
@@ -200392,7 +200422,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_printinstructions_tsx",
       "label": "PrintInstructions.tsx",
@@ -200401,7 +200431,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1384,
+      "community": 1385,
       "file_type": "code",
       "id": "printinstructions_printinstructions",
       "label": "PrintInstructions()",
@@ -200410,7 +200440,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_searchresultssection_test_tsx",
       "label": "SearchResultsSection.test.tsx",
@@ -200419,7 +200449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1385,
+      "community": 1386,
       "file_type": "code",
       "id": "searchresultssection_test_buildproduct",
       "label": "buildProduct()",
@@ -200428,7 +200458,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sessiondemo_tsx",
       "label": "SessionDemo.tsx",
@@ -200437,7 +200467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1386,
+      "community": 1387,
       "file_type": "code",
       "id": "sessiondemo_sessiondemo",
       "label": "SessionDemo()",
@@ -200446,7 +200476,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "expensereportview_handleprintreceipt",
       "label": "handlePrintReceipt()",
@@ -200455,7 +200485,7 @@
       "source_location": "L95"
     },
     {
-      "community": 1387,
+      "community": 1388,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportview_tsx",
       "label": "ExpenseReportView.tsx",
@@ -200464,7 +200494,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "expensereportrows_toexpensereportrows",
       "label": "toExpenseReportRows()",
@@ -200473,30 +200503,12 @@
       "source_location": "L15"
     },
     {
-      "community": 1388,
+      "community": 1389,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_expense_reports_expensereportrows_ts",
       "label": "expenseReportRows.ts",
       "norm_label": "expensereportrows.ts",
       "source_file": "packages/athena-webapp/src/components/pos/expense-reports/expenseReportRows.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "expensecompletionpanel_test_buildcheckout",
-      "label": "buildCheckout()",
-      "norm_label": "buildcheckout()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.test.tsx",
-      "source_location": "L41"
-    },
-    {
-      "community": 1389,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_test_tsx",
-      "label": "ExpenseCompletionPanel.test.tsx",
-      "norm_label": "expensecompletionpanel.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.test.tsx",
       "source_location": "L1"
     },
     {
@@ -200646,6 +200658,24 @@
     {
       "community": 1390,
       "file_type": "code",
+      "id": "expensecompletionpanel_test_buildcheckout",
+      "label": "buildCheckout()",
+      "norm_label": "buildcheckout()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.test.tsx",
+      "source_location": "L41"
+    },
+    {
+      "community": 1390,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_register_expensecompletionpanel_test_tsx",
+      "label": "ExpenseCompletionPanel.test.tsx",
+      "norm_label": "expensecompletionpanel.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1391,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisterview_test_tsx",
       "label": "POSRegisterView.test.tsx",
       "norm_label": "posregisterview.test.tsx",
@@ -200653,7 +200683,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1390,
+      "community": 1391,
       "file_type": "code",
       "id": "posregisterview_test_pressdebugpanelshortcut",
       "label": "pressDebugPanelShortcut()",
@@ -200662,7 +200692,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercheckoutpanel_tsx",
       "label": "RegisterCheckoutPanel.tsx",
@@ -200671,7 +200701,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1391,
+      "community": 1392,
       "file_type": "code",
       "id": "registercheckoutpanel_registercheckoutpanel",
       "label": "RegisterCheckoutPanel()",
@@ -200680,7 +200710,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_test_tsx",
       "label": "RegisterCustomerAttribution.test.tsx",
@@ -200689,7 +200719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1392,
+      "community": 1393,
       "file_type": "code",
       "id": "registercustomerattribution_test_makecustomer",
       "label": "makeCustomer()",
@@ -200698,7 +200728,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registercustomerpanel_tsx",
       "label": "RegisterCustomerPanel.tsx",
@@ -200707,7 +200737,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1393,
+      "community": 1394,
       "file_type": "code",
       "id": "registercustomerpanel_registercustomerpanel",
       "label": "RegisterCustomerPanel()",
@@ -200716,7 +200746,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_test_tsx",
       "label": "RegisterDrawerGate.test.tsx",
@@ -200725,7 +200755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1394,
+      "community": 1395,
       "file_type": "code",
       "id": "registerdrawergate_test_rendergate",
       "label": "renderGate()",
@@ -200734,7 +200764,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registerdrawergate_tsx",
       "label": "RegisterDrawerGate.tsx",
@@ -200743,7 +200773,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1395,
+      "community": 1396,
       "file_type": "code",
       "id": "registerdrawergate_if",
       "label": "if()",
@@ -200752,7 +200782,7 @@
       "source_location": "L70"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_registersessionpanel_tsx",
       "label": "RegisterSessionPanel.tsx",
@@ -200761,7 +200791,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1396,
+      "community": 1397,
       "file_type": "code",
       "id": "registersessionpanel_registersessionpanel",
       "label": "RegisterSessionPanel()",
@@ -200770,7 +200800,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_sales_pulse_possalespulseview_tsx",
       "label": "POSSalesPulseView.tsx",
@@ -200779,7 +200809,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1397,
+      "community": 1398,
       "file_type": "code",
       "id": "possalespulseview_posstorepulsesection",
       "label": "POSStorePulseSection()",
@@ -200788,7 +200818,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posterminalhealthview_test_tsx",
       "label": "POSTerminalHealthView.test.tsx",
@@ -200797,31 +200827,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1398,
+      "community": 1399,
       "file_type": "code",
       "id": "posterminalhealthview_test_basesummary_attentionreasons_source_terminal_runtime_summary_terminal_setup_needs_repair_before_this_checkout_station_can_record_new_sales_type_terminal_seed_missing_health_needs_attention_recovery_commandstatus_commandtype_repair_terminal_seed_label_terminal_setup_repair_status_completed_verificationstatus_verified_readiness_needs_terminal_action_terminalactions_commandcontext_expectedblockertype_terminal_seed_commandtype_repair_terminal_seed_expectedevidence_terminalintegritystatus_healthy_reason_terminal_setup_data_needs_repair",
       "label": "[\n          {\n            ...baseSummary,\n            attentionReasons: [\n              {\n                source: \"terminal_runtime\",\n                summary:\n                  \"Terminal setup needs repair before this checkout station can record new sales.\",\n                type: \"terminal_seed_missing\",\n              },\n            ],\n            health: \"needs_attention\",\n            recovery: {\n              commandStatus: {\n                commandType: \"repair_terminal_seed\",\n                label: \"Terminal setup repair\",\n                status: \"completed\",\n                verificationStatus: \"verified\",\n              },\n              readiness: \"needs_terminal_action\",\n              terminalActions: [\n                {\n                  commandContext: {\n                    expectedBlockerType: \"terminal_seed\",\n                  },\n                  commandType: \"repair_terminal_seed\",\n                  expectedEvidence: {\n                    terminalIntegrityStatus: \"healthy\",\n                  },\n                  reason: \"Terminal setup data needs repair.\",\n                },\n              ],\n            },\n          },\n        ]()",
       "norm_label": "[\n          {\n            ...basesummary,\n            attentionreasons: [\n              {\n                source: \"terminal_runtime\",\n                summary:\n                  \"terminal setup needs repair before this checkout station can record new sales.\",\n                type: \"terminal_seed_missing\",\n              },\n            ],\n            health: \"needs_attention\",\n            recovery: {\n              commandstatus: {\n                commandtype: \"repair_terminal_seed\",\n                label: \"terminal setup repair\",\n                status: \"completed\",\n                verificationstatus: \"verified\",\n              },\n              readiness: \"needs_terminal_action\",\n              terminalactions: [\n                {\n                  commandcontext: {\n                    expectedblockertype: \"terminal_seed\",\n                  },\n                  commandtype: \"repair_terminal_seed\",\n                  expectedevidence: {\n                    terminalintegritystatus: \"healthy\",\n                  },\n                  reason: \"terminal setup data needs repair.\",\n                },\n              ],\n            },\n          },\n        ]()",
       "source_file": "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx",
       "source_location": "L608"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_terminals_posterminalhealthview_tsx",
-      "label": "POSTerminalHealthView.tsx",
-      "norm_label": "posterminalhealthview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1399,
-      "file_type": "code",
-      "id": "posterminalhealthview_countmetric",
-      "label": "CountMetric()",
-      "norm_label": "countmetric()",
-      "source_file": "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx",
-      "source_location": "L77"
     },
     {
       "community": 14,
@@ -201384,6 +201396,24 @@
     {
       "community": 1400,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_pos_terminals_posterminalhealthview_tsx",
+      "label": "POSTerminalHealthView.tsx",
+      "norm_label": "posterminalhealthview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1400,
+      "file_type": "code",
+      "id": "posterminalhealthview_countmetric",
+      "label": "CountMetric()",
+      "norm_label": "countmetric()",
+      "source_file": "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx",
+      "source_location": "L77"
+    },
+    {
+      "community": 1401,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_posclienterrorspanel_test_tsx",
       "label": "PosClientErrorsPanel.test.tsx",
       "norm_label": "posclienterrorspanel.test.tsx",
@@ -201391,7 +201421,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1400,
+      "community": 1401,
       "file_type": "code",
       "id": "posclienterrorspanel_test_buildevent",
       "label": "buildEvent()",
@@ -201400,7 +201430,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_test_tsx",
       "label": "transactionColumns.test.tsx",
@@ -201409,7 +201439,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1401,
+      "community": 1402,
       "file_type": "code",
       "id": "transactioncolumns_test_rendertransactioncell",
       "label": "renderTransactionCell()",
@@ -201418,7 +201448,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactioncolumns_tsx",
       "label": "transactionColumns.tsx",
@@ -201427,7 +201457,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1402,
+      "community": 1403,
       "file_type": "code",
       "id": "transactioncolumns_getpaymentmethodicon",
       "label": "getPaymentMethodIcon()",
@@ -201436,7 +201466,7 @@
       "source_location": "L30"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "barcodeview_barcodeview",
       "label": "BarcodeView()",
@@ -201445,7 +201475,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1403,
+      "community": 1404,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_barcodeview_tsx",
       "label": "BarcodeView.tsx",
@@ -201454,7 +201484,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "categorizationview_categorizationview",
       "label": "CategorizationView()",
@@ -201463,7 +201493,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1404,
+      "community": 1405,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_categorizationview_tsx",
       "label": "CategorizationView.tsx",
@@ -201472,7 +201502,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "imagesview_handlekeydown",
       "label": "handleKeyDown()",
@@ -201481,7 +201511,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1405,
+      "community": 1406,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_imagesview_tsx",
       "label": "ImagesView.tsx",
@@ -201490,7 +201520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productdetailview_tsx",
       "label": "ProductDetailView.tsx",
@@ -201499,7 +201529,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1406,
+      "community": 1407,
       "file_type": "code",
       "id": "productdetailview_productdetailviewheader",
       "label": "ProductDetailViewHeader()",
@@ -201508,7 +201538,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productoperationaltimeline_tsx",
       "label": "ProductOperationalTimeline.tsx",
@@ -201517,7 +201547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1407,
+      "community": 1408,
       "file_type": "code",
       "id": "productoperationaltimeline_formateventtype",
       "label": "formatEventType()",
@@ -201526,7 +201556,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_productstatus_tsx",
       "label": "ProductStatus.tsx",
@@ -201535,31 +201565,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1408,
+      "community": 1409,
       "file_type": "code",
       "id": "productstatus_productstatus",
       "label": "ProductStatus()",
       "norm_label": "productstatus()",
       "source_file": "packages/athena-webapp/src/components/product/ProductStatus.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_product_productstockpresentation_ts",
-      "label": "productStockPresentation.ts",
-      "norm_label": "productstockpresentation.ts",
-      "source_file": "packages/athena-webapp/src/components/product/productStockPresentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1409,
-      "file_type": "code",
-      "id": "productstockpresentation_productstocktextclass",
-      "label": "productStockTextClass()",
-      "norm_label": "productstocktextclass()",
-      "source_file": "packages/athena-webapp/src/components/product/productStockPresentation.ts",
-      "source_location": "L1"
     },
     {
       "community": 141,
@@ -201708,6 +201720,24 @@
     {
       "community": 1410,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_product_productstockpresentation_ts",
+      "label": "productStockPresentation.ts",
+      "norm_label": "productstockpresentation.ts",
+      "source_file": "packages/athena-webapp/src/components/product/productStockPresentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1410,
+      "file_type": "code",
+      "id": "productstockpresentation_productstocktextclass",
+      "label": "productStockTextClass()",
+      "norm_label": "productstocktextclass()",
+      "source_file": "packages/athena-webapp/src/components/product/productStockPresentation.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1411,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_actions_tsx",
       "label": "product-actions.tsx",
       "norm_label": "product-actions.tsx",
@@ -201715,7 +201745,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1410,
+      "community": 1411,
       "file_type": "code",
       "id": "product_actions_usearchiveproduct",
       "label": "useArchiveProduct()",
@@ -201724,7 +201754,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "archivedproducts_archivedproductstoolbar",
       "label": "ArchivedProductsToolbar()",
@@ -201733,7 +201763,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1411,
+      "community": 1412,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_archivedproducts_tsx",
       "label": "ArchivedProducts.tsx",
@@ -201742,7 +201772,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "categorylistview_categorylistview",
       "label": "CategoryListView()",
@@ -201751,7 +201781,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1412,
+      "community": 1413,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_categorylistview_tsx",
       "label": "CategoryListView.tsx",
@@ -201760,7 +201790,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productsview_tsx",
       "label": "ProductsView.tsx",
@@ -201769,7 +201799,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1413,
+      "community": 1414,
       "file_type": "code",
       "id": "productsview_productsview",
       "label": "ProductsView()",
@@ -201778,7 +201808,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_producttaxonomycells_tsx",
       "label": "ProductTaxonomyCells.tsx",
@@ -201787,7 +201817,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1414,
+      "community": 1415,
       "file_type": "code",
       "id": "producttaxonomycells_productcategorycell",
       "label": "ProductCategoryCell()",
@@ -201796,7 +201826,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "add_product_command_addproductcommand",
       "label": "AddProductCommand()",
@@ -201805,7 +201835,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1415,
+      "community": 1416,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_products_table_components_add_product_command_tsx",
       "label": "add-product-command.tsx",
@@ -201814,7 +201844,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_products_tsx",
       "label": "Products.tsx",
@@ -201823,7 +201853,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1416,
+      "community": 1417,
       "file_type": "code",
       "id": "products_products",
       "label": "Products()",
@@ -201832,7 +201862,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeform_tsx",
       "label": "PromoCodeForm.tsx",
@@ -201841,7 +201871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1417,
+      "community": 1418,
       "file_type": "code",
       "id": "promocodeform_togglediscounttype",
       "label": "toggleDiscountType()",
@@ -201850,7 +201880,7 @@
       "source_location": "L82"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeheader_tsx",
       "label": "PromoCodeHeader.tsx",
@@ -201859,31 +201889,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1418,
+      "community": 1419,
       "file_type": "code",
       "id": "promocodeheader_handledeletepromocode",
       "label": "handleDeletePromoCode()",
       "norm_label": "handledeletepromocode()",
       "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeHeader.tsx",
       "source_location": "L23"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
-      "label": "PromoCodePreview.tsx",
-      "norm_label": "promocodepreview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1419,
-      "file_type": "code",
-      "id": "promocodepreview_discount",
-      "label": "Discount()",
-      "norm_label": "discount()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
-      "source_location": "L37"
     },
     {
       "community": 142,
@@ -202032,6 +202044,24 @@
     {
       "community": 1420,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodepreview_tsx",
+      "label": "PromoCodePreview.tsx",
+      "norm_label": "promocodepreview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1420,
+      "file_type": "code",
+      "id": "promocodepreview_discount",
+      "label": "Discount()",
+      "norm_label": "discount()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodePreview.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 1421,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_test_tsx",
       "label": "PromoCodesView.test.tsx",
       "norm_label": "promocodesview.test.tsx",
@@ -202039,7 +202069,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1420,
+      "community": 1421,
       "file_type": "code",
       "id": "promocodesview_test_readsource",
       "label": "readSource()",
@@ -202048,7 +202078,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodesview_tsx",
       "label": "PromoCodesView.tsx",
@@ -202057,7 +202087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1421,
+      "community": 1422,
       "file_type": "code",
       "id": "promocodesview_promocodesview",
       "label": "PromoCodesView()",
@@ -202066,7 +202096,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectablecategories_tsx",
       "label": "SelectableCategories.tsx",
@@ -202075,7 +202105,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1422,
+      "community": 1423,
       "file_type": "code",
       "id": "selectablecategories_toggle",
       "label": "toggle()",
@@ -202084,7 +202114,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "discounttypetogglegroup_discounttypetogglegroup",
       "label": "DiscountTypeToggleGroup()",
@@ -202093,7 +202123,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1423,
+      "community": 1424,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_discounttypetogglegroup_tsx",
       "label": "DiscountTypeToggleGroup.tsx",
@@ -202102,7 +202132,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_add_promo_code_promocodespantogglegroup_tsx",
       "label": "PromoCodeSpanToggleGroup.tsx",
@@ -202111,7 +202141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1424,
+      "community": 1425,
       "file_type": "code",
       "id": "promocodespantogglegroup_promocodespantogglegroup",
       "label": "PromoCodeSpanToggleGroup()",
@@ -202120,7 +202150,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "capturedemails_capturedemails",
       "label": "CapturedEmails()",
@@ -202129,7 +202159,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1425,
+      "community": 1426,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_captured_capturedemails_tsx",
       "label": "CapturedEmails.tsx",
@@ -202138,7 +202168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_modals_promo_code_modal_tsx",
       "label": "promo-code-modal.tsx",
@@ -202147,7 +202177,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1426,
+      "community": 1427,
       "file_type": "code",
       "id": "promo_code_modal_promocodemodal",
       "label": "PromoCodeModal()",
@@ -202156,7 +202186,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistliveviewer_tsx",
       "label": "RemoteAssistLiveViewer.tsx",
@@ -202165,7 +202195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1427,
+      "community": 1428,
       "file_type": "code",
       "id": "remoteassistliveviewer_async",
       "label": "async()",
@@ -202174,7 +202204,7 @@
       "source_location": "L243"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_remote_assist_remoteassistruntimeshell_tsx",
       "label": "RemoteAssistRuntimeShell.tsx",
@@ -202183,31 +202213,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1428,
+      "community": 1429,
       "file_type": "code",
       "id": "remoteassistruntimeshell_handledisconnect",
       "label": "handleDisconnect()",
       "norm_label": "handledisconnect()",
       "source_file": "packages/athena-webapp/src/components/remote-assist/RemoteAssistRuntimeShell.tsx",
       "source_location": "L38"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportbacklink_tsx",
-      "label": "ReportBackLink.tsx",
-      "norm_label": "reportbacklink.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportBackLink.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1429,
-      "file_type": "code",
-      "id": "reportbacklink_reportbacklink",
-      "label": "ReportBackLink()",
-      "norm_label": "reportbacklink()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportBackLink.tsx",
-      "source_location": "L15"
     },
     {
       "community": 143,
@@ -202356,6 +202368,24 @@
     {
       "community": 1430,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportbacklink_tsx",
+      "label": "ReportBackLink.tsx",
+      "norm_label": "reportbacklink.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportBackLink.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1430,
+      "file_type": "code",
+      "id": "reportbacklink_reportbacklink",
+      "label": "ReportBackLink()",
+      "norm_label": "reportbacklink()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportBackLink.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 1431,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportmetriccomparisoncrossfade_tsx",
       "label": "ReportMetricComparisonCrossfade.tsx",
       "norm_label": "reportmetriccomparisoncrossfade.tsx",
@@ -202363,7 +202393,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1430,
+      "community": 1431,
       "file_type": "code",
       "id": "reportmetriccomparisoncrossfade_reportmetriccomparisoncrossfade",
       "label": "ReportMetricComparisonCrossfade()",
@@ -202372,7 +202402,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reporttrendchart_test_tsx",
       "label": "ReportTrendChart.test.tsx",
@@ -202381,7 +202411,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1431,
+      "community": 1432,
       "file_type": "code",
       "id": "reporttrendchart_test_labelformatter",
       "label": "labelFormatter()",
@@ -202390,7 +202420,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reporttruststrip_tsx",
       "label": "ReportTrustStrip.tsx",
@@ -202399,7 +202429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1432,
+      "community": 1433,
       "file_type": "code",
       "id": "reporttruststrip_reporttruststrip",
       "label": "ReportTrustStrip()",
@@ -202408,7 +202438,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportscataloglookup_test_tsx",
       "label": "ReportsCatalogLookup.test.tsx",
@@ -202417,7 +202447,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1433,
+      "community": 1434,
       "file_type": "code",
       "id": "reportscataloglookup_test_result",
       "label": "result()",
@@ -202426,7 +202456,7 @@
       "source_location": "L42"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemstable_tsx",
       "label": "ReportsItemsTable.tsx",
@@ -202435,7 +202465,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1434,
+      "community": 1435,
       "file_type": "code",
       "id": "reportsitemstable_reportsitemstable",
       "label": "ReportsItemsTable()",
@@ -202444,7 +202474,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemsview_test_tsx",
       "label": "ReportsItemsView.test.tsx",
@@ -202453,7 +202483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1435,
+      "community": 1436,
       "file_type": "code",
       "id": "reportsitemsview_test_isodateoffset",
       "label": "isoDateOffset()",
@@ -202462,7 +202492,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsitemsview_tsx",
       "label": "ReportsItemsView.tsx",
@@ -202471,7 +202501,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1436,
+      "community": 1437,
       "file_type": "code",
       "id": "reportsitemsview_handlepagechange",
       "label": "handlePageChange()",
@@ -202480,7 +202510,7 @@
       "source_location": "L89"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportslayout_test_tsx",
       "label": "ReportsLayout.test.tsx",
@@ -202489,7 +202519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1437,
+      "community": 1438,
       "file_type": "code",
       "id": "reportslayout_test_search",
       "label": "search()",
@@ -202498,7 +202528,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportslayout_tsx",
       "label": "ReportsLayout.tsx",
@@ -202507,31 +202537,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1438,
+      "community": 1439,
       "file_type": "code",
       "id": "reportslayout_cn",
       "label": "cn()",
       "norm_label": "cn()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsLayout.tsx",
       "source_location": "L126"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportsskudetailview_test_tsx",
-      "label": "ReportsSkuDetailView.test.tsx",
-      "norm_label": "reportsskudetailview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsSkuDetailView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1439,
-      "file_type": "code",
-      "id": "reportsskudetailview_test_isodateoffset",
-      "label": "isoDateOffset()",
-      "norm_label": "isodateoffset()",
-      "source_file": "packages/athena-webapp/src/components/reports/ReportsSkuDetailView.test.tsx",
-      "source_location": "L62"
     },
     {
       "community": 144,
@@ -202680,6 +202692,24 @@
     {
       "community": 1440,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportsskudetailview_test_tsx",
+      "label": "ReportsSkuDetailView.test.tsx",
+      "norm_label": "reportsskudetailview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsSkuDetailView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1440,
+      "file_type": "code",
+      "id": "reportsskudetailview_test_isodateoffset",
+      "label": "isoDateOffset()",
+      "norm_label": "isodateoffset()",
+      "source_file": "packages/athena-webapp/src/components/reports/ReportsSkuDetailView.test.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 1441,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsskudetailview_tsx",
       "label": "ReportsSkuDetailView.tsx",
       "norm_label": "reportsskudetailview.tsx",
@@ -202687,7 +202717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1440,
+      "community": 1441,
       "file_type": "code",
       "id": "reportsskudetailview_cn",
       "label": "cn()",
@@ -202696,7 +202726,7 @@
       "source_location": "L484"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_usestablereportquery_ts",
       "label": "useStableReportQuery.ts",
@@ -202705,7 +202735,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1441,
+      "community": 1442,
       "file_type": "code",
       "id": "usestablereportquery_usestablereportquery",
       "label": "useStableReportQuery()",
@@ -202714,7 +202744,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewactions_tsx",
       "label": "ReviewActions.tsx",
@@ -202723,7 +202753,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1442,
+      "community": 1443,
       "file_type": "code",
       "id": "reviewactions_reviewactions",
       "label": "ReviewActions()",
@@ -202732,7 +202762,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecasesview_test_tsx",
       "label": "ServiceCasesView.test.tsx",
@@ -202741,7 +202771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1443,
+      "community": 1444,
       "file_type": "code",
       "id": "servicecasesview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -202750,7 +202780,7 @@
       "source_location": "L81"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogview_test_tsx",
       "label": "ServiceCatalogView.test.tsx",
@@ -202759,7 +202789,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1444,
+      "community": 1445,
       "file_type": "code",
       "id": "servicecatalogview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -202768,7 +202798,7 @@
       "source_location": "L60"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceintakeview_auth_test_tsx",
       "label": "ServiceIntakeView.auth.test.tsx",
@@ -202777,7 +202807,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1445,
+      "community": 1446,
       "file_type": "code",
       "id": "serviceintakeview_auth_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -202786,7 +202816,7 @@
       "source_location": "L66"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_serviceworkspacedemonotice_tsx",
       "label": "ServiceWorkspaceDemoNotice.tsx",
@@ -202795,7 +202825,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1446,
+      "community": 1447,
       "file_type": "code",
       "id": "serviceworkspacedemonotice_serviceworkspacedemonotice",
       "label": "ServiceWorkspaceDemoNotice()",
@@ -202804,7 +202834,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicesworkspaceview_test_tsx",
       "label": "ServicesWorkspaceView.test.tsx",
@@ -202813,7 +202843,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1447,
+      "community": 1448,
       "file_type": "code",
       "id": "servicesworkspaceview_test_chooseselectoption",
       "label": "chooseSelectOption()",
@@ -202822,7 +202852,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "demonotice_demonotice",
       "label": "DemoNotice()",
@@ -202831,31 +202861,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1448,
+      "community": 1449,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_demonotice_tsx",
       "label": "DemoNotice.tsx",
       "norm_label": "demonotice.tsx",
       "source_file": "packages/athena-webapp/src/components/shared-demo/DemoNotice.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemomanagersigninguidance_tsx",
-      "label": "SharedDemoManagerSignInGuidance.tsx",
-      "norm_label": "shareddemomanagersigninguidance.tsx",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoManagerSignInGuidance.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1449,
-      "file_type": "code",
-      "id": "shareddemomanagersigninguidance_shareddemomanagersigninguidance",
-      "label": "SharedDemoManagerSignInGuidance()",
-      "norm_label": "shareddemomanagersigninguidance()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoManagerSignInGuidance.tsx",
-      "source_location": "L4"
     },
     {
       "community": 145,
@@ -203004,6 +203016,24 @@
     {
       "community": 1450,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemomanagersigninguidance_tsx",
+      "label": "SharedDemoManagerSignInGuidance.tsx",
+      "norm_label": "shareddemomanagersigninguidance.tsx",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoManagerSignInGuidance.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1450,
+      "file_type": "code",
+      "id": "shareddemomanagersigninguidance_shareddemomanagersigninguidance",
+      "label": "SharedDemoManagerSignInGuidance()",
+      "norm_label": "shareddemomanagersigninguidance()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/SharedDemoManagerSignInGuidance.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 1451,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoownerhome_tsx",
       "label": "SharedDemoOwnerHome.tsx",
       "norm_label": "shareddemoownerhome.tsx",
@@ -203011,7 +203041,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1450,
+      "community": 1451,
       "file_type": "code",
       "id": "shareddemoownerhome_shareddemoownerhome",
       "label": "SharedDemoOwnerHome()",
@@ -203020,7 +203050,7 @@
       "source_location": "L57"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestrictedsurface_tsx",
       "label": "SharedDemoRestrictedSurface.tsx",
@@ -203029,7 +203059,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1451,
+      "community": 1452,
       "file_type": "code",
       "id": "shareddemorestrictedsurface_shareddemorestrictedsurface",
       "label": "SharedDemoRestrictedSurface()",
@@ -203038,7 +203068,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoruntime_test_tsx",
       "label": "SharedDemoRuntime.test.tsx",
@@ -203047,7 +203077,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1452,
+      "community": 1453,
       "file_type": "code",
       "id": "shareddemoruntime_test_providerstatusprobe",
       "label": "ProviderStatusProbe()",
@@ -203056,7 +203086,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemostatusbar_tsx",
       "label": "SharedDemoStatusBar.tsx",
@@ -203065,7 +203095,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1453,
+      "community": 1454,
       "file_type": "code",
       "id": "shareddemostatusbar_normalizepathname",
       "label": "normalizePathname()",
@@ -203074,7 +203104,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoactivitytracking_test_ts",
       "label": "sharedDemoActivityTracking.test.ts",
@@ -203083,7 +203113,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1454,
+      "community": 1455,
       "file_type": "code",
       "id": "shareddemoactivitytracking_test_storage",
       "label": "storage()",
@@ -203092,7 +203122,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoproviderstatus_ts",
       "label": "sharedDemoProviderStatus.ts",
@@ -203101,7 +203131,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1455,
+      "community": 1456,
       "file_type": "code",
       "id": "shareddemoproviderstatus_resolveshareddemoprovidedbootstrapstatus",
       "label": "resolveSharedDemoProvidedBootstrapStatus()",
@@ -203110,7 +203140,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestoreoverlaymodel_ts",
       "label": "sharedDemoRestoreOverlayModel.ts",
@@ -203119,7 +203149,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1456,
+      "community": 1457,
       "file_type": "code",
       "id": "shareddemorestoreoverlaymodel_resolveshareddemorestoreoverlayphase",
       "label": "resolveSharedDemoRestoreOverlayPhase()",
@@ -203128,7 +203158,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemorestrictions_ts",
       "label": "sharedDemoRestrictions.ts",
@@ -203137,7 +203167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1457,
+      "community": 1458,
       "file_type": "code",
       "id": "shareddemorestrictions_isshareddemorestrictedpath",
       "label": "isSharedDemoRestrictedPath()",
@@ -203146,7 +203176,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemoroutes_ts",
       "label": "sharedDemoRoutes.ts",
@@ -203155,31 +203185,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1458,
+      "community": 1459,
       "file_type": "code",
       "id": "shareddemoroutes_getshareddemoroutes",
       "label": "getSharedDemoRoutes()",
       "norm_label": "getshareddemoroutes()",
       "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRoutes.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemoruntimecoordinator_test_ts",
-      "label": "sharedDemoRuntimeCoordinator.test.ts",
-      "norm_label": "shareddemoruntimecoordinator.test.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRuntimeCoordinator.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1459,
-      "file_type": "code",
-      "id": "shareddemoruntimecoordinator_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRuntimeCoordinator.test.ts",
-      "source_location": "L9"
     },
     {
       "community": 146,
@@ -203328,6 +203340,24 @@
     {
       "community": 1460,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemoruntimecoordinator_test_ts",
+      "label": "sharedDemoRuntimeCoordinator.test.ts",
+      "norm_label": "shareddemoruntimecoordinator.test.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRuntimeCoordinator.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1460,
+      "file_type": "code",
+      "id": "shareddemoruntimecoordinator_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoRuntimeCoordinator.test.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 1461,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_staffmessagesview_tsx",
       "label": "StaffMessagesView.tsx",
       "norm_label": "staffmessagesview.tsx",
@@ -203335,7 +203365,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1460,
+      "community": 1461,
       "file_type": "code",
       "id": "staffmessagesview_submit",
       "label": "submit()",
@@ -203344,7 +203374,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_staff_auth_staffpinpolicy_ts",
       "label": "staffPinPolicy.ts",
@@ -203353,7 +203383,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1461,
+      "community": 1462,
       "file_type": "code",
       "id": "staffpinpolicy_normalizestaffpin",
       "label": "normalizeStaffPin()",
@@ -203362,7 +203392,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "empty_state_onclick",
       "label": "onClick()",
@@ -203371,7 +203401,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1462,
+      "community": 1463,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_empty_empty_state_tsx",
       "label": "empty-state.tsx",
@@ -203380,7 +203410,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "nopermission_nopermission",
       "label": "NoPermission()",
@@ -203389,7 +203419,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1463,
+      "community": 1464,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermission_tsx",
       "label": "NoPermission.tsx",
@@ -203398,7 +203428,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "nopermissionview_nopermissionview",
       "label": "NoPermissionView()",
@@ -203407,7 +203437,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1464,
+      "community": 1465,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_no_permission_nopermissionview_tsx",
       "label": "NoPermissionView.tsx",
@@ -203416,7 +203446,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "notfoundview_notfoundview",
       "label": "NotFoundView()",
@@ -203425,7 +203455,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1465,
+      "community": 1466,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_not_found_notfoundview_tsx",
       "label": "NotFoundView.tsx",
@@ -203434,7 +203464,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_states_signed_out_protectedadminsigninview_tsx",
       "label": "ProtectedAdminSignInView.tsx",
@@ -203443,7 +203473,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1466,
+      "community": 1467,
       "file_type": "code",
       "id": "protectedadminsigninview_protectedadminsigninview",
       "label": "ProtectedAdminSignInView()",
@@ -203452,7 +203482,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "contactview_contactview",
       "label": "ContactView()",
@@ -203461,7 +203491,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1467,
+      "community": 1468,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_contactview_tsx",
       "label": "ContactView.tsx",
@@ -203470,7 +203500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "header_header",
       "label": "Header()",
@@ -203479,30 +203509,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1468,
+      "community": 1469,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_header_tsx",
       "label": "Header.tsx",
       "norm_label": "header.tsx",
       "source_file": "packages/athena-webapp/src/components/store-configuration/components/Header.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "maintenanceview_maintenanceview",
-      "label": "MaintenanceView()",
-      "norm_label": "maintenanceview()",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
-      "source_location": "L11"
-    },
-    {
-      "community": 1469,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
-      "label": "MaintenanceView.tsx",
-      "norm_label": "maintenanceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
       "source_location": "L1"
     },
     {
@@ -203652,6 +203664,24 @@
     {
       "community": 1470,
       "file_type": "code",
+      "id": "maintenanceview_maintenanceview",
+      "label": "MaintenanceView()",
+      "norm_label": "maintenanceview()",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 1470,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_store_configuration_components_maintenanceview_tsx",
+      "label": "MaintenanceView.tsx",
+      "norm_label": "maintenanceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/store-configuration/components/MaintenanceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1471,
+      "file_type": "code",
       "id": "notificationsview_async",
       "label": "async()",
       "norm_label": "async()",
@@ -203659,7 +203689,7 @@
       "source_location": "L327"
     },
     {
-      "community": 1470,
+      "community": 1471,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_notificationsview_tsx",
       "label": "NotificationsView.tsx",
@@ -203668,7 +203698,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1472,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_storehoursview_test_tsx",
       "label": "StoreHoursView.test.tsx",
@@ -203677,7 +203707,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1471,
+      "community": 1472,
       "file_type": "code",
       "id": "storehoursview_test_changeanchorandsave",
       "label": "changeAnchorAndSave()",
@@ -203686,7 +203716,7 @@
       "source_location": "L229"
     },
     {
-      "community": 1472,
+      "community": 1473,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_taxview_tsx",
       "label": "TaxView.tsx",
@@ -203695,7 +203725,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1472,
+      "community": 1473,
       "file_type": "code",
       "id": "taxview_handleupdatetaxsettings",
       "label": "handleUpdateTaxSettings()",
@@ -203704,7 +203734,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1473,
+      "community": 1474,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usenotificationsubscriptions_test_tsx",
       "label": "useNotificationSubscriptions.test.tsx",
@@ -203713,7 +203743,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1473,
+      "community": 1474,
       "file_type": "code",
       "id": "usenotificationsubscriptions_test_emptylist",
       "label": "emptyList()",
@@ -203722,7 +203752,7 @@
       "source_location": "L69"
     },
     {
-      "community": 1474,
+      "community": 1475,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestoreconfigupdate_ts",
       "label": "useStoreConfigUpdate.ts",
@@ -203731,7 +203761,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1474,
+      "community": 1475,
       "file_type": "code",
       "id": "usestoreconfigupdate_usestoreconfigupdate",
       "label": "useStoreConfigUpdate()",
@@ -203740,7 +203770,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1475,
+      "community": 1476,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usestorescheduleupdate_ts",
       "label": "useStoreScheduleUpdate.ts",
@@ -203749,7 +203779,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1475,
+      "community": 1476,
       "file_type": "code",
       "id": "usestorescheduleupdate_usestorescheduleupdate",
       "label": "useStoreScheduleUpdate()",
@@ -203758,7 +203788,7 @@
       "source_location": "L94"
     },
     {
-      "community": 1476,
+      "community": 1477,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_switcher_tsx",
       "label": "store-switcher.tsx",
@@ -203767,7 +203797,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1476,
+      "community": 1477,
       "file_type": "code",
       "id": "store_switcher_onstoreselect",
       "label": "onStoreSelect()",
@@ -203776,7 +203806,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1477,
+      "community": 1478,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
       "label": "WorkflowTraceView.tsx",
@@ -203785,7 +203815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1477,
+      "community": 1478,
       "file_type": "code",
       "id": "workflowtraceview_formattracelabel",
       "label": "formatTraceLabel()",
@@ -203794,7 +203824,7 @@
       "source_location": "L47"
     },
     {
-      "community": 1478,
+      "community": 1479,
       "file_type": "code",
       "id": "chart_usechart",
       "label": "useChart()",
@@ -203803,30 +203833,12 @@
       "source_location": "L25"
     },
     {
-      "community": 1478,
+      "community": 1479,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_chart_tsx",
       "label": "chart.tsx",
       "norm_label": "chart.tsx",
       "source_file": "packages/athena-webapp/src/components/ui/chart.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1479,
-      "file_type": "code",
-      "id": "copy_button_handlecopy",
-      "label": "handleCopy()",
-      "norm_label": "handlecopy()",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 1479,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
-      "label": "copy-button.tsx",
-      "norm_label": "copy-button.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
       "source_location": "L1"
     },
     {
@@ -203976,6 +203988,24 @@
     {
       "community": 1480,
       "file_type": "code",
+      "id": "copy_button_handlecopy",
+      "label": "handleCopy()",
+      "norm_label": "handlecopy()",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 1480,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_copy_button_tsx",
+      "label": "copy-button.tsx",
+      "norm_label": "copy-button.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/copy-button.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1481,
+      "file_type": "code",
       "id": "copy_wrapper_handlecopy",
       "label": "handleCopy()",
       "norm_label": "handlecopy()",
@@ -203983,7 +204013,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1480,
+      "community": 1481,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_copy_wrapper_tsx",
       "label": "copy-wrapper.tsx",
@@ -203992,7 +204022,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1481,
+      "community": 1482,
       "file_type": "code",
       "id": "label_label",
       "label": "Label()",
@@ -204001,7 +204031,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1481,
+      "community": 1482,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_label_tsx",
       "label": "label.tsx",
@@ -204010,7 +204040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1482,
+      "community": 1483,
       "file_type": "code",
       "id": "custom_modal_custommodal",
       "label": "CustomModal()",
@@ -204019,7 +204049,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1482,
+      "community": 1483,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_tsx",
       "label": "custom-modal.tsx",
@@ -204028,7 +204058,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1483,
+      "community": 1484,
       "file_type": "code",
       "id": "organization_modal_onsubmit",
       "label": "onSubmit()",
@@ -204037,7 +204067,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1483,
+      "community": 1484,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_organization_modal_tsx",
       "label": "organization-modal.tsx",
@@ -204046,7 +204076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1485,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_store_modal_tsx",
       "label": "store-modal.tsx",
@@ -204055,7 +204085,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1484,
+      "community": 1485,
       "file_type": "code",
       "id": "store_modal_onsubmit",
       "label": "onSubmit()",
@@ -204064,7 +204094,7 @@
       "source_location": "L63"
     },
     {
-      "community": 1485,
+      "community": 1486,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_example_tsx",
       "label": "welcome-back-modal-example.tsx",
@@ -204073,7 +204103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1485,
+      "community": 1486,
       "file_type": "code",
       "id": "welcome_back_modal_example_welcomebackmodalexample",
       "label": "WelcomeBackModalExample()",
@@ -204082,7 +204112,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1486,
+      "community": 1487,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_welcome_back_modal_tsx",
       "label": "welcome-back-modal.tsx",
@@ -204091,7 +204121,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1486,
+      "community": 1487,
       "file_type": "code",
       "id": "welcome_back_modal_welcomebackmodal",
       "label": "WelcomeBackModal()",
@@ -204100,7 +204130,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1487,
+      "community": 1488,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_relative_timestamp_test_tsx",
       "label": "relative-timestamp.test.tsx",
@@ -204109,7 +204139,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1487,
+      "community": 1488,
       "file_type": "code",
       "id": "relative_timestamp_test_freezeclock",
       "label": "freezeClock()",
@@ -204118,7 +204148,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1488,
+      "community": 1489,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_relative_timestamp_tsx",
       "label": "relative-timestamp.tsx",
@@ -204127,31 +204157,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1488,
+      "community": 1489,
       "file_type": "code",
       "id": "relative_timestamp_relativetimestamp",
       "label": "RelativeTimestamp()",
       "norm_label": "relativetimestamp()",
       "source_file": "packages/athena-webapp/src/components/ui/relative-timestamp.tsx",
       "source_location": "L22"
-    },
-    {
-      "community": 1489,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
-      "label": "select-native.tsx",
-      "norm_label": "select-native.tsx",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1489,
-      "file_type": "code",
-      "id": "select_native_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
-      "source_location": "L15"
     },
     {
       "community": 149,
@@ -204300,6 +204312,24 @@
     {
       "community": 1490,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_ui_select_native_tsx",
+      "label": "select-native.tsx",
+      "norm_label": "select-native.tsx",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1490,
+      "file_type": "code",
+      "id": "select_native_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/ui/select-native.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 1491,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_sidebar_test_tsx",
       "label": "sidebar.test.tsx",
       "norm_label": "sidebar.test.tsx",
@@ -204307,7 +204337,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1490,
+      "community": 1491,
       "file_type": "code",
       "id": "sidebar_test_sidebartoggleprobe",
       "label": "SidebarToggleProbe()",
@@ -204316,7 +204346,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1491,
+      "community": 1492,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_timeline_item_tsx",
       "label": "timeline-item.tsx",
@@ -204325,7 +204355,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1491,
+      "community": 1492,
       "file_type": "code",
       "id": "timeline_item_timelineitem",
       "label": "TimelineItem()",
@@ -204334,7 +204364,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1492,
+      "community": 1493,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_webp_image_tsx",
       "label": "webp-image.tsx",
@@ -204343,7 +204373,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1492,
+      "community": 1493,
       "file_type": "code",
       "id": "webp_image_webpimage",
       "label": "WebpImage()",
@@ -204352,7 +204382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1493,
+      "community": 1494,
       "file_type": "code",
       "id": "bagitems_bagitems",
       "label": "BagItems()",
@@ -204361,7 +204391,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1493,
+      "community": 1494,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitems_tsx",
       "label": "BagItems.tsx",
@@ -204370,7 +204400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1494,
+      "community": 1495,
       "file_type": "code",
       "id": "bagitemsview_bagitemsview",
       "label": "BagItemsView()",
@@ -204379,7 +204409,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1494,
+      "community": 1495,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bagitemsview_tsx",
       "label": "BagItemsView.tsx",
@@ -204388,7 +204418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1495,
+      "community": 1496,
       "file_type": "code",
       "id": "bags_bags",
       "label": "Bags()",
@@ -204397,7 +204427,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1495,
+      "community": 1496,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_bags_tsx",
       "label": "Bags.tsx",
@@ -204406,7 +204436,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1496,
+      "community": 1497,
       "file_type": "code",
       "id": "customerbehaviortimeline_string",
       "label": "String()",
@@ -204415,7 +204445,7 @@
       "source_location": "L101"
     },
     {
-      "community": 1496,
+      "community": 1497,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_customerbehaviortimeline_tsx",
       "label": "CustomerBehaviorTimeline.tsx",
@@ -204424,7 +204454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1497,
+      "community": 1498,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useranalyticsname_tsx",
       "label": "UserAnalyticsName.tsx",
@@ -204433,7 +204463,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1497,
+      "community": 1498,
       "file_type": "code",
       "id": "useranalyticsname_useranalyticsname",
       "label": "UserAnalyticsName()",
@@ -204442,7 +204472,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1498,
+      "community": 1499,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userbag_tsx",
       "label": "UserBag.tsx",
@@ -204451,31 +204481,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1498,
+      "community": 1499,
       "file_type": "code",
       "id": "userbag_userbag",
       "label": "UserBag()",
       "norm_label": "userbag()",
       "source_file": "packages/athena-webapp/src/components/users/UserBag.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_users_userinsightssection_test_tsx",
-      "label": "UserInsightsSection.test.tsx",
-      "norm_label": "userinsightssection.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1499,
-      "file_type": "code",
-      "id": "userinsightssection_test_renderwithqueries",
-      "label": "renderWithQueries()",
-      "norm_label": "renderwithqueries()",
-      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.test.tsx",
-      "source_location": "L36"
     },
     {
       "community": 15,
@@ -205029,6 +205041,24 @@
     {
       "community": 1500,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_users_userinsightssection_test_tsx",
+      "label": "UserInsightsSection.test.tsx",
+      "norm_label": "userinsightssection.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1500,
+      "file_type": "code",
+      "id": "userinsightssection_test_renderwithqueries",
+      "label": "renderWithQueries()",
+      "norm_label": "renderwithqueries()",
+      "source_file": "packages/athena-webapp/src/components/users/UserInsightsSection.test.tsx",
+      "source_location": "L36"
+    },
+    {
+      "community": 1501,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_useronlineorders_tsx",
       "label": "UserOnlineOrders.tsx",
       "norm_label": "useronlineorders.tsx",
@@ -205036,7 +205066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1500,
+      "community": 1501,
       "file_type": "code",
       "id": "useronlineorders_useronlineorders",
       "label": "UserOnlineOrders()",
@@ -205045,7 +205075,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1501,
+      "community": 1502,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userstatus_tsx",
       "label": "UserStatus.tsx",
@@ -205054,7 +205084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1501,
+      "community": 1502,
       "file_type": "code",
       "id": "userstatus_userstatus",
       "label": "UserStatus()",
@@ -205063,7 +205093,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1502,
+      "community": 1503,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_userview_tsx",
       "label": "UserView.tsx",
@@ -205072,7 +205102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1502,
+      "community": 1503,
       "file_type": "code",
       "id": "userview_useractions",
       "label": "UserActions()",
@@ -205081,7 +205111,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1503,
+      "community": 1504,
       "file_type": "code",
       "id": "customerjourneystage_customerjourneystagecard",
       "label": "CustomerJourneyStageCard()",
@@ -205090,7 +205120,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1503,
+      "community": 1504,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_customerjourneystage_tsx",
       "label": "CustomerJourneyStage.tsx",
@@ -205099,7 +205129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1504,
+      "community": 1505,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_users_behavioral_insights_userbehaviorinsights_tsx",
       "label": "UserBehaviorInsights.tsx",
@@ -205108,7 +205138,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1504,
+      "community": 1505,
       "file_type": "code",
       "id": "userbehaviorinsights_userbehaviorinsights",
       "label": "UserBehaviorInsights()",
@@ -205117,7 +205147,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1505,
+      "community": 1506,
       "file_type": "code",
       "id": "athenawebappcontextevents_buildathenawebappcontextevent",
       "label": "buildAthenaWebappContextEvent()",
@@ -205126,7 +205156,7 @@
       "source_location": "L28"
     },
     {
-      "community": 1505,
+      "community": 1506,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexttracking_athenawebappcontextevents_ts",
       "label": "athenaWebappContextEvents.ts",
@@ -205135,7 +205165,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1506,
+      "community": 1507,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexttracking_usedocsworkspacetracking_ts",
       "label": "useDocsWorkspaceTracking.ts",
@@ -205144,7 +205174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1506,
+      "community": 1507,
       "file_type": "code",
       "id": "usedocsworkspacetracking_usedocsworkspacetracking",
       "label": "useDocsWorkspaceTracking()",
@@ -205153,7 +205183,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1507,
+      "community": 1508,
       "file_type": "code",
       "id": "managerelevationcontext_test_wrapper",
       "label": "wrapper()",
@@ -205162,7 +205192,7 @@
       "source_location": "L64"
     },
     {
-      "community": 1507,
+      "community": 1508,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_test_tsx",
       "label": "ManagerElevationContext.test.tsx",
@@ -205171,7 +205201,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1508,
+      "community": 1509,
       "file_type": "code",
       "id": "onlineordercontext_test_sessionorderprobe",
       "label": "SessionOrderProbe()",
@@ -205180,31 +205210,13 @@
       "source_location": "L41"
     },
     {
-      "community": 1508,
+      "community": 1509,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_onlineordercontext_test_tsx",
       "label": "OnlineOrderContext.test.tsx",
       "norm_label": "onlineordercontext.test.tsx",
       "source_file": "packages/athena-webapp/src/contexts/OnlineOrderContext.test.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_contexts_productcontext_test_tsx",
-      "label": "ProductContext.test.tsx",
-      "norm_label": "productcontext.test.tsx",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1509,
-      "file_type": "code",
-      "id": "productcontext_test_buildproductsku",
-      "label": "buildProductSku()",
-      "norm_label": "buildproductsku()",
-      "source_file": "packages/athena-webapp/src/contexts/ProductContext.test.tsx",
-      "source_location": "L6"
     },
     {
       "community": 151,
@@ -205353,6 +205365,24 @@
     {
       "community": 1510,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_contexts_productcontext_test_tsx",
+      "label": "ProductContext.test.tsx",
+      "norm_label": "productcontext.test.tsx",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1510,
+      "file_type": "code",
+      "id": "productcontext_test_buildproductsku",
+      "label": "buildProductSku()",
+      "norm_label": "buildproductsku()",
+      "source_file": "packages/athena-webapp/src/contexts/ProductContext.test.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 1511,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_extensions_screenredactextension_test_ts",
       "label": "screenRedactExtension.test.ts",
       "norm_label": "screenredactextension.test.ts",
@@ -205360,7 +205390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1510,
+      "community": 1511,
       "file_type": "code",
       "id": "screenredactextension_test_runscreenredactextension",
       "label": "runScreenRedactExtension()",
@@ -205369,7 +205399,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1511,
+      "community": 1512,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_image_upload_ts",
       "label": "use-image-upload.ts",
@@ -205378,7 +205408,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1511,
+      "community": 1512,
       "file_type": "code",
       "id": "use_image_upload_useimageupload",
       "label": "useImageUpload()",
@@ -205387,7 +205417,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1512,
+      "community": 1513,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_mobile_tsx",
       "label": "use-mobile.tsx",
@@ -205396,7 +205426,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1512,
+      "community": 1513,
       "file_type": "code",
       "id": "use_mobile_useismobile",
       "label": "useIsMobile()",
@@ -205405,7 +205435,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1513,
+      "community": 1514,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigate_back_ts",
       "label": "use-navigate-back.ts",
@@ -205414,7 +205444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1513,
+      "community": 1514,
       "file_type": "code",
       "id": "use_navigate_back_usenavigateback",
       "label": "useNavigateBack()",
@@ -205423,7 +205453,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1514,
+      "community": 1515,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_navigation_keyboard_shortcuts_ts",
       "label": "use-navigation-keyboard-shortcuts.ts",
@@ -205432,7 +205462,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1514,
+      "community": 1515,
       "file_type": "code",
       "id": "use_navigation_keyboard_shortcuts_usenavigationkeyboardshortcuts",
       "label": "useNavigationKeyboardShortcuts()",
@@ -205441,7 +205471,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1515,
+      "community": 1516,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_pagination_persistence_ts",
       "label": "use-pagination-persistence.ts",
@@ -205450,7 +205480,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1515,
+      "community": 1516,
       "file_type": "code",
       "id": "use_pagination_persistence_usepaginationpersistence",
       "label": "usePaginationPersistence()",
@@ -205459,7 +205489,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1516,
+      "community": 1517,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_use_table_keyboard_pagination_ts",
       "label": "use-table-keyboard-pagination.ts",
@@ -205468,7 +205498,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1516,
+      "community": 1517,
       "file_type": "code",
       "id": "use_table_keyboard_pagination_usetablekeyboardpagination",
       "label": "useTableKeyboardPagination()",
@@ -205477,7 +205507,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1517,
+      "community": 1518,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usebulkoperations_test_ts",
       "label": "useBulkOperations.test.ts",
@@ -205486,7 +205516,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1517,
+      "community": 1518,
       "file_type": "code",
       "id": "usebulkoperations_test_makesku",
       "label": "makeSku()",
@@ -205495,7 +205525,7 @@
       "source_location": "L189"
     },
     {
-      "community": 1518,
+      "community": 1519,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useconvexauthidentity_ts",
       "label": "useConvexAuthIdentity.ts",
@@ -205504,31 +205534,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1518,
+      "community": 1519,
       "file_type": "code",
       "id": "useconvexauthidentity_useconvexauthidentity",
       "label": "useConvexAuthIdentity()",
       "norm_label": "useconvexauthidentity()",
       "source_file": "packages/athena-webapp/src/hooks/useConvexAuthIdentity.ts",
       "source_location": "L5"
-    },
-    {
-      "community": 1519,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
-      "label": "useCopyText.ts",
-      "norm_label": "usecopytext.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1519,
-      "file_type": "code",
-      "id": "usecopytext_usecopytext",
-      "label": "useCopyText()",
-      "norm_label": "usecopytext()",
-      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
-      "source_location": "L1"
     },
     {
       "community": 152,
@@ -205677,6 +205689,24 @@
     {
       "community": 1520,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usecopytext_ts",
+      "label": "useCopyText.ts",
+      "norm_label": "usecopytext.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1520,
+      "file_type": "code",
+      "id": "usecopytext_usecopytext",
+      "label": "useCopyText()",
+      "norm_label": "usecopytext()",
+      "source_file": "packages/athena-webapp/src/hooks/useCopyText.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1521,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usecreatecomplimentaryproduct_ts",
       "label": "useCreateComplimentaryProduct.ts",
       "norm_label": "usecreatecomplimentaryproduct.ts",
@@ -205684,7 +205714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1520,
+      "community": 1521,
       "file_type": "code",
       "id": "usecreatecomplimentaryproduct_usecreatecomplimentaryproduct",
       "label": "useCreateComplimentaryProduct()",
@@ -205693,7 +205723,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1521,
+      "community": 1522,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usedebounce_ts",
       "label": "useDebounce.ts",
@@ -205702,7 +205732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1521,
+      "community": 1522,
       "file_type": "code",
       "id": "usedebounce_usedebounce",
       "label": "useDebounce()",
@@ -205711,7 +205741,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1522,
+      "community": 1523,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetactiveproduct_ts",
       "label": "useGetActiveProduct.ts",
@@ -205720,7 +205750,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1522,
+      "community": 1523,
       "file_type": "code",
       "id": "usegetactiveproduct_usegetactiveproduct",
       "label": "useGetActiveProduct()",
@@ -205729,7 +205759,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1523,
+      "community": 1524,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetautheduser_ts",
       "label": "useGetAuthedUser.ts",
@@ -205738,7 +205768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1523,
+      "community": 1524,
       "file_type": "code",
       "id": "usegetautheduser_usegetautheduser",
       "label": "useGetAuthedUser()",
@@ -205747,7 +205777,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1524,
+      "community": 1525,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcategories_ts",
       "label": "useGetCategories.ts",
@@ -205756,7 +205786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1524,
+      "community": 1525,
       "file_type": "code",
       "id": "usegetcategories_usegetcategories",
       "label": "useGetCategories()",
@@ -205765,7 +205795,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1525,
+      "community": 1526,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcomplimentaryproducts_ts",
       "label": "useGetComplimentaryProducts.ts",
@@ -205774,7 +205804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1525,
+      "community": 1526,
       "file_type": "code",
       "id": "usegetcomplimentaryproducts_usegetcomplimentaryproducts",
       "label": "useGetComplimentaryProducts()",
@@ -205783,7 +205813,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1526,
+      "community": 1527,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetcurrencyformatter_ts",
       "label": "useGetCurrencyFormatter.ts",
@@ -205792,7 +205822,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1526,
+      "community": 1527,
       "file_type": "code",
       "id": "usegetcurrencyformatter_usegetcurrencyformatter",
       "label": "useGetCurrencyFormatter()",
@@ -205801,7 +205831,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1527,
+      "community": 1528,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetsubcategories_ts",
       "label": "useGetSubcategories.ts",
@@ -205810,7 +205840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1527,
+      "community": 1528,
       "file_type": "code",
       "id": "usegetsubcategories_usegetsubcategories",
       "label": "useGetSubcategories()",
@@ -205819,7 +205849,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1528,
+      "community": 1529,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usegetterminal_ts",
       "label": "useGetTerminal.ts",
@@ -205828,31 +205858,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1528,
+      "community": 1529,
       "file_type": "code",
       "id": "usegetterminal_usegetterminal",
       "label": "useGetTerminal()",
       "norm_label": "usegetterminal()",
       "source_file": "packages/athena-webapp/src/hooks/useGetTerminal.ts",
       "source_location": "L17"
-    },
-    {
-      "community": 1529,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
-      "label": "useNewOrderNotification.ts",
-      "norm_label": "usenewordernotification.ts",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1529,
-      "file_type": "code",
-      "id": "usenewordernotification_usenewordernotification",
-      "label": "useNewOrderNotification()",
-      "norm_label": "usenewordernotification()",
-      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
-      "source_location": "L8"
     },
     {
       "community": 153,
@@ -206001,6 +206013,24 @@
     {
       "community": 1530,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_hooks_usenewordernotification_ts",
+      "label": "useNewOrderNotification.ts",
+      "norm_label": "usenewordernotification.ts",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1530,
+      "file_type": "code",
+      "id": "usenewordernotification_usenewordernotification",
+      "label": "useNewOrderNotification()",
+      "norm_label": "usenewordernotification()",
+      "source_file": "packages/athena-webapp/src/hooks/useNewOrderNotification.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 1531,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usepermissions_ts",
       "label": "usePermissions.ts",
       "norm_label": "usepermissions.ts",
@@ -206008,7 +206038,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1530,
+      "community": 1531,
       "file_type": "code",
       "id": "usepermissions_usepermissions",
       "label": "usePermissions()",
@@ -206017,7 +206047,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1531,
+      "community": 1532,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductsearchresults_ts",
       "label": "useProductSearchResults.ts",
@@ -206026,7 +206056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1531,
+      "community": 1532,
       "file_type": "code",
       "id": "useproductsearchresults_useproductsearchresults",
       "label": "useProductSearchResults()",
@@ -206035,7 +206065,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1532,
+      "community": 1533,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useproductwithnoimagesnotification_tsx",
       "label": "useProductWithNoImagesNotification.tsx",
@@ -206044,7 +206074,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1532,
+      "community": 1533,
       "file_type": "code",
       "id": "useproductwithnoimagesnotification_useproductwithnoimagesnotification",
       "label": "useProductWithNoImagesNotification()",
@@ -206053,7 +206083,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1533,
+      "community": 1534,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useprotectedadminpagestate_ts",
       "label": "useProtectedAdminPageState.ts",
@@ -206062,7 +206092,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1533,
+      "community": 1534,
       "file_type": "code",
       "id": "useprotectedadminpagestate_useprotectedadminpagestate",
       "label": "useProtectedAdminPageState()",
@@ -206071,7 +206101,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1534,
+      "community": 1535,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usesheetreturnposition_ts",
       "label": "useSheetReturnPosition.ts",
@@ -206080,7 +206110,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1534,
+      "community": 1535,
       "file_type": "code",
       "id": "usesheetreturnposition_usesheetreturnposition",
       "label": "useSheetReturnPosition()",
@@ -206089,7 +206119,7 @@
       "source_location": "L74"
     },
     {
-      "community": 1535,
+      "community": 1536,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedincheckout_ts",
       "label": "useSkusReservedInCheckout.ts",
@@ -206098,7 +206128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1535,
+      "community": 1536,
       "file_type": "code",
       "id": "useskusreservedincheckout_useskusreservedincheckout",
       "label": "useSkusReservedInCheckout()",
@@ -206107,7 +206137,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1536,
+      "community": 1537,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useskusreservedinpossession_ts",
       "label": "useSkusReservedInPosSession.ts",
@@ -206116,7 +206146,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1536,
+      "community": 1537,
       "file_type": "code",
       "id": "useskusreservedinpossession_useskusreservedinpossession",
       "label": "useSkusReservedInPosSession()",
@@ -206125,7 +206155,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1537,
+      "community": 1538,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_usetogglecomplimentaryproductactive_ts",
       "label": "useToggleComplimentaryProductActive.ts",
@@ -206134,7 +206164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1537,
+      "community": 1538,
       "file_type": "code",
       "id": "usetogglecomplimentaryproductactive_usetogglecomplimentaryproductactive",
       "label": "useToggleComplimentaryProductActive()",
@@ -206143,7 +206173,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1538,
+      "community": 1539,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_useappactionblocker_test_tsx",
       "label": "useAppActionBlocker.test.tsx",
@@ -206152,31 +206182,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1538,
+      "community": 1539,
       "file_type": "code",
       "id": "useappactionblocker_test_wrapper",
       "label": "wrapper()",
       "norm_label": "wrapper()",
       "source_file": "packages/athena-webapp/src/lib/app-messages/useAppActionBlocker.test.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 1539,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_updatecoordinatorprovider_tsx",
-      "label": "UpdateCoordinatorProvider.tsx",
-      "norm_label": "updatecoordinatorprovider.tsx",
-      "source_file": "packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1539,
-      "file_type": "code",
-      "id": "updatecoordinatorprovider_updatecoordinatorprovider",
-      "label": "UpdateCoordinatorProvider()",
-      "norm_label": "updatecoordinatorprovider()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx",
-      "source_location": "L28"
     },
     {
       "community": 154,
@@ -206325,6 +206337,24 @@
     {
       "community": 1540,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_updatecoordinatorprovider_tsx",
+      "label": "UpdateCoordinatorProvider.tsx",
+      "norm_label": "updatecoordinatorprovider.tsx",
+      "source_file": "packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1540,
+      "file_type": "code",
+      "id": "updatecoordinatorprovider_updatecoordinatorprovider",
+      "label": "UpdateCoordinatorProvider()",
+      "norm_label": "updatecoordinatorprovider()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/UpdateCoordinatorProvider.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 1541,
+      "file_type": "code",
       "id": "appupdatereload_test_createfakewindow",
       "label": "createFakeWindow()",
       "norm_label": "createfakewindow()",
@@ -206332,7 +206362,7 @@
       "source_location": "L41"
     },
     {
-      "community": 1540,
+      "community": 1541,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_test_ts",
       "label": "appUpdateReload.test.ts",
@@ -206341,7 +206371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1541,
+      "community": 1542,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updateassetstaging_test_ts",
       "label": "updateAssetStaging.test.ts",
@@ -206350,7 +206380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1541,
+      "community": 1542,
       "file_type": "code",
       "id": "updateassetstaging_test_fakemessagechannel",
       "label": "FakeMessageChannel",
@@ -206359,7 +206389,7 @@
       "source_location": "L171"
     },
     {
-      "community": 1542,
+      "community": 1543,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatecommunicationpreference_tsx",
       "label": "updateCommunicationPreference.tsx",
@@ -206368,7 +206398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1542,
+      "community": 1543,
       "file_type": "code",
       "id": "updatecommunicationpreference_updatecommunicationpreferenceprovider",
       "label": "UpdateCommunicationPreferenceProvider()",
@@ -206377,7 +206407,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1543,
+      "community": 1544,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatedetectionsequencer_test_ts",
       "label": "updateDetectionSequencer.test.ts",
@@ -206386,7 +206416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1543,
+      "community": 1544,
       "file_type": "code",
       "id": "updatedetectionsequencer_test_createdeferredstatus",
       "label": "createDeferredStatus()",
@@ -206395,7 +206425,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1544,
+      "community": 1545,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_updatedetectionsequencer_ts",
       "label": "updateDetectionSequencer.ts",
@@ -206404,7 +206434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1544,
+      "community": 1545,
       "file_type": "code",
       "id": "updatedetectionsequencer_createupdatedetectionsequencer",
       "label": "createUpdateDetectionSequencer()",
@@ -206413,7 +206443,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1545,
+      "community": 1546,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_useupdateapplyblocker_ts",
       "label": "useUpdateApplyBlocker.ts",
@@ -206422,7 +206452,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1545,
+      "community": 1546,
       "file_type": "code",
       "id": "useupdateapplyblocker_useupdateapplyblocker",
       "label": "useUpdateApplyBlocker()",
@@ -206431,7 +206461,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1546,
+      "community": 1547,
       "file_type": "code",
       "id": "operatormessages_tooperatormessage",
       "label": "toOperatorMessage()",
@@ -206440,7 +206470,7 @@
       "source_location": "L52"
     },
     {
-      "community": 1546,
+      "community": 1547,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_operatormessages_ts",
       "label": "operatorMessages.ts",
@@ -206449,7 +206479,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1547,
+      "community": 1548,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_presentunexpectederrortoast_ts",
       "label": "presentUnexpectedErrorToast.ts",
@@ -206458,7 +206488,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1547,
+      "community": 1548,
       "file_type": "code",
       "id": "presentunexpectederrortoast_presentunexpectederrortoast",
       "label": "presentUnexpectedErrorToast()",
@@ -206467,7 +206497,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1548,
+      "community": 1549,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_shareddemodenialobserver_test_ts",
       "label": "sharedDemoDenialObserver.test.ts",
@@ -206476,31 +206506,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1548,
+      "community": 1549,
       "file_type": "code",
       "id": "shareddemodenialobserver_test_demodenial",
       "label": "demoDenial()",
       "norm_label": "demodenial()",
       "source_file": "packages/athena-webapp/src/lib/errors/sharedDemoDenialObserver.test.ts",
       "source_location": "L11"
-    },
-    {
-      "community": 1549,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_ts",
-      "label": "storeEntryRoute.ts",
-      "norm_label": "storeentryroute.ts",
-      "source_file": "packages/athena-webapp/src/lib/navigation/storeEntryRoute.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1549,
-      "file_type": "code",
-      "id": "storeentryroute_getstoreentryrouteforrole",
-      "label": "getStoreEntryRouteForRole()",
-      "norm_label": "getstoreentryrouteforrole()",
-      "source_file": "packages/athena-webapp/src/lib/navigation/storeEntryRoute.ts",
-      "source_location": "L7"
     },
     {
       "community": 155,
@@ -206649,6 +206661,24 @@
     {
       "community": 1550,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_navigation_storeentryroute_ts",
+      "label": "storeEntryRoute.ts",
+      "norm_label": "storeentryroute.ts",
+      "source_file": "packages/athena-webapp/src/lib/navigation/storeEntryRoute.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1550,
+      "file_type": "code",
+      "id": "storeentryroute_getstoreentryrouteforrole",
+      "label": "getStoreEntryRouteForRole()",
+      "norm_label": "getstoreentryrouteforrole()",
+      "source_file": "packages/athena-webapp/src/lib/navigation/storeEntryRoute.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 1551,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_poslocalstoretypes_ts",
       "label": "posLocalStoreTypes.ts",
       "norm_label": "poslocalstoretypes.ts",
@@ -206656,7 +206686,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1550,
+      "community": 1551,
       "file_type": "code",
       "id": "poslocalstoretypes_canuploadposlocaleventtype",
       "label": "canUploadPosLocalEventType()",
@@ -206665,7 +206695,7 @@
       "source_location": "L51"
     },
     {
-      "community": 1551,
+      "community": 1552,
       "file_type": "code",
       "id": "additem_additem",
       "label": "addItem()",
@@ -206674,7 +206704,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1551,
+      "community": 1552,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_additem_ts",
       "label": "addItem.ts",
@@ -206683,7 +206713,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1552,
+      "community": 1553,
       "file_type": "code",
       "id": "bootstrapregister_bootstrapregister",
       "label": "bootstrapRegister()",
@@ -206692,7 +206722,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1552,
+      "community": 1553,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_bootstrapregister_ts",
       "label": "bootstrapRegister.ts",
@@ -206701,7 +206731,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1553,
+      "community": 1554,
       "file_type": "code",
       "id": "holdsession_holdsession",
       "label": "holdSession()",
@@ -206710,7 +206740,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1553,
+      "community": 1554,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_holdsession_ts",
       "label": "holdSession.ts",
@@ -206719,7 +206749,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1554,
+      "community": 1555,
       "file_type": "code",
       "id": "opendrawer_opendrawer",
       "label": "openDrawer()",
@@ -206728,7 +206758,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1554,
+      "community": 1555,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_opendrawer_ts",
       "label": "openDrawer.ts",
@@ -206737,7 +206767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1555,
+      "community": 1556,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_usecases_startsession_ts",
       "label": "startSession.ts",
@@ -206746,7 +206776,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1555,
+      "community": 1556,
       "file_type": "code",
       "id": "startsession_startsession",
       "label": "startSession()",
@@ -206755,7 +206785,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1556,
+      "community": 1557,
       "file_type": "code",
       "id": "calculations_calculatecarttotals",
       "label": "calculateCartTotals()",
@@ -206764,7 +206794,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1556,
+      "community": 1557,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_calculations_ts",
       "label": "calculations.ts",
@@ -206773,7 +206803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1557,
+      "community": 1558,
       "file_type": "code",
       "id": "expenselocalcommandgateway_test_scope",
       "label": "scope()",
@@ -206782,7 +206812,7 @@
       "source_location": "L250"
     },
     {
-      "community": 1557,
+      "community": 1558,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_test_ts",
       "label": "expenseLocalCommandGateway.test.ts",
@@ -206791,7 +206821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1558,
+      "community": 1559,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalledgerpolicy_ts",
       "label": "posLocalLedgerPolicy.ts",
@@ -206800,31 +206830,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1558,
+      "community": 1559,
       "file_type": "code",
       "id": "poslocalledgerpolicy_assessposlocalledgerretention",
       "label": "assessPosLocalLedgerRetention()",
       "norm_label": "assessposlocalledgerretention()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalLedgerPolicy.ts",
       "source_location": "L49"
-    },
-    {
-      "community": 1559,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageboundary_test_ts",
-      "label": "posLocalStorageBoundary.test.ts",
-      "norm_label": "poslocalstorageboundary.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageBoundary.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1559,
-      "file_type": "code",
-      "id": "poslocalstorageboundary_test_collectproductionsources",
-      "label": "collectProductionSources()",
-      "norm_label": "collectproductionsources()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageBoundary.test.ts",
-      "source_location": "L39"
     },
     {
       "community": 156,
@@ -206964,6 +206976,24 @@
     {
       "community": 1560,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageboundary_test_ts",
+      "label": "posLocalStorageBoundary.test.ts",
+      "norm_label": "poslocalstorageboundary.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageBoundary.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1560,
+      "file_type": "code",
+      "id": "poslocalstorageboundary_test_collectproductionsources",
+      "label": "collectProductionSources()",
+      "norm_label": "collectproductionsources()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStorageBoundary.test.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 1561,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstorageruntimecontext_test_tsx",
       "label": "posLocalStorageRuntimeContext.test.tsx",
       "norm_label": "poslocalstorageruntimecontext.test.tsx",
@@ -206971,7 +207001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1560,
+      "community": 1561,
       "file_type": "code",
       "id": "poslocalstorageruntimecontext_test_runtimestatus",
       "label": "RuntimeStatus()",
@@ -206980,7 +207010,7 @@
       "source_location": "L61"
     },
     {
-      "community": 1561,
+      "community": 1562,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreerrortaxonomy_test_ts",
       "label": "posLocalStoreErrorTaxonomy.test.ts",
@@ -206989,7 +207019,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1561,
+      "community": 1562,
       "file_type": "code",
       "id": "poslocalstoreerrortaxonomy_test_failingadapter",
       "label": "failingAdapter()",
@@ -206998,7 +207028,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1562,
+      "community": 1563,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrationcoordinator_test_ts",
       "label": "posLocalStoreMigrationCoordinator.test.ts",
@@ -207007,7 +207037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1562,
+      "community": 1563,
       "file_type": "code",
       "id": "poslocalstoremigrationcoordinator_test_createlogicalfixtureengine",
       "label": "createLogicalFixtureEngine()",
@@ -207016,7 +207046,7 @@
       "source_location": "L176"
     },
     {
-      "community": 1563,
+      "community": 1564,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrationcoordinator_ts",
       "label": "posLocalStoreMigrationCoordinator.ts",
@@ -207025,7 +207055,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1563,
+      "community": 1564,
       "file_type": "code",
       "id": "poslocalstoremigrationcoordinator_createtestonlyposlocalstoremigrationcoordinator",
       "label": "createTestOnlyPosLocalStoreMigrationCoordinator()",
@@ -207034,7 +207064,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1564,
+      "community": 1565,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoremigrations_ts",
       "label": "posLocalStoreMigrations.ts",
@@ -207043,7 +207073,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1564,
+      "community": 1565,
       "file_type": "code",
       "id": "poslocalstoremigrations_runposlocalstoremigrations",
       "label": "runPosLocalStoreMigrations()",
@@ -207052,7 +207082,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1565,
+      "community": 1566,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoresnapshot_ts",
       "label": "posLocalStoreSnapshot.ts",
@@ -207061,7 +207091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1565,
+      "community": 1566,
       "file_type": "code",
       "id": "poslocalstoresnapshot_validateposlocalstoresnapshotshape",
       "label": "validatePosLocalStoreSnapshotShape()",
@@ -207070,7 +207100,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1566,
+      "community": 1567,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_poslocalstoreversions_ts",
       "label": "posLocalStoreVersions.ts",
@@ -207079,7 +207109,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1566,
+      "community": 1567,
       "file_type": "code",
       "id": "poslocalstoreversions_compareposlocalstoreversion",
       "label": "comparePosLocalStoreVersion()",
@@ -207088,7 +207118,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1567,
+      "community": 1568,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registeravailabilitysnapshot_test_ts",
       "label": "registerAvailabilitySnapshot.test.ts",
@@ -207097,7 +207127,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1567,
+      "community": 1568,
       "file_type": "code",
       "id": "registeravailabilitysnapshot_test_buildavailabilityrow",
       "label": "buildAvailabilityRow()",
@@ -207106,7 +207136,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1568,
+      "community": 1569,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registeravailabilitysnapshot_ts",
       "label": "registerAvailabilitySnapshot.ts",
@@ -207115,31 +207145,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1568,
+      "community": 1569,
       "file_type": "code",
       "id": "registeravailabilitysnapshot_readregisteravailabilitysnapshotstate",
       "label": "readRegisterAvailabilitySnapshotState()",
       "norm_label": "readregisteravailabilitysnapshotstate()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerAvailabilitySnapshot.ts",
       "source_location": "L33"
-    },
-    {
-      "community": 1569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityreconciliation_test_ts",
-      "label": "registerLifecycleAuthorityReconciliation.test.ts",
-      "norm_label": "registerlifecycleauthorityreconciliation.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityReconciliation.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1569,
-      "file_type": "code",
-      "id": "registerlifecycleauthorityreconciliation_test_versioned",
-      "label": "versioned()",
-      "norm_label": "versioned()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityReconciliation.test.ts",
-      "source_location": "L8"
     },
     {
       "community": 157,
@@ -207279,6 +207291,24 @@
     {
       "community": 1570,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthorityreconciliation_test_ts",
+      "label": "registerLifecycleAuthorityReconciliation.test.ts",
+      "norm_label": "registerlifecycleauthorityreconciliation.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityReconciliation.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1570,
+      "file_type": "code",
+      "id": "registerlifecycleauthorityreconciliation_test_versioned",
+      "label": "versioned()",
+      "norm_label": "versioned()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityReconciliation.test.ts",
+      "source_location": "L8"
+    },
+    {
+      "community": 1571,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerservicecatalogsnapshot_test_ts",
       "label": "registerServiceCatalogSnapshot.test.ts",
       "norm_label": "registerservicecatalogsnapshot.test.ts",
@@ -207286,7 +207316,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1570,
+      "community": 1571,
       "file_type": "code",
       "id": "registerservicecatalogsnapshot_test_buildservicecatalogrow",
       "label": "buildServiceCatalogRow()",
@@ -207295,7 +207325,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1571,
+      "community": 1572,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerservicecatalogsnapshot_ts",
       "label": "registerServiceCatalogSnapshot.ts",
@@ -207304,7 +207334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1571,
+      "community": 1572,
       "file_type": "code",
       "id": "registerservicecatalogsnapshot_readregisterservicecatalogsnapshotstate",
       "label": "readRegisterServiceCatalogSnapshotState()",
@@ -207313,7 +207343,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1572,
+      "community": 1573,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registersessionauthoritybootstrap_ts",
       "label": "registerSessionAuthorityBootstrap.ts",
@@ -207322,7 +207352,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1572,
+      "community": 1573,
       "file_type": "code",
       "id": "registersessionauthoritybootstrap_seedregistersessionauthoritybootstrap",
       "label": "seedRegisterSessionAuthorityBootstrap()",
@@ -207331,7 +207361,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1573,
+      "community": 1574,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncgapdiagnosis_ts",
       "label": "syncGapDiagnosis.ts",
@@ -207340,7 +207370,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1573,
+      "community": 1574,
       "file_type": "code",
       "id": "syncgapdiagnosis_diagnoseheldsyncblocker",
       "label": "diagnoseHeldSyncBlocker()",
@@ -207349,7 +207379,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1574,
+      "community": 1575,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncscheduler_test_ts",
       "label": "syncScheduler.test.ts",
@@ -207358,7 +207388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1574,
+      "community": 1575,
       "file_type": "code",
       "id": "syncscheduler_test_baseevent",
       "label": "baseEvent()",
@@ -207367,7 +207397,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1575,
+      "community": 1576,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_syncstatus_test_ts",
       "label": "syncStatus.test.ts",
@@ -207376,7 +207406,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1575,
+      "community": 1576,
       "file_type": "code",
       "id": "syncstatus_test_event",
       "label": "event()",
@@ -207385,7 +207415,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1576,
+      "community": 1577,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalruntimestatus_test_ts",
       "label": "terminalRuntimeStatus.test.ts",
@@ -207394,7 +207424,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1576,
+      "community": 1577,
       "file_type": "code",
       "id": "terminalruntimestatus_test_buildlocalevent",
       "label": "buildLocalEvent()",
@@ -207403,7 +207433,7 @@
       "source_location": "L1033"
     },
     {
-      "community": 1577,
+      "community": 1578,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_terminalstaffauthorityrefresh_test_ts",
       "label": "terminalStaffAuthorityRefresh.test.ts",
@@ -207412,7 +207442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1577,
+      "community": 1578,
       "file_type": "code",
       "id": "terminalstaffauthorityrefresh_test_buildauthorityrecord",
       "label": "buildAuthorityRecord()",
@@ -207421,7 +207451,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1578,
+      "community": 1579,
       "file_type": "code",
       "id": "loggergateway_tometadatarecord",
       "label": "toMetadataRecord()",
@@ -207430,31 +207460,13 @@
       "source_location": "L5"
     },
     {
-      "community": 1578,
+      "community": 1579,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_loggergateway_ts",
       "label": "loggerGateway.ts",
       "norm_label": "loggergateway.ts",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/loggerGateway.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_useposclienttelemetrydrain_test_ts",
-      "label": "usePosClientTelemetryDrain.test.ts",
-      "norm_label": "useposclienttelemetrydrain.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/usePosClientTelemetryDrain.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1579,
-      "file_type": "code",
-      "id": "useposclienttelemetrydrain_test_dispatchunhandledrejection",
-      "label": "dispatchUnhandledRejection()",
-      "norm_label": "dispatchunhandledrejection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/usePosClientTelemetryDrain.test.ts",
-      "source_location": "L26"
     },
     {
       "community": 158,
@@ -207594,6 +207606,24 @@
     {
       "community": 1580,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_useposclienttelemetrydrain_test_ts",
+      "label": "usePosClientTelemetryDrain.test.ts",
+      "norm_label": "useposclienttelemetrydrain.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/usePosClientTelemetryDrain.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1580,
+      "file_type": "code",
+      "id": "useposclienttelemetrydrain_test_dispatchunhandledrejection",
+      "label": "dispatchUnhandledRejection()",
+      "norm_label": "dispatchunhandledrejection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/usePosClientTelemetryDrain.test.ts",
+      "source_location": "L26"
+    },
+    {
+      "community": 1581,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_useposclienttelemetrydrain_ts",
       "label": "usePosClientTelemetryDrain.ts",
       "norm_label": "useposclienttelemetrydrain.ts",
@@ -207601,7 +207631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1580,
+      "community": 1581,
       "file_type": "code",
       "id": "useposclienttelemetrydrain_useposclienttelemetrydrain",
       "label": "usePosClientTelemetryDrain()",
@@ -207610,7 +207640,7 @@
       "source_location": "L25"
     },
     {
-      "community": 1581,
+      "community": 1582,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercatalogindex_ts",
       "label": "useRegisterCatalogIndex.ts",
@@ -207619,7 +207649,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1581,
+      "community": 1582,
       "file_type": "code",
       "id": "useregistercatalogindex_useregistercatalogindex",
       "label": "useRegisterCatalogIndex()",
@@ -207628,7 +207658,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1582,
+      "community": 1583,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregistercheckoutdraftstate_ts",
       "label": "useRegisterCheckoutDraftState.ts",
@@ -207637,7 +207667,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1582,
+      "community": 1583,
       "file_type": "code",
       "id": "useregistercheckoutdraftstate_useregistercheckoutdraftstate",
       "label": "useRegisterCheckoutDraftState()",
@@ -207646,7 +207676,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1583,
+      "community": 1584,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterlocalruntime_test_ts",
       "label": "useRegisterLocalRuntime.test.ts",
@@ -207655,7 +207685,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1583,
+      "community": 1584,
       "file_type": "code",
       "id": "useregisterlocalruntime_test_renderruntime",
       "label": "renderRuntime()",
@@ -207664,7 +207694,7 @@
       "source_location": "L96"
     },
     {
-      "community": 1584,
+      "community": 1585,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_registersessioncode_ts",
       "label": "registerSessionCode.ts",
@@ -207673,7 +207703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1584,
+      "community": 1585,
       "file_type": "code",
       "id": "registersessioncode_formatregistersessioncode",
       "label": "formatRegisterSessionCode()",
@@ -207682,7 +207712,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1585,
+      "community": 1586,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_remoteassistcobrowserecorder_test_ts",
       "label": "remoteAssistCobrowseRecorder.test.ts",
@@ -207691,7 +207721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1585,
+      "community": 1586,
       "file_type": "code",
       "id": "remoteassistcobrowserecorder_test_setelementrect",
       "label": "setElementRect()",
@@ -207700,7 +207730,7 @@
       "source_location": "L395"
     },
     {
-      "community": 1586,
+      "community": 1587,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_test_ts",
       "label": "runtime.test.ts",
@@ -207709,7 +207739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1586,
+      "community": 1587,
       "file_type": "code",
       "id": "runtime_test_buildstate",
       "label": "buildState()",
@@ -207718,7 +207748,7 @@
       "source_location": "L99"
     },
     {
-      "community": 1587,
+      "community": 1588,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_ts",
       "label": "runtime.ts",
@@ -207727,7 +207757,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1587,
+      "community": 1588,
       "file_type": "code",
       "id": "runtime_getremoteassistconnectedstate",
       "label": "getRemoteAssistConnectedState()",
@@ -207736,7 +207766,7 @@
       "source_location": "L44"
     },
     {
-      "community": 1588,
+      "community": 1589,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_support_useremoteassistsupporttransport_ts",
       "label": "useRemoteAssistSupportTransport.ts",
@@ -207745,31 +207775,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1588,
+      "community": 1589,
       "file_type": "code",
       "id": "useremoteassistsupporttransport_useremoteassistsupporttransport",
       "label": "useRemoteAssistSupportTransport()",
       "norm_label": "useremoteassistsupporttransport()",
       "source_file": "packages/athena-webapp/src/lib/remote-assist/support/useRemoteAssistSupportTransport.ts",
       "source_location": "L20"
-    },
-    {
-      "community": 1589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_transport_remoteassistlivetransportclient_test_ts",
-      "label": "RemoteAssistLiveTransportClient.test.ts",
-      "norm_label": "remoteassistlivetransportclient.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/RemoteAssistLiveTransportClient.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1589,
-      "file_type": "code",
-      "id": "remoteassistlivetransportclient_test_encode",
-      "label": "encode()",
-      "norm_label": "encode()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/RemoteAssistLiveTransportClient.test.ts",
-      "source_location": "L255"
     },
     {
       "community": 159,
@@ -207909,6 +207921,24 @@
     {
       "community": 1590,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_transport_remoteassistlivetransportclient_test_ts",
+      "label": "RemoteAssistLiveTransportClient.test.ts",
+      "norm_label": "remoteassistlivetransportclient.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/RemoteAssistLiveTransportClient.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1590,
+      "file_type": "code",
+      "id": "remoteassistlivetransportclient_test_encode",
+      "label": "encode()",
+      "norm_label": "encode()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/transport/RemoteAssistLiveTransportClient.test.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 1591,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_security_pinhash_ts",
       "label": "pinHash.ts",
       "norm_label": "pinhash.ts",
@@ -207916,7 +207946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1590,
+      "community": 1591,
       "file_type": "code",
       "id": "pinhash_hashpin",
       "label": "hashPin()",
@@ -207925,7 +207955,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1591,
+      "community": 1592,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_test_ts",
       "label": "productSkuSearchAdapters.test.ts",
@@ -207934,7 +207964,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1591,
+      "community": 1592,
       "file_type": "code",
       "id": "productskusearchadapters_test_buildresult",
       "label": "buildResult()",
@@ -207943,7 +207973,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1592,
+      "community": 1593,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_theme_test_ts",
       "label": "theme.test.ts",
@@ -207952,7 +207982,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1592,
+      "community": 1593,
       "file_type": "code",
       "id": "theme_test_installmatchmedia",
       "label": "installMatchMedia()",
@@ -207961,7 +207991,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1593,
+      "community": 1594,
       "file_type": "code",
       "id": "authenticated_layout_authenticatedlayout",
       "label": "AuthenticatedLayout()",
@@ -207970,7 +208000,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1593,
+      "community": 1594,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authenticated_layout_tsx",
       "label": "-authenticated-layout.tsx",
@@ -207979,7 +208009,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1594,
+      "community": 1595,
       "file_type": "code",
       "id": "demo_presentation_getshareddemoentrypresentation",
       "label": "getSharedDemoEntryPresentation()",
@@ -207988,7 +208018,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1594,
+      "community": 1595,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_demo_presentation_ts",
       "label": "-demo-presentation.ts",
@@ -207997,7 +208027,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1595,
+      "community": 1596,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_public_layout_tsx",
       "label": "-public-layout.tsx",
@@ -208006,7 +208036,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1595,
+      "community": 1596,
       "file_type": "code",
       "id": "public_layout_onscroll",
       "label": "onScroll()",
@@ -208015,7 +208045,7 @@
       "source_location": "L92"
     },
     {
-      "community": 1596,
+      "community": 1597,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_settings_waiver_passkey_tsx",
       "label": "waiver-passkey.tsx",
@@ -208024,7 +208054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1596,
+      "community": 1597,
       "file_type": "code",
       "id": "waiver_passkey_enroll",
       "label": "enroll()",
@@ -208033,7 +208063,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1597,
+      "community": 1598,
       "file_type": "code",
       "id": "index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -208042,7 +208072,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1597,
+      "community": 1598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_index_tsx",
       "label": "index.tsx",
@@ -208051,7 +208081,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1598,
+      "community": 1599,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_tsx",
       "label": "$sessionId.tsx",
@@ -208060,30 +208090,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1598,
+      "community": 1599,
       "file_type": "code",
       "id": "sessionid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
       "norm_label": "hasorgnotfoundpayload()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId.tsx",
-      "source_location": "L6"
-    },
-    {
-      "community": 1599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_activity_tsx",
-      "label": "registers.$sessionId.activity.tsx",
-      "norm_label": "registers.$sessionid.activity.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.$sessionId.activity.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1599,
-      "file_type": "code",
-      "id": "registers_sessionid_activity_hasorgnotfoundpayload",
-      "label": "hasOrgNotFoundPayload()",
-      "norm_label": "hasorgnotfoundpayload()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.$sessionId.activity.tsx",
       "source_location": "L6"
     },
     {
@@ -208611,6 +208623,24 @@
     {
       "community": 1600,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_sessionid_activity_tsx",
+      "label": "registers.$sessionId.activity.tsx",
+      "norm_label": "registers.$sessionid.activity.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.$sessionId.activity.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1600,
+      "file_type": "code",
+      "id": "registers_sessionid_activity_hasorgnotfoundpayload",
+      "label": "hasOrgNotFoundPayload()",
+      "norm_label": "hasorgnotfoundpayload()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers.$sessionId.activity.tsx",
+      "source_location": "L6"
+    },
+    {
+      "community": 1601,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_cash_controls_registers_index_tsx",
       "label": "registers.index.tsx",
       "norm_label": "registers.index.tsx",
@@ -208618,7 +208648,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1600,
+      "community": 1601,
       "file_type": "code",
       "id": "registers_index_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -208627,7 +208657,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1601,
+      "community": 1602,
       "file_type": "code",
       "id": "index_storerootredirect",
       "label": "StoreRootRedirect()",
@@ -208636,7 +208666,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1601,
+      "community": 1602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_index_tsx",
       "label": "index.tsx",
@@ -208645,7 +208675,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1602,
+      "community": 1603,
       "file_type": "code",
       "id": "inventory_import_route_inventoryimportroute",
       "label": "InventoryImportRoute()",
@@ -208654,7 +208684,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1602,
+      "community": 1603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_inventory_import_route_tsx",
       "label": "-inventory-import-route.tsx",
@@ -208663,7 +208693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1603,
+      "community": 1604,
       "file_type": "code",
       "id": "approvals_approvalsroute",
       "label": "ApprovalsRoute()",
@@ -208672,7 +208702,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1603,
+      "community": 1604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_approvals_tsx",
       "label": "approvals.tsx",
@@ -208681,7 +208711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1604,
+      "community": 1605,
       "file_type": "code",
       "id": "daily_close_history_dailyclosehistoryroute",
       "label": "DailyCloseHistoryRoute()",
@@ -208690,7 +208720,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1604,
+      "community": 1605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_history_tsx",
       "label": "daily-close-history.tsx",
@@ -208699,7 +208729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1605,
+      "community": 1606,
       "file_type": "code",
       "id": "daily_close_dailycloseroute",
       "label": "DailyCloseRoute()",
@@ -208708,7 +208738,7 @@
       "source_location": "L36"
     },
     {
-      "community": 1605,
+      "community": 1606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_daily_close_tsx",
       "label": "daily-close.tsx",
@@ -208717,7 +208747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1606,
+      "community": 1607,
       "file_type": "code",
       "id": "index_dailyoperationsroute",
       "label": "DailyOperationsRoute()",
@@ -208726,7 +208756,7 @@
       "source_location": "L32"
     },
     {
-      "community": 1606,
+      "community": 1607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_index_tsx",
       "label": "index.tsx",
@@ -208735,7 +208765,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1607,
+      "community": 1608,
       "file_type": "code",
       "id": "open_work_openworkroute",
       "label": "OpenWorkRoute()",
@@ -208744,7 +208774,7 @@
       "source_location": "L20"
     },
     {
-      "community": 1607,
+      "community": 1608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_open_work_tsx",
       "label": "open-work.tsx",
@@ -208753,7 +208783,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1608,
+      "community": 1609,
       "file_type": "code",
       "id": "opening_dailyopeningroute",
       "label": "DailyOpeningRoute()",
@@ -208762,31 +208792,13 @@
       "source_location": "L21"
     },
     {
-      "community": 1608,
+      "community": 1609,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_opening_tsx",
       "label": "opening.tsx",
       "norm_label": "opening.tsx",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 1609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
-      "label": "stock-adjustments.tsx",
-      "norm_label": "stock-adjustments.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1609,
-      "file_type": "code",
-      "id": "stock_adjustments_stockadjustmentsroute",
-      "label": "StockAdjustmentsRoute()",
-      "norm_label": "stockadjustmentsroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
-      "source_location": "L28"
     },
     {
       "community": 161,
@@ -208926,6 +208938,24 @@
     {
       "community": 1610,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_stock_adjustments_tsx",
+      "label": "stock-adjustments.tsx",
+      "norm_label": "stock-adjustments.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1610,
+      "file_type": "code",
+      "id": "stock_adjustments_stockadjustmentsroute",
+      "label": "StockAdjustmentsRoute()",
+      "norm_label": "stockadjustmentsroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx",
+      "source_location": "L28"
+    },
+    {
+      "community": 1611,
+      "file_type": "code",
       "id": "expense_index_expenseroutecomponent",
       "label": "ExpenseRouteComponent()",
       "norm_label": "expenseroutecomponent()",
@@ -208933,7 +208963,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1610,
+      "community": 1611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_expense_index_tsx",
       "label": "expense.index.tsx",
@@ -208942,7 +208972,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1611,
+      "community": 1612,
       "file_type": "code",
       "id": "index_pointofsaleroute",
       "label": "PointOfSaleRoute()",
@@ -208951,7 +208981,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1611,
+      "community": 1612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_index_tsx",
       "label": "index.tsx",
@@ -208960,7 +208990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1612,
+      "community": 1613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_settings_index_tsx",
       "label": "settings.index.tsx",
@@ -208969,7 +208999,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1612,
+      "community": 1613,
       "file_type": "code",
       "id": "settings_index_settingsnotfoundcomponent",
       "label": "SettingsNotFoundComponent()",
@@ -208978,7 +209008,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1613,
+      "community": 1614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_pos_terminals_route_test_tsx",
       "label": "terminals.route.test.tsx",
@@ -208987,7 +209017,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1613,
+      "community": 1614,
       "file_type": "code",
       "id": "terminals_route_test_routebuilder",
       "label": "routeBuilder()",
@@ -208996,7 +209026,7 @@
       "source_location": "L26"
     },
     {
-      "community": 1614,
+      "community": 1615,
       "file_type": "code",
       "id": "index_complimentaryproductsnotfoundcomponent",
       "label": "ComplimentaryProductsNotFoundComponent()",
@@ -209005,7 +209035,7 @@
       "source_location": "L23"
     },
     {
-      "community": 1614,
+      "community": 1615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_complimentary_index_tsx",
       "label": "index.tsx",
@@ -209014,7 +209044,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1615,
+      "community": 1616,
       "file_type": "code",
       "id": "index_productsnotfoundcomponent",
       "label": "ProductsNotFoundComponent()",
@@ -209023,7 +209053,7 @@
       "source_location": "L24"
     },
     {
-      "community": 1615,
+      "community": 1616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_products_index_tsx",
       "label": "index.tsx",
@@ -209032,7 +209062,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1616,
+      "community": 1617,
       "file_type": "code",
       "id": "index_reportsitemsroute",
       "label": "ReportsItemsRoute()",
@@ -209041,7 +209071,7 @@
       "source_location": "L34"
     },
     {
-      "community": 1616,
+      "community": 1617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_items_index_tsx",
       "label": "index.tsx",
@@ -209050,7 +209080,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1617,
+      "community": 1618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reviews_published_index_tsx",
       "label": "published.index.tsx",
@@ -209059,7 +209089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1617,
+      "community": 1618,
       "file_type": "code",
       "id": "published_index_routecomponent",
       "label": "RouteComponent()",
@@ -209068,7 +209098,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1618,
+      "community": 1619,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_shared_demo_tsx",
       "label": "shared-demo.tsx",
@@ -209077,31 +209107,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1618,
+      "community": 1619,
       "file_type": "code",
       "id": "shared_demo_shareddemohomeroute",
       "label": "SharedDemoHomeRoute()",
       "norm_label": "shareddemohomeroute()",
       "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/shared-demo.tsx",
       "source_location": "L7"
-    },
-    {
-      "community": 1619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_route_test_tsx",
-      "label": "_authed.route.test.tsx",
-      "norm_label": "_authed.route.test.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.route.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_tsx",
-      "label": "_authed.tsx",
-      "norm_label": "_authed.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
-      "source_location": "L1"
     },
     {
       "community": 162,
@@ -209241,6 +209253,24 @@
     {
       "community": 1620,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_route_test_tsx",
+      "label": "_authed.route.test.tsx",
+      "norm_label": "_authed.route.test.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.route.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1620,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_tsx",
+      "label": "_authed.tsx",
+      "norm_label": "_authed.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1621,
+      "file_type": "code",
       "id": "docs_reports_index_setquery",
       "label": "setQuery()",
       "norm_label": "setquery()",
@@ -209248,7 +209278,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1620,
+      "community": 1621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_reports_index_tsx",
       "label": "docs.reports.index.tsx",
@@ -209257,7 +209287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1621,
+      "community": 1622,
       "file_type": "code",
       "id": "docs_solutions_category_slug_solutiondoccontent",
       "label": "SolutionDocContent()",
@@ -209266,7 +209296,7 @@
       "source_location": "L80"
     },
     {
-      "community": 1621,
+      "community": 1622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_solutions_category_slug_tsx",
       "label": "docs.solutions.$category.$slug.tsx",
@@ -209275,7 +209305,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1622,
+      "community": 1623,
       "file_type": "code",
       "id": "login_ready_view_athenaloginreadyview",
       "label": "AthenaLoginReadyView()",
@@ -209284,7 +209314,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1622,
+      "community": 1623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_ready_view_tsx",
       "label": "-login-ready-view.tsx",
@@ -209293,7 +209323,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1623,
+      "community": 1624,
       "file_type": "code",
       "id": "layout_test_activehandoff",
       "label": "activeHandoff()",
@@ -209302,7 +209332,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1623,
+      "community": 1624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_layout_test_tsx",
       "label": "_layout.test.tsx",
@@ -209311,7 +209341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1624,
+      "community": 1625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_waiver_approve_tsx",
       "label": "waiver.approve.tsx",
@@ -209320,7 +209350,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1624,
+      "community": 1625,
       "file_type": "code",
       "id": "waiver_approve_approve",
       "label": "approve()",
@@ -209329,7 +209359,7 @@
       "source_location": "L49"
     },
     {
-      "community": 1625,
+      "community": 1626,
       "file_type": "code",
       "id": "organizationssettingsaccordion_organizationsettingsaccordion",
       "label": "OrganizationSettingsAccordion()",
@@ -209338,7 +209368,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1625,
+      "community": 1626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationssettingsaccordion_tsx",
       "label": "OrganizationsSettingsAccordion.tsx",
@@ -209347,7 +209377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1626,
+      "community": 1627,
       "file_type": "code",
       "id": "overview_stories_patternsoverview",
       "label": "PatternsOverview()",
@@ -209356,7 +209386,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1626,
+      "community": 1627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -209365,7 +209395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1627,
+      "community": 1628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_patterns_view_patterns_tsx",
       "label": "view-patterns.tsx",
@@ -209374,7 +209404,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1627,
+      "community": 1628,
       "file_type": "code",
       "id": "view_patterns_cn",
       "label": "cn()",
@@ -209383,7 +209413,7 @@
       "source_location": "L142"
     },
     {
-      "community": 1628,
+      "community": 1629,
       "file_type": "code",
       "id": "controls_stories_controlsshowcase",
       "label": "ControlsShowcase()",
@@ -209392,30 +209422,12 @@
       "source_location": "L17"
     },
     {
-      "community": 1628,
+      "community": 1629,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_controls_stories_tsx",
       "label": "Controls.stories.tsx",
       "norm_label": "controls.stories.tsx",
       "source_file": "packages/athena-webapp/src/stories/Primitives/Controls.stories.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1629,
-      "file_type": "code",
-      "id": "dialog_stories_dialogshowcase",
-      "label": "DialogShowcase()",
-      "norm_label": "dialogshowcase()",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
-      "source_location": "L15"
-    },
-    {
-      "community": 1629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
-      "label": "Dialog.stories.tsx",
-      "norm_label": "dialog.stories.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
       "source_location": "L1"
     },
     {
@@ -209556,6 +209568,24 @@
     {
       "community": 1630,
       "file_type": "code",
+      "id": "dialog_stories_dialogshowcase",
+      "label": "DialogShowcase()",
+      "norm_label": "dialogshowcase()",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 1630,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_primitives_dialog_stories_tsx",
+      "label": "Dialog.stories.tsx",
+      "norm_label": "dialog.stories.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Primitives/Dialog.stories.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1631,
+      "file_type": "code",
       "id": "feedback_stories_feedbackshowcase",
       "label": "FeedbackShowcase()",
       "norm_label": "feedbackshowcase()",
@@ -209563,7 +209593,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1630,
+      "community": 1631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_feedback_stories_tsx",
       "label": "Feedback.stories.tsx",
@@ -209572,7 +209602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1631,
+      "community": 1632,
       "file_type": "code",
       "id": "overview_stories_primitivesoverview",
       "label": "PrimitivesOverview()",
@@ -209581,7 +209611,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1631,
+      "community": 1632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -209590,7 +209620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1632,
+      "community": 1633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_popover_stories_tsx",
       "label": "Popover.stories.tsx",
@@ -209599,7 +209629,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1632,
+      "community": 1633,
       "file_type": "code",
       "id": "popover_stories_popovershowcase",
       "label": "PopoverShowcase()",
@@ -209608,7 +209638,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1633,
+      "community": 1634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_sheet_stories_tsx",
       "label": "Sheet.stories.tsx",
@@ -209617,7 +209647,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1633,
+      "community": 1634,
       "file_type": "code",
       "id": "sheet_stories_sheetshowcase",
       "label": "SheetShowcase()",
@@ -209626,7 +209656,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1634,
+      "community": 1635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_primitives_tooltip_stories_tsx",
       "label": "Tooltip.stories.tsx",
@@ -209635,7 +209665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1634,
+      "community": 1635,
       "file_type": "code",
       "id": "tooltip_stories_tooltipshowcase",
       "label": "TooltipShowcase()",
@@ -209644,7 +209674,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1635,
+      "community": 1636,
       "file_type": "code",
       "id": "overview_stories_templatesoverview",
       "label": "TemplatesOverview()",
@@ -209653,7 +209683,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1635,
+      "community": 1636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_templates_overview_stories_tsx",
       "label": "Overview.stories.tsx",
@@ -209662,7 +209692,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1636,
+      "community": 1637,
       "file_type": "code",
       "id": "dailyoperationsfixtures_wedat",
       "label": "wedAt()",
@@ -209671,7 +209701,7 @@
       "source_location": "L550"
     },
     {
-      "community": 1636,
+      "community": 1637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_dailyoperationsfixtures_ts",
       "label": "dailyOperationsFixtures.ts",
@@ -209680,7 +209710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1637,
+      "community": 1638,
       "file_type": "code",
       "id": "openinghandofffixtures_wedat",
       "label": "wedAt()",
@@ -209689,7 +209719,7 @@
       "source_location": "L189"
     },
     {
-      "community": 1637,
+      "community": 1638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_openinghandofffixtures_ts",
       "label": "openingHandoffFixtures.ts",
@@ -209698,7 +209728,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1638,
+      "community": 1639,
       "file_type": "code",
       "id": "operationsfixturecontext_momentat",
       "label": "momentAt()",
@@ -209707,31 +209737,13 @@
       "source_location": "L34"
     },
     {
-      "community": 1638,
+      "community": 1639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_operationsfixturecontext_ts",
       "label": "operationsFixtureContext.ts",
       "norm_label": "operationsfixturecontext.ts",
       "source_file": "packages/athena-webapp/src/stories/operations/operationsFixtureContext.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 1639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_operations_poshubfixtures_ts",
-      "label": "posHubFixtures.ts",
-      "norm_label": "poshubfixtures.ts",
-      "source_file": "packages/athena-webapp/src/stories/operations/posHubFixtures.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1639,
-      "file_type": "code",
-      "id": "poshubfixtures_buildtrend",
-      "label": "buildTrend()",
-      "norm_label": "buildtrend()",
-      "source_file": "packages/athena-webapp/src/stories/operations/posHubFixtures.ts",
-      "source_location": "L70"
     },
     {
       "community": 164,
@@ -209871,6 +209883,24 @@
     {
       "community": 1640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_operations_poshubfixtures_ts",
+      "label": "posHubFixtures.ts",
+      "norm_label": "poshubfixtures.ts",
+      "source_file": "packages/athena-webapp/src/stories/operations/posHubFixtures.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1640,
+      "file_type": "code",
+      "id": "poshubfixtures_buildtrend",
+      "label": "buildTrend()",
+      "norm_label": "buildtrend()",
+      "source_file": "packages/athena-webapp/src/stories/operations/posHubFixtures.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 1641,
+      "file_type": "code",
       "id": "formatnumber_formatnumber",
       "label": "formatNumber()",
       "norm_label": "formatnumber()",
@@ -209878,7 +209908,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1640,
+      "community": 1641,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_formatnumber_ts",
       "label": "formatNumber.ts",
@@ -209887,7 +209917,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1641,
+      "community": 1642,
       "file_type": "code",
       "id": "bannermessage_getbannermessage",
       "label": "getBannerMessage()",
@@ -209896,7 +209926,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1641,
+      "community": 1642,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -209905,7 +209935,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1642,
+      "community": 1643,
       "file_type": "code",
       "id": "checkoutsession_test_jsonresponse",
       "label": "jsonResponse()",
@@ -209914,7 +209944,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1642,
+      "community": 1643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_checkoutsession_test_ts",
       "label": "checkoutSession.test.ts",
@@ -209923,7 +209953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1643,
+      "community": 1644,
       "file_type": "code",
       "id": "guest_updateguest",
       "label": "updateGuest()",
@@ -209932,7 +209962,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1643,
+      "community": 1644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_guest_ts",
       "label": "guest.ts",
@@ -209941,7 +209971,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1644,
+      "community": 1645,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_test_ts",
       "label": "posTransaction.test.ts",
@@ -209950,7 +209980,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1644,
+      "community": 1645,
       "file_type": "code",
       "id": "postransaction_test_jsonresponse",
       "label": "jsonResponse()",
@@ -209959,7 +209989,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1645,
+      "community": 1646,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefront_ts",
       "label": "storefront.ts",
@@ -209968,7 +209998,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1645,
+      "community": 1646,
       "file_type": "code",
       "id": "storefront_getstore",
       "label": "getStore()",
@@ -209977,7 +210007,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1646,
+      "community": 1647,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_trackingevents_ts",
       "label": "trackingEvents.ts",
@@ -209986,7 +210016,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1646,
+      "community": 1647,
       "file_type": "code",
       "id": "trackingevents_posttrackingevent",
       "label": "postTrackingEvent()",
@@ -209995,7 +210025,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1647,
+      "community": 1648,
       "file_type": "code",
       "id": "entitypage_entitypage",
       "label": "EntityPage()",
@@ -210004,7 +210034,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1647,
+      "community": 1648,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_entitypage_tsx",
       "label": "EntityPage.tsx",
@@ -210013,7 +210043,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1648,
+      "community": 1649,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_productspage_tsx",
       "label": "ProductsPage.tsx",
@@ -210022,31 +210052,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1648,
+      "community": 1649,
       "file_type": "code",
       "id": "productspage_productcardloadingskeleton",
       "label": "ProductCardLoadingSkeleton()",
       "norm_label": "productcardloadingskeleton()",
       "source_file": "packages/storefront-webapp/src/components/ProductsPage.tsx",
       "source_location": "L10"
-    },
-    {
-      "community": 1649,
-      "file_type": "code",
-      "id": "auth_authcomponent",
-      "label": "AuthComponent()",
-      "norm_label": "authcomponent()",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L4"
-    },
-    {
-      "community": 1649,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
-      "label": "Auth.tsx",
-      "norm_label": "auth.tsx",
-      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
-      "source_location": "L1"
     },
     {
       "community": 165,
@@ -210186,6 +210198,24 @@
     {
       "community": 1650,
       "file_type": "code",
+      "id": "auth_authcomponent",
+      "label": "AuthComponent()",
+      "norm_label": "authcomponent()",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L4"
+    },
+    {
+      "community": 1650,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_auth_auth_tsx",
+      "label": "Auth.tsx",
+      "norm_label": "auth.tsx",
+      "source_file": "packages/storefront-webapp/src/components/auth/Auth.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1651,
+      "file_type": "code",
       "id": "bagsummary_tobagsummaryitems",
       "label": "toBagSummaryItems()",
       "norm_label": "tobagsummaryitems()",
@@ -210193,7 +210223,7 @@
       "source_location": "L39"
     },
     {
-      "community": 1650,
+      "community": 1651,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_bagsummary_tsx",
       "label": "BagSummary.tsx",
@@ -210202,7 +210232,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1651,
+      "community": 1652,
       "file_type": "code",
       "id": "checkoutform_checkoutform",
       "label": "CheckoutForm()",
@@ -210211,7 +210241,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1651,
+      "community": 1652,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutform_tsx",
       "label": "CheckoutForm.tsx",
@@ -210220,7 +210250,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1652,
+      "community": 1653,
       "file_type": "code",
       "id": "checkoutprovider_checkoutprovider",
       "label": "CheckoutProvider()",
@@ -210229,7 +210259,7 @@
       "source_location": "L71"
     },
     {
-      "community": 1652,
+      "community": 1653,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_checkoutprovider_tsx",
       "label": "CheckoutProvider.tsx",
@@ -210238,7 +210268,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1653,
+      "community": 1654,
       "file_type": "code",
       "id": "enteredbillingaddressdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -210247,7 +210277,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1653,
+      "community": 1654,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_enteredbillingaddressdetails_tsx",
       "label": "EnteredBillingAddressDetails.tsx",
@@ -210256,7 +210286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1654,
+      "community": 1655,
       "file_type": "code",
       "id": "ordersummary_ordersummary",
       "label": "OrderSummary()",
@@ -210265,7 +210295,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1654,
+      "community": 1655,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_ordersummary_tsx",
       "label": "OrderSummary.tsx",
@@ -210274,7 +210304,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1655,
+      "community": 1656,
       "file_type": "code",
       "id": "index_pickupdetails",
       "label": "PickupDetails()",
@@ -210283,7 +210313,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1655,
+      "community": 1656,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_orderdetails_index_tsx",
       "label": "index.tsx",
@@ -210292,7 +210322,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1656,
+      "community": 1657,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentmethodsection_tsx",
       "label": "PaymentMethodSection.tsx",
@@ -210301,7 +210331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1656,
+      "community": 1657,
       "file_type": "code",
       "id": "paymentmethodsection_paymentmethodsection",
       "label": "PaymentMethodSection()",
@@ -210310,7 +210340,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1657,
+      "community": 1658,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_paymentsection_tsx",
       "label": "PaymentSection.tsx",
@@ -210319,7 +210349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1657,
+      "community": 1658,
       "file_type": "code",
       "id": "paymentsection_paymentsection",
       "label": "PaymentSection()",
@@ -210328,7 +210358,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1658,
+      "community": 1659,
       "file_type": "code",
       "id": "deliveryfees_calculatedeliveryfee",
       "label": "calculateDeliveryFee()",
@@ -210337,30 +210367,12 @@
       "source_location": "L40"
     },
     {
-      "community": 1658,
+      "community": 1659,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_deliveryfees_ts",
       "label": "deliveryFees.ts",
       "norm_label": "deliveryfees.ts",
       "source_file": "packages/storefront-webapp/src/components/checkout/deliveryFees.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1659,
-      "file_type": "code",
-      "id": "derivecheckoutstate_derivecheckoutstate",
-      "label": "deriveCheckoutState()",
-      "norm_label": "derivecheckoutstate()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
-      "source_location": "L3"
-    },
-    {
-      "community": 1659,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
-      "label": "deriveCheckoutState.ts",
-      "norm_label": "derivecheckoutstate.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
       "source_location": "L1"
     },
     {
@@ -210501,6 +210513,24 @@
     {
       "community": 1660,
       "file_type": "code",
+      "id": "derivecheckoutstate_derivecheckoutstate",
+      "label": "deriveCheckoutState()",
+      "norm_label": "derivecheckoutstate()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L3"
+    },
+    {
+      "community": 1660,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_checkout_derivecheckoutstate_ts",
+      "label": "deriveCheckoutState.ts",
+      "norm_label": "derivecheckoutstate.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/deriveCheckoutState.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1661,
+      "file_type": "code",
       "id": "checkoutschemas_test_getissuemap",
       "label": "getIssueMap()",
       "norm_label": "getissuemap()",
@@ -210508,7 +210538,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1660,
+      "community": 1661,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_checkoutschemas_test_ts",
       "label": "checkoutSchemas.test.ts",
@@ -210517,7 +210547,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1661,
+      "community": 1662,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_schemas_weborderschema_test_ts",
       "label": "webOrderSchema.test.ts",
@@ -210526,7 +210556,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1661,
+      "community": 1662,
       "file_type": "code",
       "id": "weborderschema_test_getissuemap",
       "label": "getIssueMap()",
@@ -210535,7 +210565,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1662,
+      "community": 1663,
       "file_type": "code",
       "id": "customerdetailsform_onsubmit",
       "label": "onSubmit()",
@@ -210544,7 +210574,7 @@
       "source_location": "L77"
     },
     {
-      "community": 1662,
+      "community": 1663,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_customerdetailsform_tsx",
       "label": "CustomerDetailsForm.tsx",
@@ -210553,7 +210583,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1663,
+      "community": 1664,
       "file_type": "code",
       "id": "deliverydetailsform_onsubmit",
       "label": "onSubmit()",
@@ -210562,7 +210592,7 @@
       "source_location": "L161"
     },
     {
-      "community": 1663,
+      "community": 1664,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_forms_deliverydetailsform_tsx",
       "label": "DeliveryDetailsForm.tsx",
@@ -210571,7 +210601,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1664,
+      "community": 1665,
       "file_type": "code",
       "id": "hooks_usecountdown",
       "label": "useCountdown()",
@@ -210580,7 +210610,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1664,
+      "community": 1665,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_common_hooks_ts",
       "label": "hooks.ts",
@@ -210589,7 +210619,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1665,
+      "community": 1666,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_communication_trustsignals_tsx",
       "label": "TrustSignals.tsx",
@@ -210598,7 +210628,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1665,
+      "community": 1666,
       "file_type": "code",
       "id": "trustsignals_trustsignals",
       "label": "TrustSignals()",
@@ -210607,7 +210637,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1666,
+      "community": 1667,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_filter_productfilter_tsx",
       "label": "ProductFilter.tsx",
@@ -210616,7 +210646,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1666,
+      "community": 1667,
       "file_type": "code",
       "id": "productfilter_productfilter",
       "label": "ProductFilter()",
@@ -210625,7 +210655,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1667,
+      "community": 1668,
       "file_type": "code",
       "id": "filter_handlecheckboxchange",
       "label": "handleCheckboxChange()",
@@ -210634,7 +210664,7 @@
       "source_location": "L27"
     },
     {
-      "community": 1667,
+      "community": 1668,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_footer_filter_tsx",
       "label": "Filter.tsx",
@@ -210643,7 +210673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1668,
+      "community": 1669,
       "file_type": "code",
       "id": "bestsellerssection_bestsellerssection",
       "label": "BestSellersSection()",
@@ -210652,30 +210682,12 @@
       "source_location": "L18"
     },
     {
-      "community": 1668,
+      "community": 1669,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_bestsellerssection_tsx",
       "label": "BestSellersSection.tsx",
       "norm_label": "bestsellerssection.tsx",
       "source_file": "packages/storefront-webapp/src/components/home/BestSellersSection.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1669,
-      "file_type": "code",
-      "id": "bagmenu_handleonlinkclick",
-      "label": "handleOnLinkClick()",
-      "norm_label": "handleonlinkclick()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 1669,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
-      "label": "BagMenu.tsx",
-      "norm_label": "bagmenu.tsx",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
       "source_location": "L1"
     },
     {
@@ -210816,6 +210828,24 @@
     {
       "community": 1670,
       "file_type": "code",
+      "id": "bagmenu_handleonlinkclick",
+      "label": "handleOnLinkClick()",
+      "norm_label": "handleonlinkclick()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 1670,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_bagmenu_tsx",
+      "label": "BagMenu.tsx",
+      "norm_label": "bagmenu.tsx",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/BagMenu.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1671,
+      "file_type": "code",
       "id": "mobilebagmenu_mobilebagmenu",
       "label": "MobileBagMenu()",
       "norm_label": "mobilebagmenu()",
@@ -210823,7 +210853,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1670,
+      "community": 1671,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_mobilebagmenu_tsx",
       "label": "MobileBagMenu.tsx",
@@ -210832,7 +210862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1671,
+      "community": 1672,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_navigation_bar_sitebanner_tsx",
       "label": "SiteBanner.tsx",
@@ -210841,7 +210871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1671,
+      "community": 1672,
       "file_type": "code",
       "id": "sitebanner_sitebanner",
       "label": "SiteBanner()",
@@ -210850,7 +210880,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1672,
+      "community": 1673,
       "file_type": "code",
       "id": "notificationpill_notificationpill",
       "label": "NotificationPill()",
@@ -210859,7 +210889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1672,
+      "community": 1673,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_notification_notificationpill_tsx",
       "label": "NotificationPill.tsx",
@@ -210868,7 +210898,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1673,
+      "community": 1674,
       "file_type": "code",
       "id": "dimensionbar_mapvaluetolabelindex",
       "label": "mapValueToLabelIndex()",
@@ -210877,7 +210907,7 @@
       "source_location": "L12"
     },
     {
-      "community": 1673,
+      "community": 1674,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_dimensionbar_tsx",
       "label": "DimensionBar.tsx",
@@ -210886,7 +210916,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1674,
+      "community": 1675,
       "file_type": "code",
       "id": "discountbadge_discountbadge",
       "label": "DiscountBadge()",
@@ -210895,7 +210925,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1674,
+      "community": 1675,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_discountbadge_tsx",
       "label": "DiscountBadge.tsx",
@@ -210904,7 +210934,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1675,
+      "community": 1676,
       "file_type": "code",
       "id": "galleryviewer_handleclickonpreview",
       "label": "handleClickOnPreview()",
@@ -210913,7 +210943,7 @@
       "source_location": "L45"
     },
     {
-      "community": 1675,
+      "community": 1676,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_galleryviewer_tsx",
       "label": "GalleryViewer.tsx",
@@ -210922,7 +210952,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1676,
+      "community": 1677,
       "file_type": "code",
       "id": "onsaleproduct_onsaleproduct",
       "label": "OnsaleProduct()",
@@ -210931,7 +210961,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1676,
+      "community": 1677,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_onsaleproduct_tsx",
       "label": "OnSaleProduct.tsx",
@@ -210940,7 +210970,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1677,
+      "community": 1678,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productactions_tsx",
       "label": "ProductActions.tsx",
@@ -210949,7 +210979,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1677,
+      "community": 1678,
       "file_type": "code",
       "id": "productactions_productactions",
       "label": "ProductActions()",
@@ -210958,7 +210988,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1678,
+      "community": 1679,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productattributes_tsx",
       "label": "ProductAttributes.tsx",
@@ -210967,31 +210997,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1678,
+      "community": 1679,
       "file_type": "code",
       "id": "productattributes_productattributes",
       "label": "ProductAttributes()",
       "norm_label": "productattributes()",
       "source_file": "packages/storefront-webapp/src/components/product-page/ProductAttributes.tsx",
       "source_location": "L3"
-    },
-    {
-      "community": 1679,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
-      "label": "ProductPage.test.tsx",
-      "norm_label": "productpage.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1679,
-      "file_type": "code",
-      "id": "productpage_test_makepagestate",
-      "label": "makePageState()",
-      "norm_label": "makepagestate()",
-      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
-      "source_location": "L37"
     },
     {
       "community": 168,
@@ -211131,6 +211143,24 @@
     {
       "community": 1680,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_product_page_productpage_test_tsx",
+      "label": "ProductPage.test.tsx",
+      "norm_label": "productpage.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1680,
+      "file_type": "code",
+      "id": "productpage_test_makepagestate",
+      "label": "makePageState()",
+      "norm_label": "makepagestate()",
+      "source_file": "packages/storefront-webapp/src/components/product-page/ProductPage.test.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 1681,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productpage_tsx",
       "label": "ProductPage.tsx",
       "norm_label": "productpage.tsx",
@@ -211138,7 +211168,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1680,
+      "community": 1681,
       "file_type": "code",
       "id": "productpage_showshippingpolicy",
       "label": "showShippingPolicy()",
@@ -211147,7 +211177,7 @@
       "source_location": "L79"
     },
     {
-      "community": 1681,
+      "community": 1682,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_productreview_tsx",
       "label": "ProductReview.tsx",
@@ -211156,7 +211186,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1681,
+      "community": 1682,
       "file_type": "code",
       "id": "productreview_handlehelpful",
       "label": "handleHelpful()",
@@ -211165,7 +211195,7 @@
       "source_location": "L87"
     },
     {
-      "community": 1682,
+      "community": 1683,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_reviewsummary_tsx",
       "label": "ReviewSummary.tsx",
@@ -211174,7 +211204,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1682,
+      "community": 1683,
       "file_type": "code",
       "id": "reviewsummary_reviewsummary",
       "label": "ReviewSummary()",
@@ -211183,7 +211213,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1683,
+      "community": 1684,
       "file_type": "code",
       "id": "orderitem_orderitem",
       "label": "OrderItem()",
@@ -211192,7 +211222,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1683,
+      "community": 1684,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_orderitem_tsx",
       "label": "OrderItem.tsx",
@@ -211201,7 +211231,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1684,
+      "community": 1685,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_reviews_ratingselector_tsx",
       "label": "RatingSelector.tsx",
@@ -211210,7 +211240,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1684,
+      "community": 1685,
       "file_type": "code",
       "id": "ratingselector_ratingselector",
       "label": "RatingSelector()",
@@ -211219,7 +211249,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1685,
+      "community": 1686,
       "file_type": "code",
       "id": "guestrewardsprompt_guestrewardsprompt",
       "label": "GuestRewardsPrompt()",
@@ -211228,7 +211258,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1685,
+      "community": 1686,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_guestrewardsprompt_tsx",
       "label": "GuestRewardsPrompt.tsx",
@@ -211237,7 +211267,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1686,
+      "community": 1687,
       "file_type": "code",
       "id": "orderpointsdisplay_orderpointsdisplay",
       "label": "OrderPointsDisplay()",
@@ -211246,7 +211276,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1686,
+      "community": 1687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_orderpointsdisplay_tsx",
       "label": "OrderPointsDisplay.tsx",
@@ -211255,7 +211285,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1687,
+      "community": 1688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_pastordersrewards_tsx",
       "label": "PastOrdersRewards.tsx",
@@ -211264,7 +211294,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1687,
+      "community": 1688,
       "file_type": "code",
       "id": "pastordersrewards_handleclaimpoints",
       "label": "handleClaimPoints()",
@@ -211273,7 +211303,7 @@
       "source_location": "L60"
     },
     {
-      "community": 1688,
+      "community": 1689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_rewards_rewardspanel_tsx",
       "label": "RewardsPanel.tsx",
@@ -211282,31 +211312,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1688,
+      "community": 1689,
       "file_type": "code",
       "id": "rewardspanel_handleredeemreward",
       "label": "handleRedeemReward()",
       "norm_label": "handleredeemreward()",
       "source_file": "packages/storefront-webapp/src/components/rewards/RewardsPanel.tsx",
       "source_location": "L33"
-    },
-    {
-      "community": 1689,
-      "file_type": "code",
-      "id": "bagitem_bagitem",
-      "label": "BagItem()",
-      "norm_label": "bagitem()",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L20"
-    },
-    {
-      "community": 1689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
-      "label": "BagItem.tsx",
-      "norm_label": "bagitem.tsx",
-      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
-      "source_location": "L1"
     },
     {
       "community": 169,
@@ -211446,6 +211458,24 @@
     {
       "community": 1690,
       "file_type": "code",
+      "id": "bagitem_bagitem",
+      "label": "BagItem()",
+      "norm_label": "bagitem()",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L20"
+    },
+    {
+      "community": 1690,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_shopping_bag_bagitem_tsx",
+      "label": "BagItem.tsx",
+      "norm_label": "bagitem.tsx",
+      "source_file": "packages/storefront-webapp/src/components/shopping-bag/BagItem.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1691,
+      "file_type": "code",
       "id": "checkoutunavailable_checkoutunavailable",
       "label": "CheckoutUnavailable()",
       "norm_label": "checkoutunavailable()",
@@ -211453,7 +211483,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1690,
+      "community": 1691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_unavailable_checkoutunavailable_tsx",
       "label": "CheckoutUnavailable.tsx",
@@ -211462,7 +211492,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1691,
+      "community": 1692,
       "file_type": "code",
       "id": "errorboundary_errorboundary",
       "label": "ErrorBoundary()",
@@ -211471,7 +211501,7 @@
       "source_location": "L22"
     },
     {
-      "community": 1691,
+      "community": 1692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_error_errorboundary_tsx",
       "label": "ErrorBoundary.tsx",
@@ -211480,7 +211510,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1692,
+      "community": 1693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_scrolldownbutton_tsx",
       "label": "ScrollDownButton.tsx",
@@ -211489,7 +211519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1692,
+      "community": 1693,
       "file_type": "code",
       "id": "scrolldownbutton_scrolldownbutton",
       "label": "ScrollDownButton()",
@@ -211498,7 +211528,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1693,
+      "community": 1694,
       "file_type": "code",
       "id": "country_select_countryselect",
       "label": "CountrySelect()",
@@ -211507,7 +211537,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1693,
+      "community": 1694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_country_select_tsx",
       "label": "country-select.tsx",
@@ -211516,7 +211546,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1694,
+      "community": 1695,
       "file_type": "code",
       "id": "ghana_region_select_ghanaregionselect",
       "label": "GhanaRegionSelect()",
@@ -211525,7 +211555,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1694,
+      "community": 1695,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghana_region_select_tsx",
       "label": "ghana-region-select.tsx",
@@ -211534,7 +211564,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1695,
+      "community": 1696,
       "file_type": "code",
       "id": "ghost_button_ghostbutton",
       "label": "GhostButton()",
@@ -211543,7 +211573,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1695,
+      "community": 1696,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_ghost_button_tsx",
       "label": "ghost-button.tsx",
@@ -211552,7 +211582,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1696,
+      "community": 1697,
       "file_type": "code",
       "id": "leaveareviewmodal_handleclose",
       "label": "handleClose()",
@@ -211561,7 +211591,7 @@
       "source_location": "L66"
     },
     {
-      "community": 1696,
+      "community": 1697,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_leaveareviewmodal_tsx",
       "label": "LeaveAReviewModal.tsx",
@@ -211570,7 +211600,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1697,
+      "community": 1698,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_upsellmodalsuccess_tsx",
       "label": "UpsellModalSuccess.tsx",
@@ -211579,7 +211609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1697,
+      "community": 1698,
       "file_type": "code",
       "id": "upsellmodalsuccess_upsellmodalsuccess",
       "label": "UpsellModalSuccess()",
@@ -211588,7 +211618,7 @@
       "source_location": "L19"
     },
     {
-      "community": 1698,
+      "community": 1699,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_welcomebackmodalsuccess_tsx",
       "label": "WelcomeBackModalSuccess.tsx",
@@ -211597,31 +211627,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1698,
+      "community": 1699,
       "file_type": "code",
       "id": "welcomebackmodalsuccess_welcomebackmodalsuccess",
       "label": "WelcomeBackModalSuccess()",
       "norm_label": "welcomebackmodalsuccess()",
       "source_file": "packages/storefront-webapp/src/components/ui/modals/WelcomeBackModalSuccess.tsx",
       "source_location": "L13"
-    },
-    {
-      "community": 1699,
-      "file_type": "code",
-      "id": "leavereviewmodalconfig_getmodalconfig",
-      "label": "getModalConfig()",
-      "norm_label": "getmodalconfig()",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 1699,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
-      "label": "leaveReviewModalConfig.tsx",
-      "norm_label": "leavereviewmodalconfig.tsx",
-      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
-      "source_location": "L1"
     },
     {
       "community": 17,
@@ -212139,6 +212151,24 @@
     {
       "community": 1700,
       "file_type": "code",
+      "id": "leavereviewmodalconfig_getmodalconfig",
+      "label": "getModalConfig()",
+      "norm_label": "getmodalconfig()",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 1700,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_ui_modals_config_leavereviewmodalconfig_tsx",
+      "label": "leaveReviewModalConfig.tsx",
+      "norm_label": "leavereviewmodalconfig.tsx",
+      "source_file": "packages/storefront-webapp/src/components/ui/modals/config/leaveReviewModalConfig.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1701,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_modals_config_welcomebackmodalconfig_tsx",
       "label": "welcomeBackModalConfig.tsx",
       "norm_label": "welcomebackmodalconfig.tsx",
@@ -212146,7 +212176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1700,
+      "community": 1701,
       "file_type": "code",
       "id": "welcomebackmodalconfig_getmodalconfig",
       "label": "getModalConfig()",
@@ -212155,7 +212185,7 @@
       "source_location": "L46"
     },
     {
-      "community": 1701,
+      "community": 1702,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_webp_jpg_tsx",
       "label": "webp-jpg.tsx",
@@ -212164,7 +212194,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1701,
+      "community": 1702,
       "file_type": "code",
       "id": "webp_jpg_webpimage",
       "label": "WebpImage()",
@@ -212173,7 +212203,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1702,
+      "community": 1703,
       "file_type": "code",
       "id": "formsubmissionprovider_useformsubmission",
       "label": "useFormSubmission()",
@@ -212182,7 +212212,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1702,
+      "community": 1703,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_contexts_formsubmissionprovider_tsx",
       "label": "FormSubmissionProvider.tsx",
@@ -212191,7 +212221,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1703,
+      "community": 1704,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usecheckout_ts",
       "label": "useCheckout.ts",
@@ -212200,7 +212230,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1703,
+      "community": 1704,
       "file_type": "code",
       "id": "usecheckout_usecheckout",
       "label": "useCheckout()",
@@ -212209,7 +212239,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1704,
+      "community": 1705,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usediscountcodealert_tsx",
       "label": "useDiscountCodeAlert.tsx",
@@ -212218,7 +212248,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1704,
+      "community": 1705,
       "file_type": "code",
       "id": "usediscountcodealert_usediscountcodealert",
       "label": "useDiscountCodeAlert()",
@@ -212227,7 +212257,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1705,
+      "community": 1706,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useenhancedtracking_ts",
       "label": "useEnhancedTracking.ts",
@@ -212236,7 +212266,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1705,
+      "community": 1706,
       "file_type": "code",
       "id": "useenhancedtracking_useenhancedtracking",
       "label": "useEnhancedTracking()",
@@ -212245,7 +212275,7 @@
       "source_location": "L29"
     },
     {
-      "community": 1706,
+      "community": 1707,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetactivecheckoutsession_tsx",
       "label": "useGetActiveCheckoutSession.tsx",
@@ -212254,7 +212284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1706,
+      "community": 1707,
       "file_type": "code",
       "id": "usegetactivecheckoutsession_usegetactivecheckoutsession",
       "label": "useGetActiveCheckoutSession()",
@@ -212263,7 +212293,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1707,
+      "community": 1708,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproduct_tsx",
       "label": "useGetProduct.tsx",
@@ -212272,7 +212302,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1707,
+      "community": 1708,
       "file_type": "code",
       "id": "usegetproduct_usegetproductquery",
       "label": "useGetProductQuery()",
@@ -212281,7 +212311,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1708,
+      "community": 1709,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetproductfilters_ts",
       "label": "useGetProductFilters.ts",
@@ -212290,31 +212320,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1708,
+      "community": 1709,
       "file_type": "code",
       "id": "usegetproductfilters_usegetproductfilters",
       "label": "useGetProductFilters()",
       "norm_label": "usegetproductfilters()",
       "source_file": "packages/storefront-webapp/src/hooks/useGetProductFilters.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 1709,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
-      "label": "useGetProductReviews.ts",
-      "norm_label": "usegetproductreviews.ts",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1709,
-      "file_type": "code",
-      "id": "usegetproductreviews_usegetproductreviewsquery",
-      "label": "useGetProductReviewsQuery()",
-      "norm_label": "usegetproductreviewsquery()",
-      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
-      "source_location": "L4"
     },
     {
       "community": 171,
@@ -212445,6 +212457,24 @@
     {
       "community": 1710,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_usegetproductreviews_ts",
+      "label": "useGetProductReviews.ts",
+      "norm_label": "usegetproductreviews.ts",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1710,
+      "file_type": "code",
+      "id": "usegetproductreviews_usegetproductreviewsquery",
+      "label": "useGetProductReviewsQuery()",
+      "norm_label": "usegetproductreviewsquery()",
+      "source_file": "packages/storefront-webapp/src/hooks/useGetProductReviews.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 1711,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usegetstore_ts",
       "label": "useGetStore.ts",
       "norm_label": "usegetstore.ts",
@@ -212452,7 +212482,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1710,
+      "community": 1711,
       "file_type": "code",
       "id": "usegetstore_usegetstore",
       "label": "useGetStore()",
@@ -212461,7 +212491,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1711,
+      "community": 1712,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useinventorystatus_ts",
       "label": "useInventoryStatus.ts",
@@ -212470,7 +212500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1711,
+      "community": 1712,
       "file_type": "code",
       "id": "useinventorystatus_useinventorystatus",
       "label": "useInventoryStatus()",
@@ -212479,7 +212509,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1712,
+      "community": 1713,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useleaveareviewmodal_tsx",
       "label": "useLeaveAReviewModal.tsx",
@@ -212488,7 +212518,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1712,
+      "community": 1713,
       "file_type": "code",
       "id": "useleaveareviewmodal_useleaveareviewmodal",
       "label": "useLeaveAReviewModal()",
@@ -212497,7 +212527,7 @@
       "source_location": "L17"
     },
     {
-      "community": 1713,
+      "community": 1714,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_uselogout_ts",
       "label": "useLogout.ts",
@@ -212506,7 +212536,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1713,
+      "community": 1714,
       "file_type": "code",
       "id": "uselogout_uselogout",
       "label": "useLogout()",
@@ -212515,7 +212545,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1714,
+      "community": 1715,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usemodalstate_tsx",
       "label": "useModalState.tsx",
@@ -212524,7 +212554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1714,
+      "community": 1715,
       "file_type": "code",
       "id": "usemodalstate_usemodalstate",
       "label": "useModalState()",
@@ -212533,7 +212563,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1715,
+      "community": 1716,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductpagelogic_ts",
       "label": "useProductPageLogic.ts",
@@ -212542,7 +212572,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1715,
+      "community": 1716,
       "file_type": "code",
       "id": "useproductpagelogic_useproductpagelogic",
       "label": "useProductPageLogic()",
@@ -212551,7 +212581,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1716,
+      "community": 1717,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useproductreminder_tsx",
       "label": "useProductReminder.tsx",
@@ -212560,7 +212590,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1716,
+      "community": 1717,
       "file_type": "code",
       "id": "useproductreminder_useproductreminder",
       "label": "useProductReminder()",
@@ -212569,7 +212599,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1717,
+      "community": 1718,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usepromoalert_tsx",
       "label": "usePromoAlert.tsx",
@@ -212578,7 +212608,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1717,
+      "community": 1718,
       "file_type": "code",
       "id": "usepromoalert_usepromoalert",
       "label": "usePromoAlert()",
@@ -212587,7 +212617,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1718,
+      "community": 1719,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usequeryenabled_ts",
       "label": "useQueryEnabled.ts",
@@ -212596,31 +212626,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1718,
+      "community": 1719,
       "file_type": "code",
       "id": "usequeryenabled_usequeryenabled",
       "label": "useQueryEnabled()",
       "norm_label": "usequeryenabled()",
       "source_file": "packages/storefront-webapp/src/hooks/useQueryEnabled.ts",
       "source_location": "L3"
-    },
-    {
-      "community": 1719,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
-      "label": "useRewardsAlert.tsx",
-      "norm_label": "userewardsalert.tsx",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1719,
-      "file_type": "code",
-      "id": "userewardsalert_userewardsalert",
-      "label": "useRewardsAlert()",
-      "norm_label": "userewardsalert()",
-      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
-      "source_location": "L11"
     },
     {
       "community": 172,
@@ -212751,6 +212763,24 @@
     {
       "community": 1720,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_hooks_userewardsalert_tsx",
+      "label": "useRewardsAlert.tsx",
+      "norm_label": "userewardsalert.tsx",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1720,
+      "file_type": "code",
+      "id": "userewardsalert_userewardsalert",
+      "label": "useRewardsAlert()",
+      "norm_label": "userewardsalert()",
+      "source_file": "packages/storefront-webapp/src/hooks/useRewardsAlert.tsx",
+      "source_location": "L11"
+    },
+    {
+      "community": 1721,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usescrolltotop_ts",
       "label": "useScrollToTop.ts",
       "norm_label": "usescrolltotop.ts",
@@ -212758,7 +212788,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1720,
+      "community": 1721,
       "file_type": "code",
       "id": "usescrolltotop_usescrolltotop",
       "label": "useScrollToTop()",
@@ -212767,7 +212797,7 @@
       "source_location": "L3"
     },
     {
-      "community": 1721,
+      "community": 1722,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackaction_ts",
       "label": "useTrackAction.ts",
@@ -212776,7 +212806,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1721,
+      "community": 1722,
       "file_type": "code",
       "id": "usetrackaction_usetrackaction",
       "label": "useTrackAction()",
@@ -212785,7 +212815,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1722,
+      "community": 1723,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_usetrackevent_ts",
       "label": "useTrackEvent.ts",
@@ -212794,7 +212824,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1722,
+      "community": 1723,
       "file_type": "code",
       "id": "usetrackevent_usetrackevent",
       "label": "useTrackEvent()",
@@ -212803,7 +212833,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1723,
+      "community": 1724,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_hooks_useupsellmodal_tsx",
       "label": "useUpsellModal.tsx",
@@ -212812,7 +212842,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1723,
+      "community": 1724,
       "file_type": "code",
       "id": "useupsellmodal_useupsellmodal",
       "label": "useUpsellModal()",
@@ -212821,7 +212851,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1724,
+      "community": 1725,
       "file_type": "code",
       "id": "analytics_usepostanalytics",
       "label": "usePostAnalytics()",
@@ -212830,7 +212860,7 @@
       "source_location": "L4"
     },
     {
-      "community": 1724,
+      "community": 1725,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_mutations_ts_analytics_ts",
       "label": "analytics.ts",
@@ -212839,7 +212869,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1725,
+      "community": 1726,
       "file_type": "code",
       "id": "bag_usebagqueries",
       "label": "useBagQueries()",
@@ -212848,7 +212878,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1725,
+      "community": 1726,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bag_ts",
       "label": "bag.ts",
@@ -212857,7 +212887,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1726,
+      "community": 1727,
       "file_type": "code",
       "id": "bannermessage_usebannermessagequeries",
       "label": "useBannerMessageQueries()",
@@ -212866,7 +212896,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1726,
+      "community": 1727,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_bannermessage_ts",
       "label": "bannerMessage.ts",
@@ -212875,7 +212905,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1727,
+      "community": 1728,
       "file_type": "code",
       "id": "checkout_usecheckoutsessionqueries",
       "label": "useCheckoutSessionQueries()",
@@ -212884,7 +212914,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1727,
+      "community": 1728,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_checkout_ts",
       "label": "checkout.ts",
@@ -212893,7 +212923,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1728,
+      "community": 1729,
       "file_type": "code",
       "id": "homepagesnapshot_usehomepagesnapshotqueries",
       "label": "useHomepageSnapshotQueries()",
@@ -212902,30 +212932,12 @@
       "source_location": "L11"
     },
     {
-      "community": 1728,
+      "community": 1729,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_homepagesnapshot_ts",
       "label": "homepageSnapshot.ts",
       "norm_label": "homepagesnapshot.ts",
       "source_file": "packages/storefront-webapp/src/lib/queries/homepageSnapshot.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1729,
-      "file_type": "code",
-      "id": "inventory_useinventoryqueries",
-      "label": "useInventoryQueries()",
-      "norm_label": "useinventoryqueries()",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 1729,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
-      "label": "inventory.ts",
-      "norm_label": "inventory.ts",
-      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
       "source_location": "L1"
     },
     {
@@ -213057,6 +213069,24 @@
     {
       "community": 1730,
       "file_type": "code",
+      "id": "inventory_useinventoryqueries",
+      "label": "useInventoryQueries()",
+      "norm_label": "useinventoryqueries()",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 1730,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_queries_inventory_ts",
+      "label": "inventory.ts",
+      "norm_label": "inventory.ts",
+      "source_file": "packages/storefront-webapp/src/lib/queries/inventory.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1731,
+      "file_type": "code",
       "id": "onlineorder_useonlineorderqueries",
       "label": "useOnlineOrderQueries()",
       "norm_label": "useonlineorderqueries()",
@@ -213064,7 +213094,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1730,
+      "community": 1731,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -213073,7 +213103,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1731,
+      "community": 1732,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_postransaction_ts",
       "label": "posTransaction.ts",
@@ -213082,7 +213112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1731,
+      "community": 1732,
       "file_type": "code",
       "id": "postransaction_usepostransactionqueries",
       "label": "usePosTransactionQueries()",
@@ -213091,7 +213121,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1732,
+      "community": 1733,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_product_ts",
       "label": "product.ts",
@@ -213100,7 +213130,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1732,
+      "community": 1733,
       "file_type": "code",
       "id": "product_useproductqueries",
       "label": "useProductQueries()",
@@ -213109,7 +213139,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1733,
+      "community": 1734,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_promocode_ts",
       "label": "promoCode.ts",
@@ -213118,7 +213148,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1733,
+      "community": 1734,
       "file_type": "code",
       "id": "promocode_usepromocodesqueries",
       "label": "usePromoCodesQueries()",
@@ -213127,7 +213157,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1734,
+      "community": 1735,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_reviews_ts",
       "label": "reviews.ts",
@@ -213136,7 +213166,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1734,
+      "community": 1735,
       "file_type": "code",
       "id": "reviews_usereviewqueries",
       "label": "useReviewQueries()",
@@ -213145,7 +213175,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1735,
+      "community": 1736,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_rewards_ts",
       "label": "rewards.ts",
@@ -213154,7 +213184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1735,
+      "community": 1736,
       "file_type": "code",
       "id": "rewards_userewardsqueries",
       "label": "useRewardsQueries()",
@@ -213163,7 +213193,7 @@
       "source_location": "L11"
     },
     {
-      "community": 1736,
+      "community": 1737,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_upsells_ts",
       "label": "upsells.ts",
@@ -213172,7 +213202,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1736,
+      "community": 1737,
       "file_type": "code",
       "id": "upsells_useupsellsqueries",
       "label": "useUpsellsQueries()",
@@ -213181,7 +213211,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1737,
+      "community": 1738,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_user_ts",
       "label": "user.ts",
@@ -213190,7 +213220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1737,
+      "community": 1738,
       "file_type": "code",
       "id": "user_useuserqueries",
       "label": "useUserQueries()",
@@ -213199,7 +213229,7 @@
       "source_location": "L5"
     },
     {
-      "community": 1738,
+      "community": 1739,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_queries_useroffers_ts",
       "label": "userOffers.ts",
@@ -213208,31 +213238,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1738,
+      "community": 1739,
       "file_type": "code",
       "id": "useroffers_useuseroffersqueries",
       "label": "useUserOffersQueries()",
       "norm_label": "useuseroffersqueries()",
       "source_file": "packages/storefront-webapp/src/lib/queries/userOffers.ts",
       "source_location": "L6"
-    },
-    {
-      "community": 1739,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
-      "label": "storeConfig.test.ts",
-      "norm_label": "storeconfig.test.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1739,
-      "file_type": "code",
-      "id": "storeconfig_test_buildv2config",
-      "label": "buildV2Config()",
-      "norm_label": "buildv2config()",
-      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
-      "source_location": "L10"
     },
     {
       "community": 174,
@@ -213363,6 +213375,24 @@
     {
       "community": 1740,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storeconfig_test_ts",
+      "label": "storeConfig.test.ts",
+      "norm_label": "storeconfig.test.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1740,
+      "file_type": "code",
+      "id": "storeconfig_test_buildv2config",
+      "label": "buildV2Config()",
+      "norm_label": "buildv2config()",
+      "source_file": "packages/storefront-webapp/src/lib/storeConfig.test.ts",
+      "source_location": "L10"
+    },
+    {
+      "community": 1741,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_storefrontobservability_test_ts",
       "label": "storefrontObservability.test.ts",
       "norm_label": "storefrontobservability.test.ts",
@@ -213370,7 +213400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1740,
+      "community": 1741,
       "file_type": "code",
       "id": "storefrontobservability_test_creatememorystorage",
       "label": "createMemoryStorage()",
@@ -213379,7 +213409,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1741,
+      "community": 1742,
       "file_type": "code",
       "id": "email_validateemail",
       "label": "validateEmail()",
@@ -213388,7 +213418,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1741,
+      "community": 1742,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_validations_email_ts",
       "label": "email.ts",
@@ -213397,7 +213427,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1742,
+      "community": 1743,
       "file_type": "code",
       "id": "main_app",
       "label": "App()",
@@ -213406,7 +213436,7 @@
       "source_location": "L31"
     },
     {
-      "community": 1742,
+      "community": 1743,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_main_tsx",
       "label": "main.tsx",
@@ -213415,7 +213445,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1743,
+      "community": 1744,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_router_tsx",
       "label": "router.tsx",
@@ -213424,7 +213454,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1743,
+      "community": 1744,
       "file_type": "code",
       "id": "router_createrouter",
       "label": "createRouter()",
@@ -213433,7 +213463,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1744,
+      "community": 1745,
       "file_type": "code",
       "id": "homepageloader_loadhomepagedata",
       "label": "loadHomePageData()",
@@ -213442,7 +213472,7 @@
       "source_location": "L15"
     },
     {
-      "community": 1744,
+      "community": 1745,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_homepageloader_ts",
       "label": "-homePageLoader.ts",
@@ -213451,7 +213481,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1745,
+      "community": 1746,
       "file_type": "code",
       "id": "orderslayout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -213460,7 +213490,7 @@
       "source_location": "L8"
     },
     {
-      "community": 1745,
+      "community": 1746,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_orderslayout_tsx",
       "label": "_ordersLayout.tsx",
@@ -213469,7 +213499,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1746,
+      "community": 1747,
       "file_type": "code",
       "id": "contact_us_contactus",
       "label": "ContactUs()",
@@ -213478,7 +213508,7 @@
       "source_location": "L14"
     },
     {
-      "community": 1746,
+      "community": 1747,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_contact_us_tsx",
       "label": "contact-us.tsx",
@@ -213487,7 +213517,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1747,
+      "community": 1748,
       "file_type": "code",
       "id": "delivery_returns_exchanges_index_onlineorderpolicy",
       "label": "OnlineOrderPolicy()",
@@ -213496,7 +213526,7 @@
       "source_location": "L13"
     },
     {
-      "community": 1747,
+      "community": 1748,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_delivery_returns_exchanges_index_tsx",
       "label": "delivery-returns-exchanges.index.tsx",
@@ -213505,7 +213535,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1748,
+      "community": 1749,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_policies_privacy_index_tsx",
       "label": "privacy.index.tsx",
@@ -213514,31 +213544,13 @@
       "source_location": "L1"
     },
     {
-      "community": 1748,
+      "community": 1749,
       "file_type": "code",
       "id": "privacy_index_privacypolicy",
       "label": "PrivacyPolicy()",
       "norm_label": "privacypolicy()",
       "source_file": "packages/storefront-webapp/src/routes/_layout/policies/privacy.index.tsx",
       "source_location": "L9"
-    },
-    {
-      "community": 1749,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
-      "label": "tos.index.tsx",
-      "norm_label": "tos.index.tsx",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1749,
-      "file_type": "code",
-      "id": "tos_index_tossection",
-      "label": "TosSection()",
-      "norm_label": "tossection()",
-      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
-      "source_location": "L15"
     },
     {
       "community": 175,
@@ -213669,6 +213681,24 @@
     {
       "community": 1750,
       "file_type": "code",
+      "id": "packages_storefront_webapp_src_routes_layout_policies_tos_index_tsx",
+      "label": "tos.index.tsx",
+      "norm_label": "tos.index.tsx",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1750,
+      "file_type": "code",
+      "id": "tos_index_tossection",
+      "label": "TosSection()",
+      "norm_label": "tossection()",
+      "source_file": "packages/storefront-webapp/src/routes/_layout/policies/tos.index.tsx",
+      "source_location": "L15"
+    },
+    {
+      "community": 1751,
+      "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_shop_product_productslug_tsx",
       "label": "shop.product.$productSlug.tsx",
       "norm_label": "shop.product.$productslug.tsx",
@@ -213676,7 +213706,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1750,
+      "community": 1751,
       "file_type": "code",
       "id": "shop_product_productslug_component",
       "label": "Component()",
@@ -213685,7 +213715,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1751,
+      "community": 1752,
       "file_type": "code",
       "id": "layout_layoutcomponent",
       "label": "LayoutComponent()",
@@ -213694,7 +213724,7 @@
       "source_location": "L6"
     },
     {
-      "community": 1751,
+      "community": 1752,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_layout_tsx",
       "label": "_layout.tsx",
@@ -213703,7 +213733,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1752,
+      "community": 1753,
       "file_type": "code",
       "id": "index_homeroute",
       "label": "HomeRoute()",
@@ -213712,7 +213742,7 @@
       "source_location": "L10"
     },
     {
-      "community": 1752,
+      "community": 1753,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_index_tsx",
       "label": "index.tsx",
@@ -213721,7 +213751,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1753,
+      "community": 1754,
       "file_type": "code",
       "id": "canceled_checkoutcanceledview",
       "label": "CheckoutCanceledView()",
@@ -213730,7 +213760,7 @@
       "source_location": "L21"
     },
     {
-      "community": 1753,
+      "community": 1754,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_sessionidslug_canceled_tsx",
       "label": "canceled.tsx",
@@ -213739,7 +213769,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1754,
+      "community": 1755,
       "file_type": "code",
       "id": "complete_index_checkoutcomplete",
       "label": "CheckoutComplete()",
@@ -213748,7 +213778,7 @@
       "source_location": "L33"
     },
     {
-      "community": 1754,
+      "community": 1755,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_complete_index_tsx",
       "label": "complete.index.tsx",
@@ -213757,7 +213787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1755,
+      "community": 1756,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_checkout_pod_confirmation_tsx",
       "label": "pod-confirmation.tsx",
@@ -213766,7 +213796,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1755,
+      "community": 1756,
       "file_type": "code",
       "id": "pod_confirmation_completepodcheckoutsession",
       "label": "completePODCheckoutSession()",
@@ -213775,7 +213805,7 @@
       "source_location": "L196"
     },
     {
-      "community": 1756,
+      "community": 1757,
       "file_type": "code",
       "id": "index_receiptshareroute",
       "label": "ReceiptShareRoute()",
@@ -213784,7 +213814,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1756,
+      "community": 1757,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_shop_receipt_s_token_index_tsx",
       "label": "index.tsx",
@@ -213793,7 +213823,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1757,
+      "community": 1758,
       "file_type": "code",
       "id": "packages_valkey_proxy_server_test_connection_js",
       "label": "test-connection.js",
@@ -213802,7 +213832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1757,
+      "community": 1758,
       "file_type": "code",
       "id": "test_connection_main",
       "label": "main()",
@@ -213811,7 +213841,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1758,
+      "community": 1759,
       "file_type": "code",
       "id": "architecture_boundaries_test_createsnippetlinter",
       "label": "createSnippetLinter()",
@@ -213820,30 +213850,12 @@
       "source_location": "L10"
     },
     {
-      "community": 1758,
+      "community": 1759,
       "file_type": "code",
       "id": "scripts_architecture_boundaries_test_ts",
       "label": "architecture-boundaries.test.ts",
       "norm_label": "architecture-boundaries.test.ts",
       "source_file": "scripts/architecture-boundaries.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1759,
-      "file_type": "code",
-      "id": "architecture_boundary_check_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/architecture-boundary-check.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 1759,
-      "file_type": "code",
-      "id": "scripts_architecture_boundary_check_ts",
-      "label": "architecture-boundary-check.ts",
-      "norm_label": "architecture-boundary-check.ts",
-      "source_file": "scripts/architecture-boundary-check.ts",
       "source_location": "L1"
     },
     {
@@ -213975,6 +213987,24 @@
     {
       "community": 1760,
       "file_type": "code",
+      "id": "architecture_boundary_check_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 1760,
+      "file_type": "code",
+      "id": "scripts_architecture_boundary_check_ts",
+      "label": "architecture-boundary-check.ts",
+      "norm_label": "architecture-boundary-check.ts",
+      "source_file": "scripts/architecture-boundary-check.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1761,
+      "file_type": "code",
       "id": "deploy_qa_vps_test_readrepofile",
       "label": "readRepoFile()",
       "norm_label": "readrepofile()",
@@ -213982,7 +214012,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1760,
+      "community": 1761,
       "file_type": "code",
       "id": "scripts_deploy_qa_vps_test_ts",
       "label": "deploy-qa-vps.test.ts",
@@ -213991,7 +214021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1761,
+      "community": 1762,
       "file_type": "code",
       "id": "docs_solution_link_check_test_fixture",
       "label": "fixture()",
@@ -214000,7 +214030,7 @@
       "source_location": "L18"
     },
     {
-      "community": 1761,
+      "community": 1762,
       "file_type": "code",
       "id": "scripts_docs_solution_link_check_test_ts",
       "label": "docs-solution-link-check.test.ts",
@@ -214009,7 +214039,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1762,
+      "community": 1763,
       "file_type": "code",
       "id": "documentation_waiver_attestation_test_requestjson",
       "label": "requestJson()",
@@ -214018,7 +214048,7 @@
       "source_location": "L139"
     },
     {
-      "community": 1762,
+      "community": 1763,
       "file_type": "code",
       "id": "scripts_documentation_waiver_attestation_test_ts",
       "label": "documentation-waiver-attestation.test.ts",
@@ -214027,7 +214057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1763,
+      "community": 1764,
       "file_type": "code",
       "id": "documentation_waiver_workflows_test_workflow",
       "label": "workflow()",
@@ -214036,7 +214066,7 @@
       "source_location": "L7"
     },
     {
-      "community": 1763,
+      "community": 1764,
       "file_type": "code",
       "id": "scripts_documentation_waiver_workflows_test_ts",
       "label": "documentation-waiver-workflows.test.ts",
@@ -214045,7 +214075,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1764,
+      "community": 1765,
       "file_type": "code",
       "id": "git_environment_withoutgitrepositorycontext",
       "label": "withoutGitRepositoryContext()",
@@ -214054,7 +214084,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1764,
+      "community": 1765,
       "file_type": "code",
       "id": "scripts_git_environment_ts",
       "label": "git-environment.ts",
@@ -214063,7 +214093,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1765,
+      "community": 1766,
       "file_type": "code",
       "id": "github_pr_merge_test_runcommand",
       "label": "runCommand()",
@@ -214072,7 +214102,7 @@
       "source_location": "L16"
     },
     {
-      "community": 1765,
+      "community": 1766,
       "file_type": "code",
       "id": "scripts_github_pr_merge_test_ts",
       "label": "github-pr-merge.test.ts",
@@ -214081,7 +214111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1766,
+      "community": 1767,
       "file_type": "code",
       "id": "athena_runtime_app_shutdown",
       "label": "shutdown()",
@@ -214090,7 +214120,7 @@
       "source_location": "L211"
     },
     {
-      "community": 1766,
+      "community": 1767,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_athena_runtime_app_ts",
       "label": "athena-runtime-app.ts",
@@ -214099,7 +214129,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1767,
+      "community": 1768,
       "file_type": "code",
       "id": "sample_app_shutdown",
       "label": "shutdown()",
@@ -214108,7 +214138,7 @@
       "source_location": "L85"
     },
     {
-      "community": 1767,
+      "community": 1768,
       "file_type": "code",
       "id": "scripts_harness_behavior_fixtures_sample_app_ts",
       "label": "sample-app.ts",
@@ -214117,7 +214147,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1768,
+      "community": 1769,
       "file_type": "code",
       "id": "harness_runtime_trends_test_buildreportline",
       "label": "buildReportLine()",
@@ -214126,30 +214156,12 @@
       "source_location": "L15"
     },
     {
-      "community": 1768,
+      "community": 1769,
       "file_type": "code",
       "id": "scripts_harness_runtime_trends_test_ts",
       "label": "harness-runtime-trends.test.ts",
       "norm_label": "harness-runtime-trends.test.ts",
       "source_file": "scripts/harness-runtime-trends.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1769,
-      "file_type": "code",
-      "id": "pr_athena_guidance_contract_test_readrepofile",
-      "label": "readRepoFile()",
-      "norm_label": "readrepofile()",
-      "source_file": "scripts/pr-athena-guidance-contract.test.ts",
-      "source_location": "L7"
-    },
-    {
-      "community": 1769,
-      "file_type": "code",
-      "id": "scripts_pr_athena_guidance_contract_test_ts",
-      "label": "pr-athena-guidance-contract.test.ts",
-      "norm_label": "pr-athena-guidance-contract.test.ts",
-      "source_file": "scripts/pr-athena-guidance-contract.test.ts",
       "source_location": "L1"
     },
     {
@@ -214281,6 +214293,24 @@
     {
       "community": 1770,
       "file_type": "code",
+      "id": "pr_athena_guidance_contract_test_readrepofile",
+      "label": "readRepoFile()",
+      "norm_label": "readrepofile()",
+      "source_file": "scripts/pr-athena-guidance-contract.test.ts",
+      "source_location": "L7"
+    },
+    {
+      "community": 1770,
+      "file_type": "code",
+      "id": "scripts_pr_athena_guidance_contract_test_ts",
+      "label": "pr-athena-guidance-contract.test.ts",
+      "norm_label": "pr-athena-guidance-contract.test.ts",
+      "source_file": "scripts/pr-athena-guidance-contract.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1771,
+      "file_type": "code",
       "id": "scripts_validate_plan_html_test_ts",
       "label": "validate-plan-html.test.ts",
       "norm_label": "validate-plan-html.test.ts",
@@ -214288,7 +214318,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1770,
+      "community": 1771,
       "file_type": "code",
       "id": "validate_plan_html_test_createtemprepo",
       "label": "createTempRepo()",
@@ -214297,7 +214327,7 @@
       "source_location": "L9"
     },
     {
-      "community": 1771,
+      "community": 1772,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_d_ts",
       "label": "api.d.ts",
@@ -214306,7 +214336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1772,
+      "community": 1773,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_api_js",
       "label": "api.js",
@@ -214315,7 +214345,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1773,
+      "community": 1774,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_datamodel_d_ts",
       "label": "dataModel.d.ts",
@@ -214324,7 +214354,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1774,
+      "community": 1775,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_d_ts",
       "label": "server.d.ts",
@@ -214333,7 +214363,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1775,
+      "community": 1776,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_generated_server_js",
       "label": "server.js",
@@ -214342,7 +214372,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1776,
+      "community": 1777,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_app_ts",
       "label": "app.ts",
@@ -214351,7 +214381,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1777,
+      "community": 1778,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_posrecoverycode_test_ts",
       "label": "PosRecoveryCode.test.ts",
@@ -214360,21 +214390,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1778,
+      "community": 1779,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_posrecoverycode_ts",
       "label": "PosRecoveryCode.ts",
       "norm_label": "posrecoverycode.ts",
       "source_file": "packages/athena-webapp/convex/auth/PosRecoveryCode.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1779,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_auth_shareddemoticket_test_ts",
-      "label": "SharedDemoTicket.test.ts",
-      "norm_label": "shareddemoticket.test.ts",
-      "source_file": "packages/athena-webapp/convex/auth/SharedDemoTicket.test.ts",
       "source_location": "L1"
     },
     {
@@ -214506,6 +214527,15 @@
     {
       "community": 1780,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_auth_shareddemoticket_test_ts",
+      "label": "SharedDemoTicket.test.ts",
+      "norm_label": "shareddemoticket.test.ts",
+      "source_file": "packages/athena-webapp/convex/auth/SharedDemoTicket.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1781,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_config_js",
       "label": "auth.config.js",
       "norm_label": "auth.config.js",
@@ -214513,7 +214543,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1781,
+      "community": 1782,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_test_ts",
       "label": "auth.test.ts",
@@ -214522,7 +214552,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1782,
+      "community": 1783,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_auth_ts",
       "label": "auth.ts",
@@ -214531,7 +214561,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1783,
+      "community": 1784,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_authconfig_test_ts",
       "label": "authConfig.test.ts",
@@ -214540,7 +214570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1784,
+      "community": 1785,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_authconfig_ts",
       "label": "authConfig.ts",
@@ -214549,7 +214579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1785,
+      "community": 1786,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cloudflare_r2_test_ts",
       "label": "r2.test.ts",
@@ -214558,7 +214588,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1786,
+      "community": 1787,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_countries_ts",
       "label": "countries.ts",
@@ -214567,7 +214597,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1787,
+      "community": 1788,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_email_ts",
       "label": "email.ts",
@@ -214576,21 +214606,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1788,
+      "community": 1789,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_constants_ghana_ts",
       "label": "ghana.ts",
       "norm_label": "ghana.ts",
       "source_file": "packages/athena-webapp/convex/constants/ghana.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1789,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_constants_payment_ts",
-      "label": "payment.ts",
-      "norm_label": "payment.ts",
-      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
       "source_location": "L1"
     },
     {
@@ -214722,6 +214743,15 @@
     {
       "community": 1790,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_constants_payment_ts",
+      "label": "payment.ts",
+      "norm_label": "payment.ts",
+      "source_file": "packages/athena-webapp/convex/constants/payment.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1791,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_athenawebappevents_test_ts",
       "label": "athenaWebappEvents.test.ts",
       "norm_label": "athenawebappevents.test.ts",
@@ -214729,7 +214759,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1791,
+      "community": 1792,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_shareddemoactioncapture_test_ts",
       "label": "sharedDemoActionCapture.test.ts",
@@ -214738,7 +214768,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1792,
+      "community": 1793,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_types_ts",
       "label": "types.ts",
@@ -214747,7 +214777,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1793,
+      "community": 1794,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_convex_config_ts",
       "label": "convex.config.ts",
@@ -214756,7 +214786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1794,
+      "community": 1795,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_test_ts",
       "label": "crons.test.ts",
@@ -214765,7 +214795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1795,
+      "community": 1796,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_crons_ts",
       "label": "crons.ts",
@@ -214774,7 +214804,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1796,
+      "community": 1797,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_domain_test_ts",
       "label": "domain.test.ts",
@@ -214783,7 +214813,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1797,
+      "community": 1798,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_internal_ts",
       "label": "internal.ts",
@@ -214792,21 +214822,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1798,
+      "community": 1799,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
       "label": "public.test.ts",
       "norm_label": "public.test.ts",
       "source_file": "packages/athena-webapp/convex/customerMessaging/public.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1799,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_token_test_ts",
-      "label": "token.test.ts",
-      "norm_label": "token.test.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/token.test.ts",
       "source_location": "L1"
     },
     {
@@ -215325,6 +215346,15 @@
     {
       "community": 1800,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_token_test_ts",
+      "label": "token.test.ts",
+      "norm_label": "token.test.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/token.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 1801,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappclient_test_ts",
       "label": "whatsappClient.test.ts",
       "norm_label": "whatsappclient.test.ts",
@@ -215332,7 +215362,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1801,
+      "community": 1802,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_whatsappconfig_test_ts",
       "label": "whatsappConfig.test.ts",
@@ -215341,7 +215371,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1802,
+      "community": 1803,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_devpatchbadtransaction_ts",
       "label": "devPatchBadTransaction.ts",
@@ -215350,7 +215380,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1803,
+      "community": 1804,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_approvalrequestpending_test_tsx",
       "label": "ApprovalRequestPending.test.tsx",
@@ -215359,7 +215389,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1804,
+      "community": 1805,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_dailymanagerreport_test_tsx",
       "label": "DailyManagerReport.test.tsx",
@@ -215368,7 +215398,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1805,
+      "community": 1806,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_dailymanagerreportcomparisonpreview_tsx",
       "label": "DailyManagerReportComparisonPreview.tsx",
@@ -215377,7 +215407,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1806,
+      "community": 1807,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_expensereceiptemail_tsx",
       "label": "ExpenseReceiptEmail.tsx",
@@ -215386,7 +215416,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1807,
+      "community": 1808,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_feedbackrequest_tsx",
       "label": "FeedbackRequest.tsx",
@@ -215395,21 +215425,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1808,
+      "community": 1809,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_neworderadmin_test_tsx",
       "label": "NewOrderAdmin.test.tsx",
       "norm_label": "neworderadmin.test.tsx",
       "source_file": "packages/athena-webapp/convex/emails/NewOrderAdmin.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1809,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_orderemail_test_tsx",
-      "label": "OrderEmail.test.tsx",
-      "norm_label": "orderemail.test.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.test.tsx",
       "source_location": "L1"
     },
     {
@@ -215541,6 +215562,15 @@
     {
       "community": 1810,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_orderemail_test_tsx",
+      "label": "OrderEmail.test.tsx",
+      "norm_label": "orderemail.test.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/OrderEmail.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1811,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_test_tsx",
       "label": "PosReceiptEmail.test.tsx",
       "norm_label": "posreceiptemail.test.tsx",
@@ -215548,7 +215578,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1811,
+      "community": 1812,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posreceiptemail_tsx",
       "label": "PosReceiptEmail.tsx",
@@ -215557,7 +215587,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1812,
+      "community": 1813,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_posterminalhealthalert_test_tsx",
       "label": "PosTerminalHealthAlert.test.tsx",
@@ -215566,7 +215596,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1813,
+      "community": 1814,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_test_tsx",
       "label": "RegisterCloseoutVarianceAlert.test.tsx",
@@ -215575,7 +215605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1814,
+      "community": 1815,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_reportverificationalert_test_tsx",
       "label": "ReportVerificationAlert.test.tsx",
@@ -215584,7 +215614,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1815,
+      "community": 1816,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_reportverificationalert_tsx",
       "label": "ReportVerificationAlert.tsx",
@@ -215593,7 +215623,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1816,
+      "community": 1817,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_staledailyclosealert_test_tsx",
       "label": "StaleDailyCloseAlert.test.tsx",
@@ -215602,7 +215632,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1817,
+      "community": 1818,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_staledailyclosealert_tsx",
       "label": "StaleDailyCloseAlert.tsx",
@@ -215611,21 +215641,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1818,
+      "community": 1819,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_walkthroughrequestnotification_test_tsx",
       "label": "WalkthroughRequestNotification.test.tsx",
       "norm_label": "walkthroughrequestnotification.test.tsx",
       "source_file": "packages/athena-webapp/convex/emails/WalkthroughRequestNotification.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 1819,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_emails_weeklymanagerreport_test_tsx",
-      "label": "WeeklyManagerReport.test.tsx",
-      "norm_label": "weeklymanagerreport.test.tsx",
-      "source_file": "packages/athena-webapp/convex/emails/WeeklyManagerReport.test.tsx",
       "source_location": "L1"
     },
     {
@@ -215757,6 +215778,15 @@
     {
       "community": 1820,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_emails_weeklymanagerreport_test_tsx",
+      "label": "WeeklyManagerReport.test.tsx",
+      "norm_label": "weeklymanagerreport.test.tsx",
+      "source_file": "packages/athena-webapp/convex/emails/WeeklyManagerReport.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 1821,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_emailoperationalctastyles_ts",
       "label": "emailOperationalCtaStyles.ts",
       "norm_label": "emailoperationalctastyles.ts",
@@ -215764,7 +215794,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1821,
+      "community": 1822,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_env_ts",
       "label": "env.ts",
@@ -215773,7 +215803,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1822,
+      "community": 1823,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_harnesswaiver_passkeypolicy_test_ts",
       "label": "passkeyPolicy.test.ts",
@@ -215782,7 +215812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 1823,
+      "community": 1824,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_harnesswaiver_passkeys_integration_test_ts",
       "label": "passkeys.integration.test.ts",
@@ -215791,21 +215821,12 @@
       "source_location": "L1"
     },
     {
-      "community": 1824,
+      "community": 1825,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_harnesswaiver_passkeys_test_ts",
       "label": "passkeys.test.ts",
       "norm_label": "passkeys.test.ts",
       "source_file": "packages/athena-webapp/convex/harnessWaiver/passkeys.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 1825,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_harnesswaiver_registrationauthorization_test_ts",
-      "label": "registrationAuthorization.test.ts",
-      "norm_label": "registrationauthorization.test.ts",
-      "source_file": "packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.test.ts",
       "source_location": "L1"
     },
     {
@@ -218736,119 +218757,119 @@
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
+      "label": "POSSessionsView.tsx",
+      "norm_label": "possessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_formatexpiry",
+      "label": "formatExpiry()",
+      "norm_label": "formatexpiry()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L190"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_formatholddetails",
+      "label": "formatHoldDetails()",
+      "norm_label": "formatholddetails()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L216"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "possessionsview_formatregisterlabel",
+      "label": "formatRegisterLabel()",
+      "norm_label": "formatregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L147"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L191"
+      "id": "possessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L122"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "possessionsview_getcartcount",
+      "label": "getCartCount()",
+      "norm_label": "getcartcount()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L180"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L1"
+      "id": "possessionsview_getcustomerlabel",
+      "label": "getCustomerLabel()",
+      "norm_label": "getcustomerlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L176"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "possessionsview_getoperatorlabel",
+      "label": "getOperatorLabel()",
+      "norm_label": "getoperatorlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L138"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L40"
+      "id": "possessionsview_getregisterlabel",
+      "label": "getRegisterLabel()",
+      "norm_label": "getregisterlabel()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L157"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L102"
+      "id": "possessionsview_getsessioncode",
+      "label": "getSessionCode()",
+      "norm_label": "getsessioncode()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L131"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "possessionsview_getsessions",
+      "label": "getSessions()",
+      "norm_label": "getsessions()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L114"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_getproductdiscountvalue",
-      "label": "getProductDiscountValue()",
-      "norm_label": "getproductdiscountvalue()",
-      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
-      "source_location": "L75"
+      "id": "possessionsview_getstatusbadgeclass",
+      "label": "getStatusBadgeClass()",
+      "norm_label": "getstatusbadgeclass()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L250"
     },
     {
       "community": 195,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L116"
+      "id": "possessionsview_possessionsheader",
+      "label": "POSSessionsHeader()",
+      "norm_label": "possessionsheader()",
+      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "source_location": "L261"
     },
     {
       "community": 1950,
@@ -218943,119 +218964,119 @@
     {
       "community": 196,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_sessions_possessionsview_tsx",
-      "label": "POSSessionsView.tsx",
-      "norm_label": "possessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
+      "id": "localposreadiness_blocked",
+      "label": "blocked()",
+      "norm_label": "blocked()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L638"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposreadiness",
+      "label": "evaluateLocalPosReadiness()",
+      "norm_label": "evaluatelocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L124"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
+      "label": "evaluateLocalPosServiceCatalogReadiness()",
+      "norm_label": "evaluatelocalposservicecatalogreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_formatreadinessstatekey",
+      "label": "formatReadinessStateKey()",
+      "norm_label": "formatreadinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L591"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_hassettledlocalcloseout",
+      "label": "hasSettledLocalCloseout()",
+      "norm_label": "hassettledlocalcloseout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L248"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessmatchesinput",
+      "label": "localReadinessMatchesInput()",
+      "norm_label": "localreadinessmatchesinput()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L287"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_localreadinessrecordfromsnapshots",
+      "label": "localReadinessRecordFromSnapshots()",
+      "norm_label": "localreadinessrecordfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekey",
+      "label": "readinessStateKey()",
+      "norm_label": "readinessstatekey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L610"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_readinessstatekeysequal",
+      "label": "readinessStateKeysEqual()",
+      "norm_label": "readinessstatekeysequal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L624"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_readlocalposreadiness",
+      "label": "readLocalPosReadiness()",
+      "norm_label": "readlocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L299"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
+      "label": "refreshLocalPosReadinessFromSnapshots()",
+      "norm_label": "refreshlocalposreadinessfromsnapshots()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L343"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "localposreadiness_uselocalposreadiness",
+      "label": "useLocalPosReadiness()",
+      "norm_label": "uselocalposreadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 196,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
+      "label": "localPosReadiness.ts",
+      "norm_label": "localposreadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatexpiry",
-      "label": "formatExpiry()",
-      "norm_label": "formatexpiry()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L190"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatholddetails",
-      "label": "formatHoldDetails()",
-      "norm_label": "formatholddetails()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L216"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatregisterlabel",
-      "label": "formatRegisterLabel()",
-      "norm_label": "formatregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L147"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L122"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getcartcount",
-      "label": "getCartCount()",
-      "norm_label": "getcartcount()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L180"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getcustomerlabel",
-      "label": "getCustomerLabel()",
-      "norm_label": "getcustomerlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L176"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getoperatorlabel",
-      "label": "getOperatorLabel()",
-      "norm_label": "getoperatorlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getregisterlabel",
-      "label": "getRegisterLabel()",
-      "norm_label": "getregisterlabel()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L157"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getsessioncode",
-      "label": "getSessionCode()",
-      "norm_label": "getsessioncode()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getsessions",
-      "label": "getSessions()",
-      "norm_label": "getsessions()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L114"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_getstatusbadgeclass",
-      "label": "getStatusBadgeClass()",
-      "norm_label": "getstatusbadgeclass()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L250"
-    },
-    {
-      "community": 196,
-      "file_type": "code",
-      "id": "possessionsview_possessionsheader",
-      "label": "POSSessionsHeader()",
-      "norm_label": "possessionsheader()",
-      "source_file": "packages/athena-webapp/src/components/pos/sessions/POSSessionsView.tsx",
-      "source_location": "L261"
     },
     {
       "community": 1960,
@@ -219150,119 +219171,119 @@
     {
       "community": 197,
       "file_type": "code",
-      "id": "localposreadiness_blocked",
-      "label": "blocked()",
-      "norm_label": "blocked()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L638"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposreadiness",
-      "label": "evaluateLocalPosReadiness()",
-      "norm_label": "evaluatelocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L124"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_evaluatelocalposservicecatalogreadiness",
-      "label": "evaluateLocalPosServiceCatalogReadiness()",
-      "norm_label": "evaluatelocalposservicecatalogreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_formatreadinessstatekey",
-      "label": "formatReadinessStateKey()",
-      "norm_label": "formatreadinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L591"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_hassettledlocalcloseout",
-      "label": "hasSettledLocalCloseout()",
-      "norm_label": "hassettledlocalcloseout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L248"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessmatchesinput",
-      "label": "localReadinessMatchesInput()",
-      "norm_label": "localreadinessmatchesinput()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_localreadinessrecordfromsnapshots",
-      "label": "localReadinessRecordFromSnapshots()",
-      "norm_label": "localreadinessrecordfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekey",
-      "label": "readinessStateKey()",
-      "norm_label": "readinessstatekey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L610"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_readinessstatekeysequal",
-      "label": "readinessStateKeysEqual()",
-      "norm_label": "readinessstatekeysequal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L624"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_readlocalposreadiness",
-      "label": "readLocalPosReadiness()",
-      "norm_label": "readlocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L299"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_refreshlocalposreadinessfromsnapshots",
-      "label": "refreshLocalPosReadinessFromSnapshots()",
-      "norm_label": "refreshlocalposreadinessfromsnapshots()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L343"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "localposreadiness_uselocalposreadiness",
-      "label": "useLocalPosReadiness()",
-      "norm_label": "uselocalposreadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
-      "source_location": "L391"
-    },
-    {
-      "community": 197,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localposreadiness_ts",
-      "label": "localPosReadiness.ts",
-      "norm_label": "localposreadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
+      "label": "registerCatalogPinRuntime.ts",
+      "norm_label": "registercatalogpinruntime.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
+      "label": "captureRegisterCatalogRuntimePin()",
+      "norm_label": "captureregistercatalogruntimepin()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L138"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
+      "label": "chooseRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "chooseregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
+      "label": "clearRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "clearregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
+      "label": "clearRegisterCatalogRuntimeSelection()",
+      "norm_label": "clearregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L132"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
+      "label": "getRegisterCatalogRuntimeOwnerId()",
+      "norm_label": "getregistercatalogruntimeownerid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
+      "label": "hasRegisterCatalogRuntimeActionGuard()",
+      "norm_label": "hasregistercatalogruntimeactionguard()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_keyforscope",
+      "label": "keyForScope()",
+      "norm_label": "keyforscope()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_maintainownerclaim",
+      "label": "maintainOwnerClaim()",
+      "norm_label": "maintainownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L87"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_ownerclaimkey",
+      "label": "ownerClaimKey()",
+      "norm_label": "ownerclaimkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L47"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_readownerclaim",
+      "label": "readOwnerClaim()",
+      "norm_label": "readownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
+      "label": "setRegisterCatalogRuntimeSelection()",
+      "norm_label": "setregistercatalogruntimeselection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 197,
+      "file_type": "code",
+      "id": "registercatalogpinruntime_writeownerclaim",
+      "label": "writeOwnerClaim()",
+      "norm_label": "writeownerclaim()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "source_location": "L71"
     },
     {
       "community": 1970,
@@ -219357,119 +219378,119 @@
     {
       "community": 198,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registercatalogpinruntime_ts",
-      "label": "registerCatalogPinRuntime.ts",
-      "norm_label": "registercatalogpinruntime.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
+      "label": "printAttemptTelemetry.ts",
+      "norm_label": "printattempttelemetry.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
       "source_location": "L1"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_captureregistercatalogruntimepin",
-      "label": "captureRegisterCatalogRuntimePin()",
-      "norm_label": "captureregistercatalogruntimepin()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L138"
+      "id": "printattempttelemetry_appendevent",
+      "label": "appendEvent()",
+      "norm_label": "appendevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L81"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_chooseregistercatalogruntimeownerid",
-      "label": "chooseRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "chooseregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L31"
+      "id": "printattempttelemetry_beginprintattempt",
+      "label": "beginPrintAttempt()",
+      "norm_label": "beginprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L115"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeactionguard",
-      "label": "clearRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "clearregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L171"
+      "id": "printattempttelemetry_buildmetadata",
+      "label": "buildMetadata()",
+      "norm_label": "buildmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L88"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_clearregistercatalogruntimeselection",
-      "label": "clearRegisterCatalogRuntimeSelection()",
-      "norm_label": "clearregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L132"
+      "id": "printattempttelemetry_finalizeprintattempt",
+      "label": "finalizePrintAttempt()",
+      "norm_label": "finalizeprintattempt()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L211"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_getregistercatalogruntimeownerid",
-      "label": "getRegisterCatalogRuntimeOwnerId()",
-      "norm_label": "getregistercatalogruntimeownerid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L177"
+      "id": "printattempttelemetry_getprintrejectionmetadata",
+      "label": "getPrintRejectionMetadata()",
+      "norm_label": "getprintrejectionmetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L250"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_hasregistercatalogruntimeactionguard",
-      "label": "hasRegisterCatalogRuntimeActionGuard()",
-      "norm_label": "hasregistercatalogruntimeactionguard()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L165"
+      "id": "printattempttelemetry_getreasonmessage",
+      "label": "getReasonMessage()",
+      "norm_label": "getreasonmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L108"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_keyforscope",
-      "label": "keyForScope()",
-      "norm_label": "keyforscope()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L122"
+      "id": "printattempttelemetry_istargetterminal",
+      "label": "isTargetTerminal()",
+      "norm_label": "istargetterminal()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L62"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_maintainownerclaim",
-      "label": "maintainOwnerClaim()",
-      "norm_label": "maintainownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L87"
+      "id": "printattempttelemetry_mintattemptid",
+      "label": "mintAttemptId()",
+      "norm_label": "mintattemptid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L70"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_ownerclaimkey",
-      "label": "ownerClaimKey()",
-      "norm_label": "ownerclaimkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L47"
+      "id": "printattempttelemetry_recordprintattemptevent",
+      "label": "recordPrintAttemptEvent()",
+      "norm_label": "recordprintattemptevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L195"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_readownerclaim",
-      "label": "readOwnerClaim()",
-      "norm_label": "readownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L51"
+      "id": "printattempttelemetry_recordprintinvocation",
+      "label": "recordPrintInvocation()",
+      "norm_label": "recordprintinvocation()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L151"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_setregistercatalogruntimeselection",
-      "label": "setRegisterCatalogRuntimeSelection()",
-      "norm_label": "setregistercatalogruntimeselection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L126"
+      "id": "printattempttelemetry_recordprintreturn",
+      "label": "recordPrintReturn()",
+      "norm_label": "recordprintreturn()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L174"
     },
     {
       "community": 198,
       "file_type": "code",
-      "id": "registercatalogpinruntime_writeownerclaim",
-      "label": "writeOwnerClaim()",
-      "norm_label": "writeownerclaim()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerCatalogPinRuntime.ts",
-      "source_location": "L71"
+      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
+      "label": "resetPrintAttemptTelemetryForTests()",
+      "norm_label": "resetprintattempttelemetryfortests()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "source_location": "L294"
     },
     {
       "community": 1980,
@@ -219564,119 +219585,119 @@
     {
       "community": 199,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_printattempttelemetry_ts",
-      "label": "printAttemptTelemetry.ts",
-      "norm_label": "printattempttelemetry.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
+      "label": "telemetryBuffer.ts",
+      "norm_label": "telemetrybuffer.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
       "source_location": "L1"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_appendevent",
-      "label": "appendEvent()",
-      "norm_label": "appendevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L81"
+      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
+      "label": "clearPosClientTelemetryBuffer()",
+      "norm_label": "clearposclienttelemetrybuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L212"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_beginprintattempt",
-      "label": "beginPrintAttempt()",
-      "norm_label": "beginprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L115"
+      "id": "telemetrybuffer_enqueueposclientevent",
+      "label": "enqueuePosClientEvent()",
+      "norm_label": "enqueueposclientevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L167"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_buildmetadata",
-      "label": "buildMetadata()",
-      "norm_label": "buildmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L88"
+      "id": "telemetrybuffer_isbufferedevent",
+      "label": "isBufferedEvent()",
+      "norm_label": "isbufferedevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L100"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_finalizeprintattempt",
-      "label": "finalizePrintAttempt()",
-      "norm_label": "finalizeprintattempt()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L211"
+      "id": "telemetrybuffer_mintclienteventid",
+      "label": "mintClientEventId()",
+      "norm_label": "mintclienteventid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L63"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_getprintrejectionmetadata",
-      "label": "getPrintRejectionMetadata()",
-      "norm_label": "getprintrejectionmetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L250"
+      "id": "telemetrybuffer_normalizepostelemetryerror",
+      "label": "normalizePosTelemetryError()",
+      "norm_label": "normalizepostelemetryerror()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L116"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_getreasonmessage",
-      "label": "getReasonMessage()",
-      "norm_label": "getreasonmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L108"
+      "id": "telemetrybuffer_peekposclienteventbatch",
+      "label": "peekPosClientEventBatch()",
+      "norm_label": "peekposclienteventbatch()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L194"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_istargetterminal",
-      "label": "isTargetTerminal()",
-      "norm_label": "istargetterminal()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L62"
+      "id": "telemetrybuffer_posclienttelemetrybuffersize",
+      "label": "posClientTelemetryBufferSize()",
+      "norm_label": "posclienttelemetrybuffersize()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L208"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_mintattemptid",
-      "label": "mintAttemptId()",
-      "norm_label": "mintattemptid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L70"
+      "id": "telemetrybuffer_readbuffer",
+      "label": "readBuffer()",
+      "norm_label": "readbuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L74"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintattemptevent",
-      "label": "recordPrintAttemptEvent()",
-      "norm_label": "recordprintattemptevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L195"
+      "id": "telemetrybuffer_removeposclientevents",
+      "label": "removePosClientEvents()",
+      "norm_label": "removeposclientevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L200"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintinvocation",
-      "label": "recordPrintInvocation()",
-      "norm_label": "recordprintinvocation()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L151"
+      "id": "telemetrybuffer_sanitizemetadata",
+      "label": "sanitizeMetadata()",
+      "norm_label": "sanitizemetadata()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L145"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_recordprintreturn",
-      "label": "recordPrintReturn()",
-      "norm_label": "recordprintreturn()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L174"
+      "id": "telemetrybuffer_truncate",
+      "label": "truncate()",
+      "norm_label": "truncate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L59"
     },
     {
       "community": 199,
       "file_type": "code",
-      "id": "printattempttelemetry_resetprintattempttelemetryfortests",
-      "label": "resetPrintAttemptTelemetryForTests()",
-      "norm_label": "resetprintattempttelemetryfortests()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/printAttemptTelemetry.ts",
-      "source_location": "L294"
+      "id": "telemetrybuffer_writebuffer",
+      "label": "writeBuffer()",
+      "norm_label": "writebuffer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "source_location": "L90"
     },
     {
       "community": 1990,
@@ -220941,119 +220962,119 @@
     {
       "community": 200,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_telemetry_telemetrybuffer_ts",
-      "label": "telemetryBuffer.ts",
-      "norm_label": "telemetrybuffer.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
+      "label": "registerCheckoutProjection.ts",
+      "norm_label": "registercheckoutprojection.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
       "source_location": "L1"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_clearposclienttelemetrybuffer",
-      "label": "clearPosClientTelemetryBuffer()",
-      "norm_label": "clearposclienttelemetrybuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L212"
+      "id": "registercheckoutprojection_buildcompletedsalepayload",
+      "label": "buildCompletedSalePayload()",
+      "norm_label": "buildcompletedsalepayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L121"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_enqueueposclientevent",
-      "label": "enqueuePosClientEvent()",
-      "norm_label": "enqueueposclientevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L167"
+      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
+      "label": "buildServiceCheckoutBlockMessage()",
+      "norm_label": "buildservicecheckoutblockmessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L16"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_isbufferedevent",
-      "label": "isBufferedEvent()",
-      "norm_label": "isbufferedevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L100"
+      "id": "registercheckoutprojection_combinepaymentsbymethod",
+      "label": "combinePaymentsByMethod()",
+      "norm_label": "combinepaymentsbymethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L78"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_mintclienteventid",
-      "label": "mintClientEventId()",
-      "norm_label": "mintclienteventid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L63"
+      "id": "registercheckoutprojection_completedcustomerinfo",
+      "label": "completedCustomerInfo()",
+      "norm_label": "completedcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L290"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_normalizepostelemetryerror",
-      "label": "normalizePosTelemetryError()",
-      "norm_label": "normalizepostelemetryerror()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L116"
+      "id": "registercheckoutprojection_hascustomerdetails",
+      "label": "hasCustomerDetails()",
+      "norm_label": "hascustomerdetails()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L50"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_peekposclienteventbatch",
-      "label": "peekPosClientEventBatch()",
-      "norm_label": "peekposclienteventbatch()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L194"
+      "id": "registercheckoutprojection_ispospaymentmethod",
+      "label": "isPosPaymentMethod()",
+      "norm_label": "ispospaymentmethod()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L98"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_posclienttelemetrybuffersize",
-      "label": "posClientTelemetryBufferSize()",
-      "norm_label": "posclienttelemetrybuffersize()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L208"
+      "id": "registercheckoutprojection_maplocalpaymenttopayment",
+      "label": "mapLocalPaymentToPayment()",
+      "norm_label": "maplocalpaymenttopayment()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L102"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_readbuffer",
-      "label": "readBuffer()",
-      "norm_label": "readbuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L74"
+      "id": "registercheckoutprojection_maplocalservicelinetostate",
+      "label": "mapLocalServiceLineToState()",
+      "norm_label": "maplocalservicelinetostate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L197"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_removeposclientevents",
-      "label": "removePosClientEvents()",
-      "norm_label": "removeposclientevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L200"
+      "id": "registercheckoutprojection_mapsessioncustomer",
+      "label": "mapSessionCustomer()",
+      "norm_label": "mapsessioncustomer()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L65"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_sanitizemetadata",
-      "label": "sanitizeMetadata()",
-      "norm_label": "sanitizemetadata()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L145"
+      "id": "registercheckoutprojection_matchingservicelinedraft",
+      "label": "matchingServiceLineDraft()",
+      "norm_label": "matchingservicelinedraft()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L223"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_truncate",
-      "label": "truncate()",
-      "norm_label": "truncate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L59"
+      "id": "registercheckoutprojection_servicelinestatetocartline",
+      "label": "serviceLineStateToCartLine()",
+      "norm_label": "servicelinestatetocartline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L272"
     },
     {
       "community": 200,
       "file_type": "code",
-      "id": "telemetrybuffer_writebuffer",
-      "label": "writeBuffer()",
-      "norm_label": "writebuffer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/telemetry/telemetryBuffer.ts",
-      "source_location": "L90"
+      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
+      "label": "serviceLineStateToLocalPayload()",
+      "norm_label": "servicelinestatetolocalpayload()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "source_location": "L254"
     },
     {
       "community": 2000,
@@ -221148,119 +221169,119 @@
     {
       "community": 201,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registercheckoutprojection_ts",
-      "label": "registerCheckoutProjection.ts",
-      "norm_label": "registercheckoutprojection.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
+      "label": "registerDrawerPresentation.ts",
+      "norm_label": "registerdrawerpresentation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L1"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildcompletedsalepayload",
-      "label": "buildCompletedSalePayload()",
-      "norm_label": "buildcompletedsalepayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L121"
+      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
+      "label": "buildOpenDrawerFailureMessage()",
+      "norm_label": "buildopendrawerfailuremessage()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L189"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_buildservicecheckoutblockmessage",
-      "label": "buildServiceCheckoutBlockMessage()",
-      "norm_label": "buildservicecheckoutblockmessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L16"
+      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
+      "label": "findRegisterCloseoutReviewItem()",
+      "norm_label": "findregistercloseoutreviewitem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L171"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_combinepaymentsbymethod",
-      "label": "combinePaymentsByMethod()",
-      "norm_label": "combinepaymentsbymethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registercheckoutprojection_completedcustomerinfo",
-      "label": "completedCustomerInfo()",
-      "norm_label": "completedcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registercheckoutprojection_hascustomerdetails",
-      "label": "hasCustomerDetails()",
-      "norm_label": "hascustomerdetails()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 201,
-      "file_type": "code",
-      "id": "registercheckoutprojection_ispospaymentmethod",
-      "label": "isPosPaymentMethod()",
-      "norm_label": "ispospaymentmethod()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
+      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
+      "label": "formatCloseoutCloudRegisterSessionCode()",
+      "norm_label": "formatcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
       "source_location": "L98"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalpaymenttopayment",
-      "label": "mapLocalPaymentToPayment()",
-      "norm_label": "maplocalpaymenttopayment()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L102"
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
+      "label": "getCloseoutCloudRegisterSessionCode()",
+      "norm_label": "getcloseoutcloudregistersessioncode()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L68"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_maplocalservicelinetostate",
-      "label": "mapLocalServiceLineToState()",
-      "norm_label": "maplocalservicelinetostate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L197"
+      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
+      "label": "getCloseoutCloudRegisterSessionId()",
+      "norm_label": "getcloseoutcloudregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L50"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_mapsessioncustomer",
-      "label": "mapSessionCustomer()",
-      "norm_label": "mapsessioncustomer()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L65"
+      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
+      "label": "getCloseoutLocalRegisterSessionId()",
+      "norm_label": "getcloseoutlocalregistersessionid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L29"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_matchingservicelinedraft",
-      "label": "matchingServiceLineDraft()",
-      "norm_label": "matchingservicelinedraft()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L223"
+      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
+      "label": "getLatestLocalRegisterLifecycleEvent()",
+      "norm_label": "getlatestlocalregisterlifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L207"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetocartline",
-      "label": "serviceLineStateToCartLine()",
-      "norm_label": "servicelinestatetocartline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L272"
+      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
+      "label": "getPendingLocalCashVoidApprovals()",
+      "norm_label": "getpendinglocalcashvoidapprovals()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L270"
     },
     {
       "community": 201,
       "file_type": "code",
-      "id": "registercheckoutprojection_servicelinestatetolocalpayload",
-      "label": "serviceLineStateToLocalPayload()",
-      "norm_label": "servicelinestatetolocalpayload()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerCheckoutProjection.ts",
-      "source_location": "L254"
+      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
+      "label": "getPendingLocalCloseoutRegisterSession()",
+      "norm_label": "getpendinglocalcloseoutregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L234"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
+      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
+      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L114"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_readlocalsyncstatus",
+      "label": "readLocalSyncStatus()",
+      "norm_label": "readlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L146"
+    },
+    {
+      "community": 201,
+      "file_type": "code",
+      "id": "registerdrawerpresentation_stringfield",
+      "label": "stringField()",
+      "norm_label": "stringfield()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "source_location": "L334"
     },
     {
       "community": 2010,
@@ -221355,119 +221376,119 @@
     {
       "community": 202,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_registerdrawerpresentation_ts",
-      "label": "registerDrawerPresentation.ts",
-      "norm_label": "registerdrawerpresentation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_buildopendrawerfailuremessage",
-      "label": "buildOpenDrawerFailureMessage()",
-      "norm_label": "buildopendrawerfailuremessage()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L189"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_findregistercloseoutreviewitem",
-      "label": "findRegisterCloseoutReviewItem()",
-      "norm_label": "findregistercloseoutreviewitem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_formatcloseoutcloudregistersessioncode",
-      "label": "formatCloseoutCloudRegisterSessionCode()",
-      "norm_label": "formatcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessioncode",
-      "label": "getCloseoutCloudRegisterSessionCode()",
-      "norm_label": "getcloseoutcloudregistersessioncode()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 202,
-      "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutcloudregistersessionid",
-      "label": "getCloseoutCloudRegisterSessionId()",
-      "norm_label": "getcloseoutcloudregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
+      "id": "localpinverifier_base64tobytes",
+      "label": "base64ToBytes()",
+      "norm_label": "base64tobytes()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
       "source_location": "L50"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getcloseoutlocalregistersessionid",
-      "label": "getCloseoutLocalRegisterSessionId()",
-      "norm_label": "getcloseoutlocalregistersessionid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L29"
+      "id": "localpinverifier_bytestobase64",
+      "label": "bytesToBase64()",
+      "norm_label": "bytestobase64()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L38"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getlatestlocalregisterlifecycleevent",
-      "label": "getLatestLocalRegisterLifecycleEvent()",
-      "norm_label": "getlatestlocalregisterlifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L207"
+      "id": "localpinverifier_createlocalpinverifier",
+      "label": "createLocalPinVerifier()",
+      "norm_label": "createlocalpinverifier()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L131"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcashvoidapprovals",
-      "label": "getPendingLocalCashVoidApprovals()",
-      "norm_label": "getpendinglocalcashvoidapprovals()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L270"
+      "id": "localpinverifier_cryptorefdecrypt",
+      "label": "cryptoRefDecrypt()",
+      "norm_label": "cryptorefdecrypt()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L268"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_getpendinglocalcloseoutregistersession",
-      "label": "getPendingLocalCloseoutRegisterSession()",
-      "norm_label": "getpendinglocalcloseoutregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L234"
+      "id": "localpinverifier_derivepinhash",
+      "label": "derivePinHash()",
+      "norm_label": "derivepinhash()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L76"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_isknowncloudregistersessionblockinglocalprojection",
-      "label": "isKnownCloudRegisterSessionBlockingLocalProjection()",
-      "norm_label": "isknowncloudregistersessionblockinglocalprojection()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L114"
+      "id": "localpinverifier_derivewrappingkey",
+      "label": "deriveWrappingKey()",
+      "norm_label": "derivewrappingkey()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L103"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_readlocalsyncstatus",
-      "label": "readLocalSyncStatus()",
-      "norm_label": "readlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L146"
+      "id": "localpinverifier_getcrypto",
+      "label": "getCrypto()",
+      "norm_label": "getcrypto()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L30"
     },
     {
       "community": 202,
       "file_type": "code",
-      "id": "registerdrawerpresentation_stringfield",
-      "label": "stringField()",
-      "norm_label": "stringfield()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/registerDrawerPresentation.ts",
-      "source_location": "L334"
+      "id": "localpinverifier_islocalpinverifiermetadata",
+      "label": "isLocalPinVerifierMetadata()",
+      "norm_label": "islocalpinverifiermetadata()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L281"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_timingsafeequal",
+      "label": "timingSafeEqual()",
+      "norm_label": "timingsafeequal()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_unwraplocalstaffprooftoken",
+      "label": "unwrapLocalStaffProofToken()",
+      "norm_label": "unwraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_verifylocalpin",
+      "label": "verifyLocalPin()",
+      "norm_label": "verifylocalpin()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "localpinverifier_wraplocalstaffprooftoken",
+      "label": "wrapLocalStaffProofToken()",
+      "norm_label": "wraplocalstaffprooftoken()",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L183"
+    },
+    {
+      "community": 202,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
+      "label": "localPinVerifier.ts",
+      "norm_label": "localpinverifier.ts",
+      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "source_location": "L1"
     },
     {
       "community": 2020,
@@ -221562,119 +221583,119 @@
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_base64tobytes",
-      "label": "base64ToBytes()",
-      "norm_label": "base64tobytes()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L50"
+      "id": "packages_storefront_webapp_src_api_reviews_ts",
+      "label": "reviews.ts",
+      "norm_label": "reviews.ts",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L1"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_bytestobase64",
-      "label": "bytesToBase64()",
-      "norm_label": "bytestobase64()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L38"
+      "id": "reviews_createreview",
+      "label": "createReview()",
+      "norm_label": "createreview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L13"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_createlocalpinverifier",
-      "label": "createLocalPinVerifier()",
-      "norm_label": "createlocalpinverifier()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L131"
+      "id": "reviews_deletereview",
+      "label": "deleteReview()",
+      "norm_label": "deletereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L69"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_cryptorefdecrypt",
-      "label": "cryptoRefDecrypt()",
-      "norm_label": "cryptorefdecrypt()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L268"
+      "id": "reviews_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L4"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_derivepinhash",
-      "label": "derivePinHash()",
-      "norm_label": "derivepinhash()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L76"
+      "id": "reviews_getreviewbyorderitem",
+      "label": "getReviewByOrderItem()",
+      "norm_label": "getreviewbyorderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L32"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_derivewrappingkey",
-      "label": "deriveWrappingKey()",
-      "norm_label": "derivewrappingkey()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L103"
+      "id": "reviews_getreviewsbyproductid",
+      "label": "getReviewsByProductId()",
+      "norm_label": "getreviewsbyproductid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L132"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_getcrypto",
-      "label": "getCrypto()",
-      "norm_label": "getcrypto()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L30"
+      "id": "reviews_getreviewsbyproductskuid",
+      "label": "getReviewsByProductSkuId()",
+      "norm_label": "getreviewsbyproductskuid()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L83"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_islocalpinverifiermetadata",
-      "label": "isLocalPinVerifierMetadata()",
-      "norm_label": "islocalpinverifiermetadata()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L281"
+      "id": "reviews_getuserreviews",
+      "label": "getUserReviews()",
+      "norm_label": "getuserreviews()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L99"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_timingsafeequal",
-      "label": "timingSafeEqual()",
-      "norm_label": "timingsafeequal()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L63"
+      "id": "reviews_getuserreviewsforproduct",
+      "label": "getUserReviewsForProduct()",
+      "norm_label": "getuserreviewsforproduct()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L113"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_unwraplocalstaffprooftoken",
-      "label": "unwrapLocalStaffProofToken()",
-      "norm_label": "unwraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L221"
+      "id": "reviews_hasreviewfororderitem",
+      "label": "hasReviewForOrderItem()",
+      "norm_label": "hasreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L164"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "localpinverifier_verifylocalpin",
-      "label": "verifyLocalPin()",
-      "norm_label": "verifylocalpin()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 203,
-      "file_type": "code",
-      "id": "localpinverifier_wraplocalstaffprooftoken",
-      "label": "wrapLocalStaffProofToken()",
-      "norm_label": "wraplocalstaffprooftoken()",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
+      "id": "reviews_hasuserreviewfororderitem",
+      "label": "hasUserReviewForOrderItem()",
+      "norm_label": "hasuserreviewfororderitem()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
       "source_location": "L183"
     },
     {
       "community": 203,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_security_localpinverifier_ts",
-      "label": "localPinVerifier.ts",
-      "norm_label": "localpinverifier.ts",
-      "source_file": "packages/athena-webapp/src/lib/security/localPinVerifier.ts",
-      "source_location": "L1"
+      "id": "reviews_markreviewhelpful",
+      "label": "markReviewHelpful()",
+      "norm_label": "markreviewhelpful()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 203,
+      "file_type": "code",
+      "id": "reviews_updatereview",
+      "label": "updateReview()",
+      "norm_label": "updatereview()",
+      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "source_location": "L48"
     },
     {
       "community": 2030,
@@ -221769,119 +221790,119 @@
     {
       "community": 204,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_reviews_ts",
-      "label": "reviews.ts",
-      "norm_label": "reviews.ts",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
+      "id": "packages_athena_webapp_convex_inventory_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_createreview",
-      "label": "createReview()",
-      "norm_label": "createreview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L13"
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_deletereview",
-      "label": "deleteReview()",
-      "norm_label": "deletereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L69"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L4"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getreviewbyorderitem",
-      "label": "getReviewByOrderItem()",
-      "norm_label": "getreviewbyorderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L32"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L191"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductid",
-      "label": "getReviewsByProductId()",
-      "norm_label": "getreviewsbyproductid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L132"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getreviewsbyproductskuid",
-      "label": "getReviewsByProductSkuId()",
-      "norm_label": "getreviewsbyproductskuid()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L83"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getuserreviews",
-      "label": "getUserReviews()",
-      "norm_label": "getuserreviews()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L99"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_getuserreviewsforproduct",
-      "label": "getUserReviewsForProduct()",
-      "norm_label": "getuserreviewsforproduct()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L113"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L40"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_hasreviewfororderitem",
-      "label": "hasReviewForOrderItem()",
-      "norm_label": "hasreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L164"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L102"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_hasuserreviewfororderitem",
-      "label": "hasUserReviewForOrderItem()",
-      "norm_label": "hasuserreviewfororderitem()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L183"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_markreviewhelpful",
-      "label": "markReviewHelpful()",
-      "norm_label": "markreviewhelpful()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L148"
+      "id": "utils_getproductdiscountvalue",
+      "label": "getProductDiscountValue()",
+      "norm_label": "getproductdiscountvalue()",
+      "source_file": "packages/athena-webapp/convex/inventory/utils.ts",
+      "source_location": "L75"
     },
     {
       "community": 204,
       "file_type": "code",
-      "id": "reviews_updatereview",
-      "label": "updateReview()",
-      "norm_label": "updatereview()",
-      "source_file": "packages/storefront-webapp/src/api/reviews.ts",
-      "source_location": "L48"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L116"
     },
     {
       "community": 2040,
@@ -244692,87 +244713,6 @@
     {
       "community": 323,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
-      "label": "storefrontObservability.ts",
-      "norm_label": "storefrontobservability.ts",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitycontext",
-      "label": "createStorefrontObservabilityContext()",
-      "norm_label": "createstorefrontobservabilitycontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_createstorefrontobservabilitypayload",
-      "label": "createStorefrontObservabilityPayload()",
-      "norm_label": "createstorefrontobservabilitypayload()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
-      "label": "getOrCreateStorefrontObservabilitySessionId()",
-      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L157"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_isbrowserautomationcontext",
-      "label": "isBrowserAutomationContext()",
-      "norm_label": "isbrowserautomationcontext()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_issyntheticmonitororigin",
-      "label": "isSyntheticMonitorOrigin()",
-      "norm_label": "issyntheticmonitororigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
-      "label": "resolveStorefrontAnalyticsOrigin()",
-      "norm_label": "resolvestorefrontanalyticsorigin()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_resolveviewportbucket",
-      "label": "resolveViewportBucket()",
-      "norm_label": "resolveviewportbucket()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 323,
-      "file_type": "code",
-      "id": "storefrontobservability_trackstorefrontevent",
-      "label": "trackStorefrontEvent()",
-      "norm_label": "trackstorefrontevent()",
-      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 324,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
       "norm_label": "versionchecker.ts",
@@ -244780,7 +244720,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -244789,7 +244729,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -244798,7 +244738,7 @@
       "source_location": "L192"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -244807,7 +244747,7 @@
       "source_location": "L16"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -244816,7 +244756,7 @@
       "source_location": "L135"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -244825,7 +244765,7 @@
       "source_location": "L141"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -244834,7 +244774,7 @@
       "source_location": "L174"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -244843,13 +244783,94 @@
       "source_location": "L151"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_storefrontobservability_ts",
+      "label": "storefrontObservability.ts",
+      "norm_label": "storefrontobservability.ts",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitycontext",
+      "label": "createStorefrontObservabilityContext()",
+      "norm_label": "createstorefrontobservabilitycontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L182"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_createstorefrontobservabilitypayload",
+      "label": "createStorefrontObservabilityPayload()",
+      "norm_label": "createstorefrontobservabilitypayload()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L229"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_getorcreatestorefrontobservabilitysessionid",
+      "label": "getOrCreateStorefrontObservabilitySessionId()",
+      "norm_label": "getorcreatestorefrontobservabilitysessionid()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_isbrowserautomationcontext",
+      "label": "isBrowserAutomationContext()",
+      "norm_label": "isbrowserautomationcontext()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_issyntheticmonitororigin",
+      "label": "isSyntheticMonitorOrigin()",
+      "norm_label": "issyntheticmonitororigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_resolvestorefrontanalyticsorigin",
+      "label": "resolveStorefrontAnalyticsOrigin()",
+      "norm_label": "resolvestorefrontanalyticsorigin()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_resolveviewportbucket",
+      "label": "resolveViewportBucket()",
+      "norm_label": "resolveviewportbucket()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "storefrontobservability_trackstorefrontevent",
+      "label": "trackStorefrontEvent()",
+      "norm_label": "trackstorefrontevent()",
+      "source_file": "packages/storefront-webapp/src/lib/storefrontObservability.ts",
+      "source_location": "L265"
     },
     {
       "community": 325,
@@ -267210,51 +267231,6 @@
     {
       "community": 564,
       "file_type": "code",
-      "id": "currency_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 564,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 564,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 564,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 564,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 565,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_marketing_walkthroughrequestnotifications_ts",
       "label": "walkthroughRequestNotifications.ts",
       "norm_label": "walkthroughrequestnotifications.ts",
@@ -267262,7 +267238,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_boundedauditvalue",
       "label": "boundedAuditValue()",
@@ -267271,7 +267247,7 @@
       "source_location": "L27"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_classifydeliveryresult",
       "label": "classifyDeliveryResult()",
@@ -267280,7 +267256,7 @@
       "source_location": "L13"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_isdeliberateretryeligible",
       "label": "isDeliberateRetryEligible()",
@@ -267289,7 +267265,7 @@
       "source_location": "L20"
     },
     {
-      "community": 565,
+      "community": 564,
       "file_type": "code",
       "id": "walkthroughrequestnotifications_nextbackoffms",
       "label": "nextBackoffMs()",
@@ -267298,7 +267274,7 @@
       "source_location": "L12"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createctx",
       "label": "createCtx()",
@@ -267307,7 +267283,7 @@
       "source_location": "L80"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -267316,7 +267292,7 @@
       "source_location": "L29"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishbackfill",
       "label": "finishBackfill()",
@@ -267325,7 +267301,7 @@
       "source_location": "L118"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "backfillreportingcyclestart_test_finishverification",
       "label": "finishVerification()",
@@ -267334,7 +267310,7 @@
       "source_location": "L139"
     },
     {
-      "community": 566,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportingcyclestart_test_ts",
       "label": "backfillReportingCycleStart.test.ts",
@@ -267343,7 +267319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_backfillstoretimezoneauthoritywithctx",
       "label": "backfillStoreTimezoneAuthorityWithCtx()",
@@ -267352,7 +267328,7 @@
       "source_location": "L127"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_buildrow",
       "label": "buildRow()",
@@ -267361,7 +267337,7 @@
       "source_location": "L47"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_listschedulesforstore",
       "label": "listSchedulesForStore()",
@@ -267370,7 +267346,7 @@
       "source_location": "L35"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "backfillstoretimezoneauthority_normalizelimit",
       "label": "normalizeLimit()",
@@ -267379,7 +267355,7 @@
       "source_location": "L28"
     },
     {
-      "community": 567,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstoretimezoneauthority_ts",
       "label": "backfillStoreTimezoneAuthority.ts",
@@ -267388,7 +267364,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "dispatch_recordnotificationfailureeventwithctx",
       "label": "recordNotificationFailureEventWithCtx()",
@@ -267397,7 +267373,7 @@
       "source_location": "L400"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "dispatch_recordterminaldeliveryfailureevent",
       "label": "recordTerminalDeliveryFailureEvent()",
@@ -267406,7 +267382,7 @@
       "source_location": "L427"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "dispatch_resolverecipients",
       "label": "resolveRecipients()",
@@ -267415,7 +267391,7 @@
       "source_location": "L53"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "dispatch_suppressintentwithctx",
       "label": "suppressIntentWithCtx()",
@@ -267424,7 +267400,7 @@
       "source_location": "L85"
     },
     {
-      "community": 568,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_dispatch_ts",
       "label": "dispatch.ts",
@@ -267433,7 +267409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_test_ts",
       "label": "registry.test.ts",
@@ -267442,7 +267418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "registry_test_dedupekey",
       "label": "dedupeKey()",
@@ -267451,7 +267427,7 @@
       "source_location": "L665"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "registry_test_keyfor",
       "label": "keyFor()",
@@ -267460,7 +267436,7 @@
       "source_location": "L850"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "registry_test_prepare",
       "label": "prepare()",
@@ -267469,13 +267445,58 @@
       "source_location": "L48"
     },
     {
-      "community": 569,
+      "community": 568,
       "file_type": "code",
       "id": "registry_test_stubctx",
       "label": "stubCtx()",
       "norm_label": "stubctx()",
       "source_file": "packages/athena-webapp/convex/notifications/registry.test.ts",
       "source_location": "L29"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "adapters_createnormaluseroperationadapter",
+      "label": "createNormalUserOperationAdapter()",
+      "norm_label": "createnormaluseroperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "adapters_createpublicoperationadapter",
+      "label": "createPublicOperationAdapter()",
+      "norm_label": "createpublicoperationadapter()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "adapters_isadmitted",
+      "label": "isAdmitted()",
+      "norm_label": "isadmitted()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "adapters_resolveoperationadmission",
+      "label": "resolveOperationAdmission()",
+      "norm_label": "resolveoperationadmission()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
+      "source_location": "L59"
+    },
+    {
+      "community": 569,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
+      "label": "adapters.ts",
+      "norm_label": "adapters.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
+      "source_location": "L1"
     },
     {
       "community": 57,
@@ -267723,51 +267744,6 @@
     {
       "community": 570,
       "file_type": "code",
-      "id": "adapters_createnormaluseroperationadapter",
-      "label": "createNormalUserOperationAdapter()",
-      "norm_label": "createnormaluseroperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "adapters_createpublicoperationadapter",
-      "label": "createPublicOperationAdapter()",
-      "norm_label": "createpublicoperationadapter()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
-      "source_location": "L41"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "adapters_isadmitted",
-      "label": "isAdmitted()",
-      "norm_label": "isadmitted()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "adapters_resolveoperationadmission",
-      "label": "resolveOperationAdmission()",
-      "norm_label": "resolveoperationadmission()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 570,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_adapters_ts",
-      "label": "adapters.ts",
-      "norm_label": "adapters.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/adapters.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 571,
-      "file_type": "code",
       "id": "approvalrequesterchallenges_consumeapprovalrequesterchallengewithctx",
       "label": "consumeApprovalRequesterChallengeWithCtx()",
       "norm_label": "consumeapprovalrequesterchallengewithctx()",
@@ -267775,7 +267751,7 @@
       "source_location": "L97"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "approvalrequesterchallenges_createapprovalrequesterchallengewithctx",
       "label": "createApprovalRequesterChallengeWithCtx()",
@@ -267784,7 +267760,7 @@
       "source_location": "L55"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "approvalrequesterchallenges_invalidapprovalrequesterchallengeresult",
       "label": "invalidApprovalRequesterChallengeResult()",
@@ -267793,7 +267769,7 @@
       "source_location": "L37"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "approvalrequesterchallenges_torequesterbinding",
       "label": "toRequesterBinding()",
@@ -267802,7 +267778,7 @@
       "source_location": "L44"
     },
     {
-      "community": 571,
+      "community": 570,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalrequesterchallenges_ts",
       "label": "approvalRequesterChallenges.ts",
@@ -267811,7 +267787,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "customerprofiles_compactrecord",
       "label": "compactRecord()",
@@ -267820,7 +267796,7 @@
       "source_location": "L24"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "customerprofiles_ensurecustomerprofilefromsourceswithctx",
       "label": "ensureCustomerProfileFromSourcesWithCtx()",
@@ -267829,7 +267805,7 @@
       "source_location": "L207"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "customerprofiles_findexistingprofile",
       "label": "findExistingProfile()",
@@ -267838,7 +267814,7 @@
       "source_location": "L45"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "customerprofiles_loadcustomersources",
       "label": "loadCustomerSources()",
@@ -267847,7 +267823,7 @@
       "source_location": "L30"
     },
     {
-      "community": 572,
+      "community": 571,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_customerprofiles_ts",
       "label": "customerProfiles.ts",
@@ -267856,7 +267832,7 @@
       "source_location": "L1"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "operationalworkitems_test_approvalrequest",
       "label": "approvalRequest()",
@@ -267865,7 +267841,7 @@
       "source_location": "L46"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "operationalworkitems_test_createqueuecontext",
       "label": "createQueueContext()",
@@ -267874,7 +267850,7 @@
       "source_location": "L59"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "operationalworkitems_test_gethandler",
       "label": "getHandler()",
@@ -267883,7 +267859,7 @@
       "source_location": "L25"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "operationalworkitems_test_workitem",
       "label": "workItem()",
@@ -267892,7 +267868,7 @@
       "source_location": "L31"
     },
     {
-      "community": 573,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_operationalworkitems_test_ts",
       "label": "operationalWorkItems.test.ts",
@@ -267901,7 +267877,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_paymenttotals_ts",
       "label": "paymentTotals.ts",
@@ -267910,7 +267886,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "paymenttotals_buildpaymenttotals",
       "label": "buildPaymentTotals()",
@@ -267919,7 +267895,7 @@
       "source_location": "L50"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "paymenttotals_listtransactionpayments",
       "label": "listTransactionPayments()",
@@ -267928,7 +267904,7 @@
       "source_location": "L11"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "paymenttotals_transactioncashdelta",
       "label": "transactionCashDelta()",
@@ -267937,7 +267913,7 @@
       "source_location": "L81"
     },
     {
-      "community": 574,
+      "community": 573,
       "file_type": "code",
       "id": "paymenttotals_transactionpaymenttotals",
       "label": "transactionPaymentTotals()",
@@ -267946,7 +267922,7 @@
       "source_location": "L25"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_staffcredentials_test_ts",
       "label": "staffCredentials.test.ts",
@@ -267955,7 +267931,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "staffcredentials_test_admissionawareauth",
       "label": "admissionAwareAuth()",
@@ -267964,7 +267940,7 @@
       "source_location": "L256"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "staffcredentials_test_createrestoredproofvalidationctx",
       "label": "createRestoredProofValidationCtx()",
@@ -267973,7 +267949,7 @@
       "source_location": "L271"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "staffcredentials_test_createstaffcredentialsmutationctx",
       "label": "createStaffCredentialsMutationCtx()",
@@ -267982,7 +267958,7 @@
       "source_location": "L81"
     },
     {
-      "community": 575,
+      "community": 574,
       "file_type": "code",
       "id": "staffcredentials_test_gethandler",
       "label": "getHandler()",
@@ -267991,7 +267967,7 @@
       "source_location": "L267"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "assigncustomer_test_customerprofile",
       "label": "customerProfile()",
@@ -268000,7 +267976,7 @@
       "source_location": "L319"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "assigncustomer_test_guest",
       "label": "guest()",
@@ -268009,7 +267985,7 @@
       "source_location": "L346"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "assigncustomer_test_poscustomer",
       "label": "posCustomer()",
@@ -268018,7 +267994,7 @@
       "source_location": "L303"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "assigncustomer_test_storefrontuser",
       "label": "storeFrontUser()",
@@ -268027,7 +268003,7 @@
       "source_location": "L333"
     },
     {
-      "community": 576,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_assigncustomer_test_ts",
       "label": "assignCustomer.test.ts",
@@ -268036,7 +268012,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_registerlifecycleauthority_ts",
       "label": "registerLifecycleAuthority.ts",
@@ -268045,7 +268021,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "registerlifecycleauthority_acknowledgeregisterlifecycleauthority",
       "label": "acknowledgeRegisterLifecycleAuthority()",
@@ -268054,7 +268030,7 @@
       "source_location": "L46"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "registerlifecycleauthority_equivalentacknowledgement",
       "label": "equivalentAcknowledgement()",
@@ -268063,7 +268039,7 @@
       "source_location": "L124"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "registerlifecycleauthority_isrevision",
       "label": "isRevision()",
@@ -268072,7 +268048,7 @@
       "source_location": "L153"
     },
     {
-      "community": 577,
+      "community": 576,
       "file_type": "code",
       "id": "registerlifecycleauthority_normalizesafemetadata",
       "label": "normalizeSafeMetadata()",
@@ -268081,7 +268057,7 @@
       "source_location": "L145"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "correctionpolicy_builddecision",
       "label": "buildDecision()",
@@ -268090,7 +268066,7 @@
       "source_location": "L107"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "correctionpolicy_classifycorrectionintent",
       "label": "classifyCorrectionIntent()",
@@ -268099,7 +268075,7 @@
       "source_location": "L117"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "correctionpolicy_issupportedcorrectionintent",
       "label": "isSupportedCorrectionIntent()",
@@ -268108,7 +268084,7 @@
       "source_location": "L91"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "correctionpolicy_isunsupportedhighriskcorrectionintent",
       "label": "isUnsupportedHighRiskCorrectionIntent()",
@@ -268117,7 +268093,7 @@
       "source_location": "L99"
     },
     {
-      "community": 578,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_corrections_correctionpolicy_ts",
       "label": "correctionPolicy.ts",
@@ -268126,7 +268102,7 @@
       "source_location": "L1"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_reconcilesequencegaps_ts",
       "label": "reconcileSequenceGaps.ts",
@@ -268135,7 +268111,7 @@
       "source_location": "L1"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "reconcilesequencegaps_collectterminalevidence",
       "label": "collectTerminalEvidence()",
@@ -268144,7 +268120,7 @@
       "source_location": "L185"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "reconcilesequencegaps_issuegapprobe",
       "label": "issueGapProbe()",
@@ -268153,7 +268129,7 @@
       "source_location": "L249"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "reconcilesequencegaps_listheldeventsforcursor",
       "label": "listHeldEventsForCursor()",
@@ -268162,13 +268138,58 @@
       "source_location": "L156"
     },
     {
-      "community": 579,
+      "community": 578,
       "file_type": "code",
       "id": "reconcilesequencegaps_skipsequencegap",
       "label": "skipSequenceGap()",
       "norm_label": "skipsequencegap()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/reconcileSequenceGaps.ts",
       "source_location": "L295"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
+      "label": "policy.test.ts",
+      "norm_label": "policy.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "policy_test_baseinput",
+      "label": "baseInput()",
+      "norm_label": "baseinput()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
+      "source_location": "L1225"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "policy_test_buildregistersession",
+      "label": "buildRegisterSession()",
+      "norm_label": "buildregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
+      "source_location": "L1329"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "policy_test_buildruntimestatus",
+      "label": "buildRuntimeStatus()",
+      "norm_label": "buildruntimestatus()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
+      "source_location": "L1287"
+    },
+    {
+      "community": 579,
+      "file_type": "code",
+      "id": "policy_test_emptysyncevidence",
+      "label": "emptySyncEvidence()",
+      "norm_label": "emptysyncevidence()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
+      "source_location": "L1267"
     },
     {
       "community": 58,
@@ -268416,51 +268437,6 @@
     {
       "community": 580,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminaloperationalstate_policy_test_ts",
-      "label": "policy.test.ts",
-      "norm_label": "policy.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "policy_test_baseinput",
-      "label": "baseInput()",
-      "norm_label": "baseinput()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
-      "source_location": "L1225"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "policy_test_buildregistersession",
-      "label": "buildRegisterSession()",
-      "norm_label": "buildregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
-      "source_location": "L1329"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "policy_test_buildruntimestatus",
-      "label": "buildRuntimeStatus()",
-      "norm_label": "buildruntimestatus()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
-      "source_location": "L1287"
-    },
-    {
-      "community": 580,
-      "file_type": "code",
-      "id": "policy_test_emptysyncevidence",
-      "label": "emptySyncEvidence()",
-      "norm_label": "emptysyncevidence()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalOperationalState/policy.test.ts",
-      "source_location": "L1267"
-    },
-    {
-      "community": 581,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_terminalrecoveryrepository_test_ts",
       "label": "terminalRecoveryRepository.test.ts",
       "norm_label": "terminalrecoveryrepository.test.ts",
@@ -268468,7 +268444,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildctx",
       "label": "buildCtx()",
@@ -268477,7 +268453,7 @@
       "source_location": "L381"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_buildqueryctx",
       "label": "buildQueryCtx()",
@@ -268486,7 +268462,7 @@
       "source_location": "L469"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_filterrows",
       "label": "filterRows()",
@@ -268495,7 +268471,7 @@
       "source_location": "L483"
     },
     {
-      "community": 581,
+      "community": 580,
       "file_type": "code",
       "id": "terminalrecoveryrepository_test_orderedrows",
       "label": "orderedRows()",
@@ -268504,7 +268480,7 @@
       "source_location": "L492"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "customers_requireposcustomeraccessbyid",
       "label": "requirePosCustomerAccessById()",
@@ -268513,7 +268489,7 @@
       "source_location": "L76"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "customers_requireposcustomerreadaccessbyid",
       "label": "requirePosCustomerReadAccessById()",
@@ -268522,7 +268498,7 @@
       "source_location": "L123"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "customers_requireposcustomerstoreaccess",
       "label": "requirePosCustomerStoreAccess()",
@@ -268531,7 +268507,7 @@
       "source_location": "L53"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "customers_requireposcustomerstorereadaccess",
       "label": "requirePosCustomerStoreReadAccess()",
@@ -268540,7 +268516,7 @@
       "source_location": "L99"
     },
     {
-      "community": 582,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_customers_ts",
       "label": "customers.ts",
@@ -268549,7 +268525,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_posrecoverycodes_test_ts",
       "label": "posRecoveryCodes.test.ts",
@@ -268558,7 +268534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "posrecoverycodes_test_buildctx",
       "label": "buildCtx()",
@@ -268567,7 +268543,7 @@
       "source_location": "L565"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "posrecoverycodes_test_createfilter",
       "label": "createFilter()",
@@ -268576,7 +268552,7 @@
       "source_location": "L669"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "posrecoverycodes_test_createquery",
       "label": "createQuery()",
@@ -268585,7 +268561,7 @@
       "source_location": "L642"
     },
     {
-      "community": 583,
+      "community": 582,
       "file_type": "code",
       "id": "posrecoverycodes_test_gethandler",
       "label": "getHandler()",
@@ -268594,7 +268570,7 @@
       "source_location": "L25"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -268603,7 +268579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -268612,7 +268588,7 @@
       "source_location": "L106"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -268621,7 +268597,7 @@
       "source_location": "L34"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -268630,7 +268606,7 @@
       "source_location": "L24"
     },
     {
-      "community": 584,
+      "community": 583,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -268639,7 +268615,7 @@
       "source_location": "L371"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_transactions_ts",
       "label": "transactions.ts",
@@ -268648,7 +268624,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "transactions_mapcorrectionerror",
       "label": "mapCorrectionError()",
@@ -268657,7 +268633,7 @@
       "source_location": "L339"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "transactions_redactpospulsesummary",
       "label": "redactPosPulseSummary()",
@@ -268666,7 +268642,7 @@
       "source_location": "L307"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "transactions_requirepostransactionaccess",
       "label": "requirePosTransactionAccess()",
@@ -268675,7 +268651,7 @@
       "source_location": "L93"
     },
     {
-      "community": 585,
+      "community": 584,
       "file_type": "code",
       "id": "transactions_requirepostransactionstoreaccess",
       "label": "requirePosTransactionStoreAccess()",
@@ -268684,7 +268660,7 @@
       "source_location": "L64"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_application_policy_ts",
       "label": "policy.ts",
@@ -268693,7 +268669,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "policy_denied",
       "label": "denied()",
@@ -268702,7 +268678,7 @@
       "source_location": "L96"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "policy_evaluateremoteassistpolicy",
       "label": "evaluateRemoteAssistPolicy()",
@@ -268711,7 +268687,7 @@
       "source_location": "L31"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "policy_isclientfresh",
       "label": "isClientFresh()",
@@ -268720,7 +268696,7 @@
       "source_location": "L88"
     },
     {
-      "community": 586,
+      "community": 585,
       "file_type": "code",
       "id": "policy_policydecisiontocommandresult",
       "label": "policyDecisionToCommandResult()",
@@ -268729,7 +268705,7 @@
       "source_location": "L76"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_infrastructure_remoteassistreadrepository_ts",
       "label": "remoteAssistReadRepository.ts",
@@ -268738,7 +268714,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "remoteassistreadrepository_compareremoteassistsessionforsupportview",
       "label": "compareRemoteAssistSessionForSupportView()",
@@ -268747,7 +268723,7 @@
       "source_location": "L88"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "remoteassistreadrepository_createremoteassistreadrepository",
       "label": "createRemoteAssistReadRepository()",
@@ -268756,7 +268732,7 @@
       "source_location": "L10"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistclient",
       "label": "toRemoteAssistClient()",
@@ -268765,7 +268741,7 @@
       "source_location": "L108"
     },
     {
-      "community": 587,
+      "community": 586,
       "file_type": "code",
       "id": "remoteassistreadrepository_toremoteassistsession",
       "label": "toRemoteAssistSession()",
@@ -268774,7 +268750,7 @@
       "source_location": "L121"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "fingerprint_factfingerprint",
       "label": "factFingerprint()",
@@ -268783,7 +268759,7 @@
       "source_location": "L86"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "fingerprint_fingerprintpayload",
       "label": "fingerprintPayload()",
@@ -268792,7 +268768,7 @@
       "source_location": "L33"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "fingerprint_matchesstoredfingerprint",
       "label": "matchesStoredFingerprint()",
@@ -268801,7 +268777,7 @@
       "source_location": "L103"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "fingerprint_stablestringhash",
       "label": "stableStringHash()",
@@ -268810,7 +268786,7 @@
       "source_location": "L72"
     },
     {
-      "community": 588,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_fingerprint_ts",
       "label": "fingerprint.ts",
@@ -268819,7 +268795,7 @@
       "source_location": "L1"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "foldday_test_fact",
       "label": "fact()",
@@ -268828,7 +268804,7 @@
       "source_location": "L78"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "foldday_test_receipt",
       "label": "receipt()",
@@ -268837,7 +268813,7 @@
       "source_location": "L757"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "foldday_test_sale",
       "label": "sale()",
@@ -268846,7 +268822,7 @@
       "source_location": "L97"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "foldday_test_shuffle",
       "label": "shuffle()",
@@ -268855,13 +268831,58 @@
       "source_location": "L108"
     },
     {
-      "community": 589,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_test_ts",
       "label": "foldDay.test.ts",
       "norm_label": "foldday.test.ts",
       "source_file": "packages/athena-webapp/convex/reports/foldDay.test.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
+      "label": "serviceCases.test.ts",
+      "norm_label": "servicecases.test.ts",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "servicecases_test_createinventoryusagectx",
+      "label": "createInventoryUsageCtx()",
+      "norm_label": "createinventoryusagectx()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "servicecases_test_expectindex",
+      "label": "expectIndex()",
+      "norm_label": "expectindex()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "servicecases_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L73"
+    },
+    {
+      "community": 589,
+      "file_type": "code",
+      "id": "servicecases_test_gettableindexes",
+      "label": "getTableIndexes()",
+      "norm_label": "gettableindexes()",
+      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
+      "source_location": "L59"
     },
     {
       "community": 59,
@@ -269100,51 +269121,6 @@
     {
       "community": 590,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_serviceops_servicecases_test_ts",
-      "label": "serviceCases.test.ts",
-      "norm_label": "servicecases.test.ts",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "servicecases_test_createinventoryusagectx",
-      "label": "createInventoryUsageCtx()",
-      "norm_label": "createinventoryusagectx()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "servicecases_test_expectindex",
-      "label": "expectIndex()",
-      "norm_label": "expectindex()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "servicecases_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L73"
-    },
-    {
-      "community": 590,
-      "file_type": "code",
-      "id": "servicecases_test_gettableindexes",
-      "label": "getTableIndexes()",
-      "norm_label": "gettableindexes()",
-      "source_file": "packages/athena-webapp/convex/serviceOps/serviceCases.test.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 591,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_services_paystackservice_ts",
       "label": "paystackService.ts",
       "norm_label": "paystackservice.ts",
@@ -269152,7 +269128,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "paystackservice_getpaystackheaders",
       "label": "getPaystackHeaders()",
@@ -269161,7 +269137,7 @@
       "source_location": "L11"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "paystackservice_initializetransaction",
       "label": "initializeTransaction()",
@@ -269170,7 +269146,7 @@
       "source_location": "L21"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "paystackservice_initiaterefund",
       "label": "initiateRefund()",
@@ -269179,7 +269155,7 @@
       "source_location": "L87"
     },
     {
-      "community": 591,
+      "community": 590,
       "file_type": "code",
       "id": "paystackservice_verifytransaction",
       "label": "verifyTransaction()",
@@ -269188,7 +269164,7 @@
       "source_location": "L65"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "admission_test_admissioncontext",
       "label": "admissionContext()",
@@ -269197,7 +269173,7 @@
       "source_location": "L17"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "admission_test_configureadmissionenvironment",
       "label": "configureAdmissionEnvironment()",
@@ -269206,7 +269182,7 @@
       "source_location": "L60"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "admission_test_contextwith",
       "label": "contextWith()",
@@ -269215,7 +269191,7 @@
       "source_location": "L120"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "admission_test_invoke",
       "label": "invoke()",
@@ -269224,7 +269200,7 @@
       "source_location": "L14"
     },
     {
-      "community": 592,
+      "community": 591,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_admission_test_ts",
       "label": "admission.test.ts",
@@ -269233,7 +269209,7 @@
       "source_location": "L1"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "config_calculateshareddemoexpectedcash",
       "label": "calculateSharedDemoExpectedCash()",
@@ -269242,7 +269218,7 @@
       "source_location": "L23"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "config_isshareddemoenabled",
       "label": "isSharedDemoEnabled()",
@@ -269251,7 +269227,7 @@
       "source_location": "L33"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "config_readruntimeshareddemoconfig",
       "label": "readRuntimeSharedDemoConfig()",
@@ -269260,7 +269236,7 @@
       "source_location": "L59"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "config_readshareddemoconfig",
       "label": "readSharedDemoConfig()",
@@ -269269,7 +269245,7 @@
       "source_location": "L40"
     },
     {
-      "community": 593,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_config_ts",
       "label": "config.ts",
@@ -269278,7 +269254,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemoopeningbaseline",
       "label": "buildSharedDemoOpeningBaseline()",
@@ -269287,7 +269263,7 @@
       "source_location": "L63"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "openingbaseline_buildshareddemostoredayevent",
       "label": "buildSharedDemoStoreDayEvent()",
@@ -269296,7 +269272,7 @@
       "source_location": "L105"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "openingbaseline_rollshareddemoopeningbaselinewithctx",
       "label": "rollSharedDemoOpeningBaselineWithCtx()",
@@ -269305,7 +269281,7 @@
       "source_location": "L132"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "openingbaseline_shareddemooperatingdaterange",
       "label": "sharedDemoOperatingDateRange()",
@@ -269314,7 +269290,7 @@
       "source_location": "L21"
     },
     {
-      "community": 594,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_openingbaseline_ts",
       "label": "openingBaseline.ts",
@@ -269323,7 +269299,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "operationadapter_createshareddemooperationadapter",
       "label": "createSharedDemoOperationAdapter()",
@@ -269332,7 +269308,7 @@
       "source_location": "L18"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "operationadapter_isrecognizedshareddemoactorerror",
       "label": "isRecognizedSharedDemoActorError()",
@@ -269341,7 +269317,7 @@
       "source_location": "L100"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "operationadapter_shareddemodenialerror",
       "label": "sharedDemoDenialError()",
@@ -269350,7 +269326,7 @@
       "source_location": "L124"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "operationadapter_shareddemodenied",
       "label": "sharedDemoDenied()",
@@ -269359,7 +269335,7 @@
       "source_location": "L108"
     },
     {
-      "community": 595,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_operationadapter_ts",
       "label": "operationAdapter.ts",
@@ -269368,7 +269344,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_storefrontobservabilityreport_ts",
       "label": "storefrontObservabilityReport.ts",
@@ -269377,7 +269353,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "storefrontobservabilityreport_buildstorefrontobservabilityreport",
       "label": "buildStorefrontObservabilityReport()",
@@ -269386,7 +269362,7 @@
       "source_location": "L124"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "storefrontobservabilityreport_getnonemptystring",
       "label": "getNonEmptyString()",
@@ -269395,7 +269371,7 @@
       "source_location": "L67"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "storefrontobservabilityreport_gettrafficsource",
       "label": "getTrafficSource()",
@@ -269404,7 +269380,7 @@
       "source_location": "L106"
     },
     {
-      "community": 596,
+      "community": 595,
       "file_type": "code",
       "id": "storefrontobservabilityreport_normalizestorefrontobservabilityevent",
       "label": "normalizeStorefrontObservabilityEvent()",
@@ -269413,7 +269389,7 @@
       "source_location": "L73"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "onlineorder_buildlookup",
       "label": "buildLookup()",
@@ -269422,7 +269398,7 @@
       "source_location": "L65"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "onlineorder_buildonlineordertraceseed",
       "label": "buildOnlineOrderTraceSeed()",
@@ -269431,7 +269407,7 @@
       "source_location": "L85"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "onlineorder_buildsafeexternalreferenceref",
       "label": "buildSafeExternalReferenceRef()",
@@ -269440,7 +269416,7 @@
       "source_location": "L53"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "onlineorder_stablefingerprint",
       "label": "stableFingerprint()",
@@ -269449,7 +269425,7 @@
       "source_location": "L43"
     },
     {
-      "community": 597,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -269458,7 +269434,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_queryusage_test_ts",
       "label": "queryUsage.test.ts",
@@ -269467,7 +269443,7 @@
       "source_location": "L1"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "queryusage_test_comparebyfields",
       "label": "compareByFields()",
@@ -269476,7 +269452,7 @@
       "source_location": "L102"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "queryusage_test_createadmintracereadctx",
       "label": "createAdminTraceReadCtx()",
@@ -269485,7 +269461,7 @@
       "source_location": "L220"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "queryusage_test_createtestctx",
       "label": "createTestCtx()",
@@ -269494,7 +269470,7 @@
       "source_location": "L118"
     },
     {
-      "community": 598,
+      "community": 597,
       "file_type": "code",
       "id": "queryusage_test_deniedauthorizer",
       "label": "deniedAuthorizer()",
@@ -269503,7 +269479,7 @@
       "source_location": "L1071"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "appsettingsview_appearancelabel",
       "label": "appearanceLabel()",
@@ -269512,7 +269488,7 @@
       "source_location": "L38"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "appsettingsview_cn",
       "label": "cn()",
@@ -269521,7 +269497,7 @@
       "source_location": "L154"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "appsettingsview_selectthememode",
       "label": "selectThemeMode()",
@@ -269530,7 +269506,7 @@
       "source_location": "L85"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "appsettingsview_transitiontimelabel",
       "label": "transitionTimeLabel()",
@@ -269539,12 +269515,57 @@
       "source_location": "L42"
     },
     {
-      "community": 599,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
       "label": "AppSettingsView.tsx",
       "norm_label": "appsettingsview.tsx",
       "source_file": "packages/athena-webapp/src/components/app-settings/AppSettingsView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "dashboard_getperiodrange",
+      "label": "getPeriodRange()",
+      "norm_label": "getperiodrange()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "dashboard_loadingsection",
+      "label": "LoadingSection()",
+      "norm_label": "loadingsection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L49"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "dashboard_renderproductssection",
+      "label": "renderProductsSection()",
+      "norm_label": "renderproductssection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L341"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "dashboard_rendersalessection",
+      "label": "renderSalesSection()",
+      "norm_label": "rendersalessection()",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
+      "source_location": "L321"
+    },
+    {
+      "community": 599,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
+      "label": "Dashboard.tsx",
+      "norm_label": "dashboard.tsx",
+      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
       "source_location": "L1"
     },
     {
@@ -270432,51 +270453,6 @@
     {
       "community": 600,
       "file_type": "code",
-      "id": "dashboard_getperiodrange",
-      "label": "getPeriodRange()",
-      "norm_label": "getperiodrange()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "dashboard_loadingsection",
-      "label": "LoadingSection()",
-      "norm_label": "loadingsection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L49"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "dashboard_renderproductssection",
-      "label": "renderProductsSection()",
-      "norm_label": "renderproductssection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L341"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "dashboard_rendersalessection",
-      "label": "renderSalesSection()",
-      "norm_label": "rendersalessection()",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L321"
-    },
-    {
-      "community": 600,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
-      "label": "Dashboard.tsx",
-      "norm_label": "dashboard.tsx",
-      "source_file": "packages/athena-webapp/src/components/dashboard/Dashboard.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 601,
-      "file_type": "code",
       "id": "docsscrolltotop_cancel",
       "label": "cancel()",
       "norm_label": "cancel()",
@@ -270484,7 +270460,7 @@
       "source_location": "L87"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "docsscrolltotop_handleclick",
       "label": "handleClick()",
@@ -270493,7 +270469,7 @@
       "source_location": "L103"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "docsscrolltotop_read",
       "label": "read()",
@@ -270502,7 +270478,7 @@
       "source_location": "L37"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "docsscrolltotop_schedule",
       "label": "schedule()",
@@ -270511,7 +270487,7 @@
       "source_location": "L59"
     },
     {
-      "community": 601,
+      "community": 600,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsscrolltotop_tsx",
       "label": "DocsScrollToTop.tsx",
@@ -270520,7 +270496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "herosectiontabs_handledisplaytypechange",
       "label": "handleDisplayTypeChange()",
@@ -270529,7 +270505,7 @@
       "source_location": "L61"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "herosectiontabs_handleimageupdate",
       "label": "handleImageUpdate()",
@@ -270538,7 +270514,7 @@
       "source_location": "L57"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "herosectiontabs_handleoverlaytoggle",
       "label": "handleOverlayToggle()",
@@ -270547,7 +270523,7 @@
       "source_location": "L98"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "herosectiontabs_handletexttoggle",
       "label": "handleTextToggle()",
@@ -270556,7 +270532,7 @@
       "source_location": "L134"
     },
     {
-      "community": 602,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
       "label": "HeroSectionTabs.tsx",
@@ -270565,7 +270541,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
@@ -270574,7 +270550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -270583,7 +270559,7 @@
       "source_location": "L38"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -270592,7 +270568,7 @@
       "source_location": "L64"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -270601,7 +270577,7 @@
       "source_location": "L135"
     },
     {
-      "community": 603,
+      "community": 602,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -270610,7 +270586,7 @@
       "source_location": "L43"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -270619,7 +270595,7 @@
       "source_location": "L90"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -270628,7 +270604,7 @@
       "source_location": "L95"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -270637,7 +270613,7 @@
       "source_location": "L82"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -270646,7 +270622,7 @@
       "source_location": "L85"
     },
     {
-      "community": 604,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -270655,7 +270631,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -270664,7 +270640,7 @@
       "source_location": "L113"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -270673,7 +270649,7 @@
       "source_location": "L349"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -270682,7 +270658,7 @@
       "source_location": "L86"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -270691,7 +270667,7 @@
       "source_location": "L62"
     },
     {
-      "community": 605,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -270700,7 +270676,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "cashierauthdialog_test_buildlocalauthorityrecord",
       "label": "buildLocalAuthorityRecord()",
@@ -270709,7 +270685,7 @@
       "source_location": "L121"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "cashierauthdialog_test_renderdialog",
       "label": "renderDialog()",
@@ -270718,7 +270694,7 @@
       "source_location": "L152"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitcredentials",
       "label": "submitCredentials()",
@@ -270727,7 +270703,7 @@
       "source_location": "L216"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitlockedcashierpin",
       "label": "submitLockedCashierPin()",
@@ -270736,7 +270712,7 @@
       "source_location": "L208"
     },
     {
-      "community": 606,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -270745,7 +270721,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -270754,7 +270730,7 @@
       "source_location": "L49"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -270763,7 +270739,7 @@
       "source_location": "L66"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -270772,7 +270748,7 @@
       "source_location": "L75"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -270781,7 +270757,7 @@
       "source_location": "L45"
     },
     {
-      "community": 607,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -270790,7 +270766,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
@@ -270799,7 +270775,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -270808,7 +270784,7 @@
       "source_location": "L185"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -270817,7 +270793,7 @@
       "source_location": "L160"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -270826,7 +270802,7 @@
       "source_location": "L163"
     },
     {
-      "community": 608,
+      "community": 607,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -270835,7 +270811,7 @@
       "source_location": "L165"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -270844,7 +270820,7 @@
       "source_location": "L1"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -270853,7 +270829,7 @@
       "source_location": "L220"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -270862,7 +270838,7 @@
       "source_location": "L108"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -270871,13 +270847,58 @@
       "source_location": "L87"
     },
     {
-      "community": 609,
+      "community": 608,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
       "norm_label": "productactionstogglegroup()",
       "source_file": "packages/athena-webapp/src/components/products/ProductsListView.tsx",
       "source_location": "L33"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
+      "label": "PromoCodeView.tsx",
+      "norm_label": "promocodeview.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "promocodeview_handleaddpromocode",
+      "label": "handleAddPromoCode()",
+      "norm_label": "handleaddpromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L158"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "promocodeview_handleupdatepromocode",
+      "label": "handleUpdatePromoCode()",
+      "norm_label": "handleupdatepromocode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L231"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "promocodeview_updatehomepagediscountcode",
+      "label": "updateHomepageDiscountCode()",
+      "norm_label": "updatehomepagediscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L324"
+    },
+    {
+      "community": 609,
+      "file_type": "code",
+      "id": "promocodeview_updateleaveareviewdiscountcode",
+      "label": "updateLeaveAReviewDiscountCode()",
+      "norm_label": "updateleaveareviewdiscountcode()",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
+      "source_location": "L379"
     },
     {
       "community": 61,
@@ -271107,51 +271128,6 @@
     {
       "community": 610,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
-      "label": "PromoCodeView.tsx",
-      "norm_label": "promocodeview.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "promocodeview_handleaddpromocode",
-      "label": "handleAddPromoCode()",
-      "norm_label": "handleaddpromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L158"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "promocodeview_handleupdatepromocode",
-      "label": "handleUpdatePromoCode()",
-      "norm_label": "handleupdatepromocode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L231"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "promocodeview_updatehomepagediscountcode",
-      "label": "updateHomepageDiscountCode()",
-      "norm_label": "updatehomepagediscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L324"
-    },
-    {
-      "community": 610,
-      "file_type": "code",
-      "id": "promocodeview_updateleaveareviewdiscountcode",
-      "label": "updateLeaveAReviewDiscountCode()",
-      "norm_label": "updateleaveareviewdiscountcode()",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/PromoCodeView.tsx",
-      "source_location": "L379"
-    },
-    {
-      "community": 611,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "label": "ReportsOverviewView.test.tsx",
       "norm_label": "reportsoverviewview.test.tsx",
@@ -271159,7 +271135,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "reportsoverviewview_test_expectanimatedmetrics",
       "label": "expectAnimatedMetrics()",
@@ -271168,7 +271144,7 @@
       "source_location": "L450"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "reportsoverviewview_test_harness",
       "label": "Harness()",
@@ -271177,7 +271153,7 @@
       "source_location": "L173"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "reportsoverviewview_test_linkedrange",
       "label": "linkedRange()",
@@ -271186,7 +271162,7 @@
       "source_location": "L584"
     },
     {
-      "community": 611,
+      "community": 610,
       "file_type": "code",
       "id": "reportsoverviewview_test_snapshot",
       "label": "snapshot()",
@@ -271195,7 +271171,7 @@
       "source_location": "L87"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
       "label": "reportRouteSearch.ts",
@@ -271204,7 +271180,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "reportroutesearch_overviewsearchfromweeklyreturn",
       "label": "overviewSearchFromWeeklyReturn()",
@@ -271213,7 +271189,7 @@
       "source_location": "L148"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "reportroutesearch_parseunitssheetfocussearch",
       "label": "parseUnitsSheetFocusSearch()",
@@ -271222,7 +271198,7 @@
       "source_location": "L81"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "reportroutesearch_unitssheetfocussearchvalue",
       "label": "unitsSheetFocusSearchValue()",
@@ -271231,7 +271207,7 @@
       "source_location": "L72"
     },
     {
-      "community": 612,
+      "community": 611,
       "file_type": "code",
       "id": "reportroutesearch_weeklyreturnsearchfromoverview",
       "label": "weeklyReturnSearchFromOverview()",
@@ -271240,7 +271216,7 @@
       "source_location": "L125"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
@@ -271249,7 +271225,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -271258,7 +271234,7 @@
       "source_location": "L165"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -271267,7 +271243,7 @@
       "source_location": "L379"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -271276,7 +271252,7 @@
       "source_location": "L312"
     },
     {
-      "community": 613,
+      "community": 612,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -271285,7 +271261,7 @@
       "source_location": "L202"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -271294,7 +271270,7 @@
       "source_location": "L101"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -271303,7 +271279,7 @@
       "source_location": "L55"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -271312,7 +271288,7 @@
       "source_location": "L77"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -271321,7 +271297,7 @@
       "source_location": "L65"
     },
     {
-      "community": 614,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -271330,7 +271306,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -271339,7 +271315,7 @@
       "source_location": "L7"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -271348,7 +271324,7 @@
       "source_location": "L69"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -271357,7 +271333,7 @@
       "source_location": "L44"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -271366,7 +271342,7 @@
       "source_location": "L103"
     },
     {
-      "community": 615,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -271375,7 +271351,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
       "label": "useExpenseLocalRuntime.ts",
@@ -271384,7 +271360,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "useexpenselocalruntime_createlocalid",
       "label": "createLocalId()",
@@ -271393,7 +271369,7 @@
       "source_location": "L23"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "useexpenselocalruntime_getexpenselocalstore",
       "label": "getExpenseLocalStore()",
@@ -271402,7 +271378,7 @@
       "source_location": "L12"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
       "label": "notifyExpenseLocalEventAppended()",
@@ -271411,7 +271387,7 @@
       "source_location": "L17"
     },
     {
-      "community": 616,
+      "community": 615,
       "file_type": "code",
       "id": "useexpenselocalruntime_useexpenselocalruntime",
       "label": "useExpenseLocalRuntime()",
@@ -271420,7 +271396,7 @@
       "source_location": "L31"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "appmessagesprovider_appmessagesprovider",
       "label": "AppMessagesProvider()",
@@ -271429,7 +271405,7 @@
       "source_location": "L28"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "appmessagesprovider_areblockersequal",
       "label": "areBlockersEqual()",
@@ -271438,7 +271414,7 @@
       "source_location": "L215"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "appmessagesprovider_aremessagesequal",
       "label": "areMessagesEqual()",
@@ -271447,7 +271423,7 @@
       "source_location": "L185"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "appmessagesprovider_getpreferredvariant",
       "label": "getPreferredVariant()",
@@ -271456,7 +271432,7 @@
       "source_location": "L203"
     },
     {
-      "community": 617,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
       "label": "AppMessagesProvider.tsx",
@@ -271465,7 +271441,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "appactionblockers_compareappactionblockers",
       "label": "compareAppActionBlockers()",
@@ -271474,7 +271450,7 @@
       "source_location": "L41"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "appactionblockers_getselectedappactionblocker",
       "label": "getSelectedAppActionBlocker()",
@@ -271483,7 +271459,7 @@
       "source_location": "L26"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "appactionblockers_isvalidappactionblockerinput",
       "label": "isValidAppActionBlockerInput()",
@@ -271492,7 +271468,7 @@
       "source_location": "L30"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "appactionblockers_sortappactionblockers",
       "label": "sortAppActionBlockers()",
@@ -271501,7 +271477,7 @@
       "source_location": "L22"
     },
     {
-      "community": 618,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appactionblockers_ts",
       "label": "appActionBlockers.ts",
@@ -271510,7 +271486,7 @@
       "source_location": "L1"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "appmessages_compareappmessages",
       "label": "compareAppMessages()",
@@ -271519,7 +271495,7 @@
       "source_location": "L39"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "appmessages_getselectedappmessage",
       "label": "getSelectedAppMessage()",
@@ -271528,7 +271504,7 @@
       "source_location": "L27"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "appmessages_isvalidappmessageinput",
       "label": "isValidAppMessageInput()",
@@ -271537,7 +271513,7 @@
       "source_location": "L31"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "appmessages_sortappmessages",
       "label": "sortAppMessages()",
@@ -271546,12 +271522,57 @@
       "source_location": "L23"
     },
     {
-      "community": 619,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessages_ts",
       "label": "appMessages.ts",
       "norm_label": "appmessages.ts",
       "source_file": "packages/athena-webapp/src/lib/app-messages/appMessages.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
+      "label": "clearTrackedBeforeUnloadHandlers()",
+      "norm_label": "cleartrackedbeforeunloadhandlers()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "appupdatereload_getcapture",
+      "label": "getCapture()",
+      "norm_label": "getcapture()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "appupdatereload_installappupdateunloadpromptbypass",
+      "label": "installAppUpdateUnloadPromptBypass()",
+      "norm_label": "installappupdateunloadpromptbypass()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L13"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "appupdatereload_reloadbrowserforappupdate",
+      "label": "reloadBrowserForAppUpdate()",
+      "norm_label": "reloadbrowserforappupdate()",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 619,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
+      "label": "appUpdateReload.ts",
+      "norm_label": "appupdatereload.ts",
+      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
       "source_location": "L1"
     },
     {
@@ -271782,51 +271803,6 @@
     {
       "community": 620,
       "file_type": "code",
-      "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
-      "label": "clearTrackedBeforeUnloadHandlers()",
-      "norm_label": "cleartrackedbeforeunloadhandlers()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "appupdatereload_getcapture",
-      "label": "getCapture()",
-      "norm_label": "getcapture()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "appupdatereload_installappupdateunloadpromptbypass",
-      "label": "installAppUpdateUnloadPromptBypass()",
-      "norm_label": "installappupdateunloadpromptbypass()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L13"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "appupdatereload_reloadbrowserforappupdate",
-      "label": "reloadBrowserForAppUpdate()",
-      "norm_label": "reloadbrowserforappupdate()",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 620,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
-      "label": "appUpdateReload.ts",
-      "norm_label": "appupdatereload.ts",
-      "source_file": "packages/athena-webapp/src/lib/app-update/appUpdateReload.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 621,
-      "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
       "norm_label": "buffertohex()",
@@ -271834,7 +271810,7 @@
       "source_location": "L18"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -271843,7 +271819,7 @@
       "source_location": "L23"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -271852,7 +271828,7 @@
       "source_location": "L65"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -271861,7 +271837,7 @@
       "source_location": "L45"
     },
     {
-      "community": 621,
+      "community": 620,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
@@ -271870,7 +271846,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
       "label": "runCommand.ts",
@@ -271879,7 +271855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "runcommand_extracttraceid",
       "label": "extractTraceId()",
@@ -271888,7 +271864,7 @@
       "source_location": "L40"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "runcommand_getshareddemodenial",
       "label": "getSharedDemoDenial()",
@@ -271897,7 +271873,7 @@
       "source_location": "L48"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "runcommand_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -271906,7 +271882,7 @@
       "source_location": "L34"
     },
     {
-      "community": 622,
+      "community": 621,
       "file_type": "code",
       "id": "runcommand_runcommand",
       "label": "runCommand()",
@@ -271915,7 +271891,7 @@
       "source_location": "L68"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
@@ -271924,7 +271900,7 @@
       "source_location": "L78"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -271933,7 +271909,7 @@
       "source_location": "L74"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -271942,7 +271918,7 @@
       "source_location": "L103"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -271951,7 +271927,7 @@
       "source_location": "L109"
     },
     {
-      "community": 623,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -271960,7 +271936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -271969,7 +271945,7 @@
       "source_location": "L75"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -271978,7 +271954,7 @@
       "source_location": "L26"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -271987,7 +271963,7 @@
       "source_location": "L38"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -271996,7 +271972,7 @@
       "source_location": "L4"
     },
     {
-      "community": 624,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -272005,7 +271981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -272014,7 +271990,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -272023,7 +271999,7 @@
       "source_location": "L13"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -272032,7 +272008,7 @@
       "source_location": "L31"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -272041,7 +272017,7 @@
       "source_location": "L37"
     },
     {
-      "community": 625,
+      "community": 624,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -272050,7 +272026,7 @@
       "source_location": "L59"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
       "label": "createExpenseLocalCommandGateway()",
@@ -272059,7 +272035,7 @@
       "source_location": "L55"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "expenselocalcommandgateway_itempayload",
       "label": "itemPayload()",
@@ -272068,7 +272044,7 @@
       "source_location": "L282"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "expenselocalcommandgateway_reasonpayload",
       "label": "reasonPayload()",
@@ -272077,7 +272053,7 @@
       "source_location": "L303"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "expenselocalcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -272086,7 +272062,7 @@
       "source_location": "L310"
     },
     {
-      "community": 626,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
       "label": "expenseLocalCommandGateway.ts",
@@ -272095,7 +272071,7 @@
       "source_location": "L1"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "localcommandgateway_test_appendopendrawer",
       "label": "appendOpenDrawer()",
@@ -272104,7 +272080,7 @@
       "source_location": "L22"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "localcommandgateway_test_blockdrawerauthority",
       "label": "blockDrawerAuthority()",
@@ -272113,7 +272089,7 @@
       "source_location": "L34"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "localcommandgateway_test_createblockedsalegateway",
       "label": "createBlockedSaleGateway()",
@@ -272122,7 +272098,7 @@
       "source_location": "L48"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "localcommandgateway_test_salecommandinput",
       "label": "saleCommandInput()",
@@ -272131,7 +272107,7 @@
       "source_location": "L11"
     },
     {
-      "community": 627,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
       "label": "localCommandGateway.test.ts",
@@ -272140,7 +272116,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "localregisterreader_readlatestdrawerauthoritystate",
       "label": "readLatestDrawerAuthorityState()",
@@ -272149,7 +272125,7 @@
       "source_location": "L325"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "localregisterreader_readprojectedlocalregistermodel",
       "label": "readProjectedLocalRegisterModel()",
@@ -272158,7 +272134,7 @@
       "source_location": "L129"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "localregisterreader_readscopedpagesorfallback",
       "label": "readScopedPagesOrFallback()",
@@ -272167,7 +272143,7 @@
       "source_location": "L266"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "localregisterreader_readscopedposlocalevents",
       "label": "readScopedPosLocalEvents()",
@@ -272176,7 +272152,7 @@
       "source_location": "L86"
     },
     {
-      "community": 628,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localregisterreader_ts",
       "label": "localRegisterReader.ts",
@@ -272185,7 +272161,7 @@
       "source_location": "L1"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_test_ts",
       "label": "registerReadModel.test.ts",
@@ -272194,7 +272170,7 @@
       "source_location": "L1"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "registerreadmodel_test_errorcodes",
       "label": "errorCodes()",
@@ -272203,7 +272179,7 @@
       "source_location": "L1565"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "registerreadmodel_test_event",
       "label": "event()",
@@ -272212,7 +272188,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftevent",
       "label": "serviceDraftEvent()",
@@ -272221,13 +272197,58 @@
       "source_location": "L1611"
     },
     {
-      "community": 629,
+      "community": 628,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftprelude",
       "label": "serviceDraftPrelude()",
       "norm_label": "servicedraftprelude()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts",
       "source_location": "L1593"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
+      "label": "runtimeReadiness.ts",
+      "norm_label": "runtimereadiness.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "runtimereadiness_emptyposterminalruntimereadiness",
+      "label": "emptyPosTerminalRuntimeReadiness()",
+      "norm_label": "emptyposterminalruntimereadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "runtimereadiness_getruntimevisibleactiveregistersession",
+      "label": "getRuntimeVisibleActiveRegisterSession()",
+      "norm_label": "getruntimevisibleactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L165"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "runtimereadiness_refreshterminalruntimereadiness",
+      "label": "refreshTerminalRuntimeReadiness()",
+      "norm_label": "refreshterminalruntimereadiness()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L51"
+    },
+    {
+      "community": 629,
+      "file_type": "code",
+      "id": "runtimereadiness_toruntimeactiveregistersession",
+      "label": "toRuntimeActiveRegisterSession()",
+      "norm_label": "toruntimeactiveregistersession()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
+      "source_location": "L179"
     },
     {
       "community": 63,
@@ -272457,51 +272478,6 @@
     {
       "community": 630,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
-      "label": "runtimeReadiness.ts",
-      "norm_label": "runtimereadiness.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "runtimereadiness_emptyposterminalruntimereadiness",
-      "label": "emptyPosTerminalRuntimeReadiness()",
-      "norm_label": "emptyposterminalruntimereadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "runtimereadiness_getruntimevisibleactiveregistersession",
-      "label": "getRuntimeVisibleActiveRegisterSession()",
-      "norm_label": "getruntimevisibleactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L165"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "runtimereadiness_refreshterminalruntimereadiness",
-      "label": "refreshTerminalRuntimeReadiness()",
-      "norm_label": "refreshterminalruntimereadiness()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L51"
-    },
-    {
-      "community": 630,
-      "file_type": "code",
-      "id": "runtimereadiness_toruntimeactiveregistersession",
-      "label": "toRuntimeActiveRegisterSession()",
-      "norm_label": "toruntimeactiveregistersession()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 631,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.ts",
       "norm_label": "useregisterlifecycleauthorityruntime.ts",
@@ -272509,7 +272485,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_applysnapshot",
       "label": "applySnapshot()",
@@ -272518,7 +272494,7 @@
       "source_location": "L389"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_isregisterlifecyclerepairclassification",
       "label": "isRegisterLifecycleRepairClassification()",
@@ -272527,7 +272503,7 @@
       "source_location": "L554"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_toobservation",
       "label": "toObservation()",
@@ -272536,7 +272512,7 @@
       "source_location": "L523"
     },
     {
-      "community": 631,
+      "community": 630,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_useregisterlifecycleauthorityruntime",
       "label": "useRegisterLifecycleAuthorityRuntime()",
@@ -272545,7 +272521,7 @@
       "source_location": "L53"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
       "label": "transactionUtils.ts",
@@ -272554,7 +272530,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "transactionutils_calculatechange",
       "label": "calculateChange()",
@@ -272563,7 +272539,7 @@
       "source_location": "L42"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "transactionutils_formatcurrency",
       "label": "formatCurrency()",
@@ -272572,7 +272548,7 @@
       "source_location": "L29"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "transactionutils_formattimestamp",
       "label": "formatTimestamp()",
@@ -272581,7 +272557,7 @@
       "source_location": "L49"
     },
     {
-      "community": 632,
+      "community": 631,
       "file_type": "code",
       "id": "transactionutils_generatetransactionnumber",
       "label": "generateTransactionNumber()",
@@ -272590,7 +272566,7 @@
       "source_location": "L14"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_ts",
       "label": "runtimeBuildMetadata.ts",
@@ -272599,7 +272575,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "runtimebuildmetadata_getinitialruntimebuildmetadata",
       "label": "getInitialRuntimeBuildMetadata()",
@@ -272608,7 +272584,7 @@
       "source_location": "L16"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizedeploymetadata",
       "label": "normalizeDeployMetadata()",
@@ -272617,7 +272593,7 @@
       "source_location": "L49"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizemetadatavalue",
       "label": "normalizeMetadataValue()",
@@ -272626,7 +272602,7 @@
       "source_location": "L63"
     },
     {
-      "community": 633,
+      "community": 632,
       "file_type": "code",
       "id": "runtimebuildmetadata_readruntimebuildmetadata",
       "label": "readRuntimeBuildMetadata()",
@@ -272635,7 +272611,7 @@
       "source_location": "L32"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -272644,7 +272620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -272653,7 +272629,7 @@
       "source_location": "L184"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -272662,7 +272638,7 @@
       "source_location": "L200"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -272671,7 +272647,7 @@
       "source_location": "L244"
     },
     {
-      "community": 634,
+      "community": 633,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -272680,7 +272656,7 @@
       "source_location": "L206"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_ts",
       "label": "registerPosAppShellServiceWorker.ts",
@@ -272689,7 +272665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "registerposappshellserviceworker_isposappshellserviceworkerregistration",
       "label": "isPosAppShellServiceWorkerRegistration()",
@@ -272698,7 +272674,7 @@
       "source_location": "L52"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "registerposappshellserviceworker_registerposappshellserviceworker",
       "label": "registerPosAppShellServiceWorker()",
@@ -272707,7 +272683,7 @@
       "source_location": "L6"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "registerposappshellserviceworker_resetposappshellserviceworkerregistrationfortest",
       "label": "resetPosAppShellServiceWorkerRegistrationForTest()",
@@ -272716,7 +272692,7 @@
       "source_location": "L20"
     },
     {
-      "community": 635,
+      "community": 634,
       "file_type": "code",
       "id": "registerposappshellserviceworker_unregisterposappshellserviceworkerfordev",
       "label": "unregisterPosAppShellServiceWorkerForDev()",
@@ -272725,7 +272701,7 @@
       "source_location": "L24"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -272734,7 +272710,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "root_getathenadocumenttitle",
       "label": "getAthenaDocumentTitle()",
@@ -272743,7 +272719,7 @@
       "source_location": "L89"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "root_rootcomponent",
       "label": "RootComponent()",
@@ -272752,7 +272728,7 @@
       "source_location": "L62"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "root_rootdocument",
       "label": "RootDocument()",
@@ -272761,7 +272737,7 @@
       "source_location": "L72"
     },
     {
-      "community": 636,
+      "community": 635,
       "file_type": "code",
       "id": "root_rootnotfound",
       "label": "RootNotFound()",
@@ -272770,7 +272746,7 @@
       "source_location": "L48"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -272779,7 +272755,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -272788,7 +272764,7 @@
       "source_location": "L10"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -272797,7 +272773,7 @@
       "source_location": "L85"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -272806,7 +272782,7 @@
       "source_location": "L19"
     },
     {
-      "community": 637,
+      "community": 636,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -272815,7 +272791,7 @@
       "source_location": "L50"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "expensestore_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
@@ -272824,7 +272800,7 @@
       "source_location": "L179"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "expensestore_ispendingoptimisticexpensecartitem",
       "label": "isPendingOptimisticExpenseCartItem()",
@@ -272833,7 +272809,7 @@
       "source_location": "L197"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "expensestore_mapexpensesessioncartitemtocartitem",
       "label": "mapExpenseSessionCartItemToCartItem()",
@@ -272842,7 +272818,7 @@
       "source_location": "L213"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "expensestore_sessionitemrepresentscartitem",
       "label": "sessionItemRepresentsCartItem()",
@@ -272851,7 +272827,7 @@
       "source_location": "L201"
     },
     {
-      "community": 638,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -272860,7 +272836,7 @@
       "source_location": "L1"
     },
     {
-      "community": 639,
+      "community": 638,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -272869,7 +272845,7 @@
       "source_location": "L93"
     },
     {
-      "community": 639,
+      "community": 638,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -272878,7 +272854,7 @@
       "source_location": "L75"
     },
     {
-      "community": 639,
+      "community": 638,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -272887,7 +272863,7 @@
       "source_location": "L4"
     },
     {
-      "community": 639,
+      "community": 638,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -272896,12 +272872,57 @@
       "source_location": "L47"
     },
     {
-      "community": 639,
+      "community": 638,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
       "norm_label": "analytics.ts",
       "source_file": "packages/storefront-webapp/src/api/analytics.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "category_getallcategories",
+      "label": "getAllCategories()",
+      "norm_label": "getallcategories()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L11"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "category_getallcategorieswithsubcategories",
+      "label": "getAllCategoriesWithSubcategories()",
+      "norm_label": "getallcategorieswithsubcategories()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L25"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "category_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "category_getcategory",
+      "label": "getCategory()",
+      "norm_label": "getcategory()",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 639,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_category_ts",
+      "label": "category.ts",
+      "norm_label": "category.ts",
+      "source_file": "packages/storefront-webapp/src/api/category.ts",
       "source_location": "L1"
     },
     {
@@ -273132,51 +273153,6 @@
     {
       "community": 640,
       "file_type": "code",
-      "id": "category_getallcategories",
-      "label": "getAllCategories()",
-      "norm_label": "getallcategories()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L11"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "category_getallcategorieswithsubcategories",
-      "label": "getAllCategoriesWithSubcategories()",
-      "norm_label": "getallcategorieswithsubcategories()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L25"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "category_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "category_getcategory",
-      "label": "getCategory()",
-      "norm_label": "getcategory()",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 640,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_category_ts",
-      "label": "category.ts",
-      "norm_label": "category.ts",
-      "source_file": "packages/storefront-webapp/src/api/category.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 641,
-      "file_type": "code",
       "id": "onlineorder_getbaseurl",
       "label": "getBaseUrl()",
       "norm_label": "getbaseurl()",
@@ -273184,7 +273160,7 @@
       "source_location": "L4"
     },
     {
-      "community": 641,
+      "community": 640,
       "file_type": "code",
       "id": "onlineorder_getorder",
       "label": "getOrder()",
@@ -273193,7 +273169,7 @@
       "source_location": "L24"
     },
     {
-      "community": 641,
+      "community": 640,
       "file_type": "code",
       "id": "onlineorder_getorders",
       "label": "getOrders()",
@@ -273202,7 +273178,7 @@
       "source_location": "L6"
     },
     {
-      "community": 641,
+      "community": 640,
       "file_type": "code",
       "id": "onlineorder_updateordersowner",
       "label": "updateOrdersOwner()",
@@ -273211,7 +273187,7 @@
       "source_location": "L42"
     },
     {
-      "community": 641,
+      "community": 640,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_onlineorder_ts",
       "label": "onlineOrder.ts",
@@ -273220,7 +273196,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 641,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
@@ -273229,7 +273205,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 641,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -273238,7 +273214,7 @@
       "source_location": "L28"
     },
     {
-      "community": 642,
+      "community": 641,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -273247,7 +273223,7 @@
       "source_location": "L5"
     },
     {
-      "community": 642,
+      "community": 641,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -273256,7 +273232,7 @@
       "source_location": "L7"
     },
     {
-      "community": 642,
+      "community": 641,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -273265,7 +273241,7 @@
       "source_location": "L46"
     },
     {
-      "community": 643,
+      "community": 642,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -273274,7 +273250,7 @@
       "source_location": "L137"
     },
     {
-      "community": 643,
+      "community": 642,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -273283,7 +273259,7 @@
       "source_location": "L176"
     },
     {
-      "community": 643,
+      "community": 642,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -273292,7 +273268,7 @@
       "source_location": "L105"
     },
     {
-      "community": 643,
+      "community": 642,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -273301,7 +273277,7 @@
       "source_location": "L31"
     },
     {
-      "community": 643,
+      "community": 642,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -273310,7 +273286,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 643,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -273319,7 +273295,7 @@
       "source_location": "L102"
     },
     {
-      "community": 644,
+      "community": 643,
       "file_type": "code",
       "id": "homepagecontent_todisplayproduct",
       "label": "toDisplayProduct()",
@@ -273328,7 +273304,7 @@
       "source_location": "L70"
     },
     {
-      "community": 644,
+      "community": 643,
       "file_type": "code",
       "id": "homepagecontent_todisplaysku",
       "label": "toDisplaySku()",
@@ -273337,7 +273313,7 @@
       "source_location": "L54"
     },
     {
-      "community": 644,
+      "community": 643,
       "file_type": "code",
       "id": "homepagecontent_tofeatureditem",
       "label": "toFeaturedItem()",
@@ -273346,7 +273322,7 @@
       "source_location": "L78"
     },
     {
-      "community": 644,
+      "community": 643,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -273355,7 +273331,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -273364,7 +273340,7 @@
       "source_location": "L14"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -273373,7 +273349,7 @@
       "source_location": "L22"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -273382,7 +273358,7 @@
       "source_location": "L30"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -273391,12 +273367,57 @@
       "source_location": "L3"
     },
     {
-      "community": 645,
+      "community": 644,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
       "norm_label": "inventorylevelbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "currency_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/convex/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 645,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {
@@ -277443,42 +277464,6 @@
     {
       "community": 701,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 701,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 701,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 701,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 702,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -277486,7 +277471,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -277495,7 +277480,7 @@
       "source_location": "L34"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -277504,7 +277489,7 @@
       "source_location": "L29"
     },
     {
-      "community": 702,
+      "community": 701,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
@@ -277513,7 +277498,7 @@
       "source_location": "L56"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "opendrawer_test_createdbgetmock",
       "label": "createDbGetMock()",
@@ -277522,7 +277507,7 @@
       "source_location": "L39"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "opendrawer_test_createdbmock",
       "label": "createDbMock()",
@@ -277531,7 +277516,7 @@
       "source_location": "L99"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "opendrawer_test_createdbquerymock",
       "label": "createDbQueryMock()",
@@ -277540,7 +277525,7 @@
       "source_location": "L74"
     },
     {
-      "community": 703,
+      "community": 702,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
       "label": "openDrawer.test.ts",
@@ -277549,7 +277534,7 @@
       "source_location": "L1"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
@@ -277558,7 +277543,7 @@
       "source_location": "L21"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -277567,7 +277552,7 @@
       "source_location": "L42"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -277576,7 +277561,7 @@
       "source_location": "L80"
     },
     {
-      "community": 704,
+      "community": 703,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -277585,7 +277570,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -277594,7 +277579,7 @@
       "source_location": "L1"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -277603,7 +277588,7 @@
       "source_location": "L12"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -277612,7 +277597,7 @@
       "source_location": "L127"
     },
     {
-      "community": 705,
+      "community": 704,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -277621,7 +277606,7 @@
       "source_location": "L99"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -277630,7 +277615,7 @@
       "source_location": "L1"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -277639,7 +277624,7 @@
       "source_location": "L457"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -277648,7 +277633,7 @@
       "source_location": "L436"
     },
     {
-      "community": 706,
+      "community": 705,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -277657,7 +277642,7 @@
       "source_location": "L476"
     },
     {
-      "community": 707,
+      "community": 706,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
@@ -277666,7 +277651,7 @@
       "source_location": "L1"
     },
     {
-      "community": 707,
+      "community": 706,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -277675,7 +277660,7 @@
       "source_location": "L24"
     },
     {
-      "community": 707,
+      "community": 706,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -277684,7 +277669,7 @@
       "source_location": "L16"
     },
     {
-      "community": 707,
+      "community": 706,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -277693,7 +277678,7 @@
       "source_location": "L6"
     },
     {
-      "community": 708,
+      "community": 707,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -277702,7 +277687,7 @@
       "source_location": "L1"
     },
     {
-      "community": 708,
+      "community": 707,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -277711,7 +277696,7 @@
       "source_location": "L115"
     },
     {
-      "community": 708,
+      "community": 707,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -277720,7 +277705,7 @@
       "source_location": "L219"
     },
     {
-      "community": 708,
+      "community": 707,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -277729,7 +277714,7 @@
       "source_location": "L190"
     },
     {
-      "community": 709,
+      "community": 708,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -277738,7 +277723,7 @@
       "source_location": "L1"
     },
     {
-      "community": 709,
+      "community": 708,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -277747,7 +277732,7 @@
       "source_location": "L10"
     },
     {
-      "community": 709,
+      "community": 708,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -277756,13 +277741,49 @@
       "source_location": "L16"
     },
     {
-      "community": 709,
+      "community": 708,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
       "norm_label": "tohex()",
       "source_file": "packages/athena-webapp/convex/pos/application/sync/staffProof.ts",
       "source_location": "L4"
+    },
+    {
+      "community": 709,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_test_buildconflict",
+      "label": "buildConflict()",
+      "norm_label": "buildconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
+      "source_location": "L387"
+    },
+    {
+      "community": 709,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_test_buildevent",
+      "label": "buildEvent()",
+      "norm_label": "buildevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
+      "source_location": "L407"
+    },
+    {
+      "community": 709,
+      "file_type": "code",
+      "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
+      "label": "createRepairProjectionRepository()",
+      "norm_label": "createrepairprojectionrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
+      "source_location": "L282"
+    },
+    {
+      "community": 709,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
+      "label": "cloudRepairPolicy.test.ts",
+      "norm_label": "cloudrepairpolicy.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 71,
@@ -277983,42 +278004,6 @@
     {
       "community": 710,
       "file_type": "code",
-      "id": "cloudrepairpolicy_test_buildconflict",
-      "label": "buildConflict()",
-      "norm_label": "buildconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
-      "source_location": "L387"
-    },
-    {
-      "community": 710,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_test_buildevent",
-      "label": "buildEvent()",
-      "norm_label": "buildevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
-      "source_location": "L407"
-    },
-    {
-      "community": 710,
-      "file_type": "code",
-      "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
-      "label": "createRepairProjectionRepository()",
-      "norm_label": "createrepairprojectionrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
-      "source_location": "L282"
-    },
-    {
-      "community": 710,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
-      "label": "cloudRepairPolicy.test.ts",
-      "norm_label": "cloudrepairpolicy.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/terminalRecovery/cloudRepairPolicy.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 711,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
       "norm_label": "terminalcommandservice.test.ts",
@@ -278026,7 +278011,7 @@
       "source_location": "L1"
     },
     {
-      "community": 711,
+      "community": 710,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -278035,7 +278020,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 711,
+      "community": 710,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -278044,7 +278029,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 711,
+      "community": 710,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -278053,7 +278038,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 712,
+      "community": 711,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -278062,7 +278047,7 @@
       "source_location": "L1"
     },
     {
-      "community": 712,
+      "community": 711,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -278071,7 +278056,7 @@
       "source_location": "L177"
     },
     {
-      "community": 712,
+      "community": 711,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -278080,13 +278065,49 @@
       "source_location": "L68"
     },
     {
-      "community": 712,
+      "community": 711,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "register_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 712,
+      "file_type": "code",
+      "id": "register_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L38"
     },
     {
       "community": 713,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 2912
-- Graph nodes: 12358
-- Graph edges: 15207
+- Graph nodes: 12359
+- Graph edges: 15208
 - Communities: 2837
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.test.ts
+++ b/packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.test.ts
@@ -40,14 +40,16 @@ describe("authorizeRegistration", () => {
       api.harnessWaiver.registrationAuthorization.authorizeRegistration,
       args,
     )).rejects.toThrow("Sign in");
-    await expect(t.withIdentity({ email: "other@example.com" }).mutation(
+    const otherUser = await authenticatedTestUser(t, "other@example.com");
+    await expect(otherUser.mutation(
       api.harnessWaiver.registrationAuthorization.authorizeRegistration,
       args,
     )).rejects.toThrow("not authorized");
   });
 
   it("issues a short-lived ticket only for the reviewer and bootstrap secret", async () => {
-    const t = convexTest(schema, modules).withIdentity({ email: "reviewer@example.com" });
+    const base = convexTest(schema, modules);
+    const t = await authenticatedTestUser(base, "reviewer@example.com");
     await expect(t.mutation(
       api.harnessWaiver.registrationAuthorization.authorizeRegistration,
       { bootstrapSecret: "wrong", tokenHash: "b".repeat(64) },
@@ -68,3 +70,15 @@ describe("authorizeRegistration", () => {
     expect(authorization.expiresAt).toBeLessThanOrEqual(Date.now() + 60_000);
   });
 });
+
+async function authenticatedTestUser(
+  t: ReturnType<typeof convexTest>,
+  email: string,
+) {
+  const authUserId = await t.run((ctx) => ctx.db.insert("users", { email }));
+  await t.run((ctx) => ctx.db.insert("athenaUser", {
+    email,
+    normalizedEmail: email.toLowerCase(),
+  }));
+  return t.withIdentity({ subject: `${authUserId}|test-session` });
+}

--- a/packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.ts
+++ b/packages/athena-webapp/convex/harnessWaiver/registrationAuthorization.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 
 import { env, mutation } from "../_generated/server";
+import { requireAuthenticatedAthenaUserWithCtx } from "../lib/athenaUserAuth";
 import {
   requireConfiguredReviewer,
   requireEnrollmentBootstrap,
@@ -20,10 +21,9 @@ export const authorizeRegistration = mutation({
     tokenHash: v.string(),
   },
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity?.email) throw new Error("Sign in before enrolling the waiver passkey.");
+    const authenticatedUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
     const reviewerEmail = requireConfiguredReviewer(
-      identity.email,
+      authenticatedUser.email,
       required("ATHENA_WAIVER_REVIEWER_EMAIL", env.ATHENA_WAIVER_REVIEWER_EMAIL),
     );
     await requireEnrollmentBootstrap(


### PR DESCRIPTION
## Summary

Passkey enrollment now resolves the configured reviewer through Athena's established Convex Auth subject-to-user path instead of expecting an email claim that production sessions do not contain.

The regression test now uses a production-shaped identity with a subject-backed `users` record and proves both configured-reviewer admission and mismatched-reviewer rejection.

## Validation

- Focused waiver suite: 5 files, 15 tests passed.
- Production Convex verification: authorization, ticket consumption, WebAuthn challenge creation, and registration completion succeeded.
- Local merge gate intentionally skipped; CI owns gate execution for this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
