### PR TITLE
fix(harness): expose documentation waiver approval link

### DIFF
--- a/.github/workflows/athena-documentation-waiver-request.yml
+++ b/.github/workflows/athena-documentation-waiver-request.yml
@@ -23,10 +23,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  relay-request:
-    name: Relay waiver request as repository automation
+  create-approval-request:
+    name: Create passkey approval request
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - name: Create iPhone passkey approval request
         env:
@@ -66,6 +66,26 @@ jobs:
             echo
             echo "[Approve this exact candidate with Face ID]($approval_url)"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish passkey approval request
+        uses: actions/upload-artifact@v4
+        with:
+          name: athena-passkey-approval-request-${{ github.run_id }}
+          path: passkey-request.json
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 1
+
+  relay-request:
+    name: Relay waiver request as repository automation
+    needs: create-approval-request
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Download passkey approval request
+        uses: actions/download-artifact@v4
+        with:
+          name: athena-passkey-approval-request-${{ github.run_id }}
 
       - name: Wait for iPhone passkey approval
         env:

--- a/docs/solutions/harness/scope-disciplined-review-and-durable-run-telemetry-2026-08-13.md
+++ b/docs/solutions/harness/scope-disciplined-review-and-durable-run-telemetry-2026-08-13.md
@@ -20,7 +20,10 @@ tags:
   - gate-obligations
   - delivery-telemetry
   - scope-discipline
-delivery_diff_fingerprint: f9c497ca959ee789750c22885f8e5d300514eeb0536dbfaf9c7c4c7bf957906e
+  - github-actions
+  - passkey-approval
+  - job-summary
+delivery_diff_fingerprint: d43bd9f405d855c71d1936edb47eb7ef0d40db03a0d903f5438781fa89335b62
 ---
 
 # Review Findings Carry a Scope Axis, and Delivery Runs Leave a Durable Record
@@ -162,3 +165,12 @@ cross-product** — obligation kind × waiver-allowed × human/agent — which i
 actually catches an evaluator gap. Single-instance coverage hides path-specific
 holes; when a flag is honored by code selected by *another* field, test the
 combination, not the flag.
+
+**An approval link must outlive the job that publishes it.** GitHub does not
+surface a job summary while that job is still running. Publishing a passkey URL
+to `$GITHUB_STEP_SUMMARY` and then polling for that approval in the same job
+creates a UI deadlock: the human cannot see the link until the wait is over. Use
+a short producer job that creates the approval request, publishes its link, and
+uploads the request identity; make the polling job depend on and download that
+artifact. Test the job boundary itself, not merely that summary output appears
+textually before the polling step.

--- a/scripts/documentation-waiver-workflows.test.ts
+++ b/scripts/documentation-waiver-workflows.test.ts
@@ -20,9 +20,21 @@ describe("documentation waiver workflow trust chain", () => {
     expect(request).toContain("Passkey approval timed out");
     expect(request).toContain("Create iPhone passkey approval request");
     expect(request).toContain("Wait for iPhone passkey approval");
-    expect(request.indexOf("GITHUB_STEP_SUMMARY")).toBeLessThan(
-      request.indexOf("Wait for iPhone passkey approval"),
+    expect(request).toContain("create-approval-request:");
+    expect(request).toContain("needs: create-approval-request");
+    expect(request).toContain("actions/download-artifact@v4");
+    const runScopedArtifact = "athena-passkey-approval-request-${{ github.run_id }}";
+    expect(request.split(runScopedArtifact)).toHaveLength(3);
+    expect(request).not.toContain("github.run_attempt");
+    const producerJob = request.slice(
+      request.indexOf("create-approval-request:"),
+      request.indexOf("relay-request:"),
     );
+    const relayJob = request.slice(request.indexOf("relay-request:"));
+    expect(producerJob).toContain("GITHUB_STEP_SUMMARY");
+    expect(producerJob).toContain("overwrite: true");
+    expect(producerJob).not.toContain("Wait for iPhone passkey approval");
+    expect(relayJob).toContain("Wait for iPhone passkey approval");
     expect(request).toContain("relay_run_id: String(context.runId)");
     expect(request).toContain("group: documentation-waiver-request-${{ inputs.head_sha }}");
     expect(issuer).toContain("group: documentation-waiver-issuer-${{ inputs.head_sha }}");


### PR DESCRIPTION
Documentation-waiver requests now publish the passkey approval link from a producer job that completes before the relay begins polling, so GitHub renders the link while approval is still actionable. A stable run-scoped artifact carries the broker request between jobs and supports both full and failed-job reruns through explicit overwrite behavior. Regression coverage locks the producer-consumer boundary, shared artifact identity, and retry-safe configuration.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)