### PR TITLE
[V26-1435]: Fix storefront payment notifications

### DIFF
--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -105251,7 +105251,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L164",
+      "source_location": "L203",
       "target": "onlineorder_test_createunauthorizednormalorderctx",
       "weight": 1
     },
@@ -105263,7 +105263,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L160",
+      "source_location": "L199",
       "target": "onlineorder_test_gethandler",
       "weight": 1
     },
@@ -105275,7 +105275,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L156",
+      "source_location": "L195",
       "target": "onlineorder_test_getsource",
       "weight": 1
     },
@@ -105287,7 +105287,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L150",
+      "source_location": "L189",
       "target": "onlineorder_test_readstorefrontfacts",
       "weight": 1
     },
@@ -105431,7 +105431,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1082",
+      "source_location": "L1083",
       "target": "onlineorder_getorderbycheckoutsessionidwithctx",
       "weight": 1
     },
@@ -105527,7 +105527,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L2249",
+      "source_location": "L2250",
       "target": "onlineorder_returnselectedonlineorderitemstostock",
       "weight": 1
     },
@@ -105539,7 +105539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_onlineorder_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L2484",
+      "source_location": "L2485",
       "target": "onlineorder_updateonlineorderownerwithctx",
       "weight": 1
     },
@@ -105875,7 +105875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_storefront_payment_test_ts",
       "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
-      "source_location": "L372",
+      "source_location": "L445",
       "target": "payment_test_seedpaymentfixture",
       "weight": 1
     },
@@ -222286,7 +222286,7 @@
       "label": "getOrderByCheckoutSessionIdWithCtx()",
       "norm_label": "getorderbycheckoutsessionidwithctx()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L1082"
+      "source_location": "L1083"
     },
     {
       "community": 103,
@@ -222358,7 +222358,7 @@
       "label": "returnSelectedOnlineOrderItemsToStock()",
       "norm_label": "returnselectedonlineorderitemstostock()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L2249"
+      "source_location": "L2250"
     },
     {
       "community": 103,
@@ -222367,7 +222367,7 @@
       "label": "updateOnlineOrderOwnerWithCtx()",
       "norm_label": "updateonlineorderownerwithctx()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.ts",
-      "source_location": "L2484"
+      "source_location": "L2485"
     },
     {
       "community": 103,
@@ -229036,7 +229036,7 @@
       "label": "seedPaymentFixture()",
       "norm_label": "seedpaymentfixture()",
       "source_file": "packages/athena-webapp/convex/storeFront/payment.test.ts",
-      "source_location": "L372"
+      "source_location": "L445"
     },
     {
       "community": 1163,
@@ -321871,7 +321871,7 @@
       "label": "createUnauthorizedNormalOrderCtx()",
       "norm_label": "createunauthorizednormalorderctx()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L164"
+      "source_location": "L203"
     },
     {
       "community": 602,
@@ -321880,7 +321880,7 @@
       "label": "getHandler()",
       "norm_label": "gethandler()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L160"
+      "source_location": "L199"
     },
     {
       "community": 602,
@@ -321889,7 +321889,7 @@
       "label": "getSource()",
       "norm_label": "getsource()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L156"
+      "source_location": "L195"
     },
     {
       "community": 602,
@@ -321898,7 +321898,7 @@
       "label": "readStorefrontFacts()",
       "norm_label": "readstorefrontfacts()",
       "source_file": "packages/athena-webapp/convex/storeFront/onlineOrder.test.ts",
-      "source_location": "L150"
+      "source_location": "L189"
     },
     {
       "community": 602,

--- a/packages/athena-webapp/convex/storeFront/onlineOrder.test.ts
+++ b/packages/athena-webapp/convex/storeFront/onlineOrder.test.ts
@@ -121,6 +121,7 @@ async function seedFulfillableOrder(
     deliveryMethod: "delivery",
     deliveryOption: null,
     discount: null,
+    externalReference: "reference-1",
     hasVerifiedPayment: true,
     orderNumber: "ORD-1",
     pickupLocation: null,
@@ -138,6 +139,7 @@ async function seedFulfillableOrder(
     storeFrontUserId,
   });
   return {
+    checkoutSessionId,
     itemId,
     orderId,
     organizationId,
@@ -146,6 +148,43 @@ async function seedFulfillableOrder(
     storeId,
   };
 }
+
+describe("online order internal lookup", () => {
+  it("preserves lookup by online order id", async () => {
+    const t = convexTest(schema, modules);
+    const { orderId } = await t.run((ctx) => seedFulfillableOrder(ctx));
+
+    const order = await t.query(internal.storeFront.onlineOrder.getInternal, {
+      identifier: orderId,
+    });
+
+    expect(order?._id).toBe(orderId);
+  });
+
+  it("preserves lookup by external reference", async () => {
+    const t = convexTest(schema, modules);
+    const { orderId } = await t.run((ctx) => seedFulfillableOrder(ctx));
+
+    const order = await t.query(internal.storeFront.onlineOrder.getInternal, {
+      identifier: "reference-1",
+    });
+
+    expect(order?._id).toBe(orderId);
+  });
+
+  it("resolves an order by checkout session id", async () => {
+    const t = convexTest(schema, modules);
+    const { checkoutSessionId, orderId } = await t.run((ctx) =>
+      seedFulfillableOrder(ctx),
+    );
+
+    const order = await t.query(internal.storeFront.onlineOrder.getInternal, {
+      identifier: checkoutSessionId,
+    });
+
+    expect(order?._id).toBe(orderId);
+  });
+});
 
 async function readStorefrontFacts(ctx: MutationCtx, storeId: Id<"store">) {
   // eslint-disable-next-line @convex-dev/no-collect-in-query -- test-only helper over a tiny seeded fact set.

--- a/packages/athena-webapp/convex/storeFront/onlineOrder.ts
+++ b/packages/athena-webapp/convex/storeFront/onlineOrder.ts
@@ -990,9 +990,10 @@ export const getInternal = internalQuery({
     identifier: v.union(v.id("onlineOrder"), v.string()),
   },
   handler: async (ctx, args) => {
-    let order =
-      (await ctx.db.get("onlineOrder", args.identifier as Id<"onlineOrder">)) ??
-      null;
+    const onlineOrderId = ctx.db.normalizeId("onlineOrder", args.identifier);
+    let order = onlineOrderId
+      ? await ctx.db.get("onlineOrder", onlineOrderId)
+      : null;
 
     if (!order) {
       order = await ctx.db

--- a/packages/athena-webapp/convex/storeFront/payment.test.ts
+++ b/packages/athena-webapp/convex/storeFront/payment.test.ts
@@ -167,7 +167,7 @@ describe("storefront payment scheduled-run evidence", () => {
   it("records candidate auto-verify evidence for skipped and successful orders", async () => {
     paystackMock.verifyTransaction.mockResolvedValue({
       data: {
-        amount: 11_000,
+        amount: 10_000,
         status: "success",
       },
     });
@@ -181,9 +181,42 @@ describe("storefront payment scheduled-run evidence", () => {
       }
       return undefined;
     });
+    const hydratedOrder = {
+      _id: "order-verified",
+      amount: 10_000,
+      checkoutSessionId: "checkout-verified",
+      customerDetails: {
+        email: "customer@example.test",
+        firstName: "Ama",
+        lastName: "Owusu",
+      },
+      deliveryDetails: "Osu, Accra",
+      deliveryFee: 1_000,
+      deliveryMethod: "delivery",
+      discount: {
+        span: "entire-order",
+        type: "percentage",
+        value: 10,
+      },
+      externalReference: "paystack-reference-1",
+      items: [
+        {
+          price: 10_000,
+          productName: "Hydrated product",
+          productSkuId: "sku-1",
+          quantity: 1,
+        },
+      ],
+      orderNumber: "ORDER-1",
+      storeId: "store-1",
+      transitions: [],
+    };
     const ctx = {
       runMutation,
       runQuery: vi.fn(async (_definition, args?: Record<string, unknown>) => {
+        if (args && "identifier" in args) {
+          return hydratedOrder;
+        }
         if (args && "id" in args) {
           return { _id: args.id, name: "Osu" };
         }
@@ -208,14 +241,12 @@ describe("storefront payment scheduled-run evidence", () => {
             amount: 10_000,
             checkoutSessionId: "checkout-verified",
             deliveryFee: 1_000,
+            discount: {
+              span: "entire-order",
+              type: "percentage",
+              value: 10,
+            },
             externalReference: "paystack-reference-1",
-            items: [
-              {
-                price: 10_000,
-                productSkuId: "sku-1",
-                quantity: 1,
-              },
-            ],
             storeId: "store-1",
             transitions: [],
           },
@@ -229,6 +260,11 @@ describe("storefront payment scheduled-run evidence", () => {
 
     expect(paystackMock.verifyTransaction).toHaveBeenCalledWith(
       "paystack-reference-1",
+    );
+    expect(emailMock.sendPaymentVerificationEmails).toHaveBeenCalledWith(
+      expect.objectContaining({
+        order: hydratedOrder,
+      }),
     );
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
@@ -255,6 +291,43 @@ describe("storefront payment scheduled-run evidence", () => {
         succeededCount: 1,
         failedCount: 0,
         skippedCount: 1,
+      }),
+    );
+  });
+
+  it("records a failed candidate without sending email when the order cannot be hydrated", async () => {
+    paystackMock.verifyTransaction.mockResolvedValueOnce({
+      data: { amount: 11_000, status: "success" },
+    });
+    emailMock.sendPaymentVerificationEmails.mockClear();
+
+    const runMutation = vi.fn(async () => undefined);
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          _id: "order-missing",
+          amount: 10_000,
+          checkoutSessionId: "checkout-missing",
+          deliveryFee: 1_000,
+          externalReference: "paystack-reference-missing",
+          storeId: "store-1",
+        },
+      ])
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      getHandler(autoVerifyUnverifiedPayments)({ runMutation, runQuery }, {}),
+    ).resolves.toBeUndefined();
+
+    expect(emailMock.sendPaymentVerificationEmails).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        cronFamily: "auto-verify-payments",
+        failedCount: 1,
+        processedCount: 1,
+        succeededCount: 0,
       }),
     );
   });

--- a/packages/athena-webapp/convex/storeFront/payment.ts
+++ b/packages/athena-webapp/convex/storeFront/payment.ts
@@ -1008,11 +1008,19 @@ export const autoVerifyUnverifiedPayments = internalAction({
 
       try {
         const paystackResponse = await verifyTransaction(reference);
+        const orderWithItems = await ctx.runQuery(
+          internal.storeFront.onlineOrder.getInternal,
+          { identifier: order._id },
+        );
+
+        if (!orderWithItems) {
+          throw new Error(`Order ${order._id} could not be hydrated.`);
+        }
 
         // Calculate expected amount (same logic as verifyPayment)
-        const subtotal = order.amount || 0;
-        const discount = order.discount;
-        const items = (order.items || [])
+        const subtotal = orderWithItems.amount || 0;
+        const discount = orderWithItems.discount;
+        const items = (orderWithItems.items || [])
           .filter(
             (item) =>
               item.productSkuId !== undefined &&
@@ -1028,7 +1036,7 @@ export const autoVerifyUnverifiedPayments = internalAction({
         const orderAmountLessDiscounts = calculateOrderAmount({
           items,
           discount,
-          deliveryFee: order.deliveryFee || 0,
+          deliveryFee: orderWithItems.deliveryFee || 0,
           subtotal,
         });
 
@@ -1055,7 +1063,7 @@ export const autoVerifyUnverifiedPayments = internalAction({
         // Update checkout session
         await ctx.runMutation(
           internal.storeFront.checkoutSession.updateCheckoutSession,
-          { id: order.checkoutSessionId, hasVerifiedPayment: true },
+          { id: orderWithItems.checkoutSessionId, hasVerifiedPayment: true },
         );
 
         // Build order update
@@ -1063,7 +1071,7 @@ export const autoVerifyUnverifiedPayments = internalAction({
           hasVerifiedPayment: true,
           autoVerifiedAt: Date.now(),
           transitions: [
-            ...(order.transitions ?? []),
+            ...(orderWithItems.transitions ?? []),
             {
               status: "payment_auto_verified",
               date: Date.now(),
@@ -1073,16 +1081,18 @@ export const autoVerifyUnverifiedPayments = internalAction({
 
         // Send verification emails (guards against duplicates internally)
         const store = await ctx.runQuery(internal.inventory.stores.findById, {
-          id: order.storeId,
+          id: orderWithItems.storeId,
         });
 
         const emailResults = await sendPaymentVerificationEmails({
-          order,
+          order: orderWithItems,
           store,
           orderAmount: orderAmountLessDiscounts,
           discountValue,
-          didSendNewOrderEmail: order.didSendNewOrderReceivedEmail || false,
-          didSendConfirmationEmail: order.didSendConfirmationEmail || false,
+          didSendNewOrderEmail:
+            orderWithItems.didSendNewOrderReceivedEmail || false,
+          didSendConfirmationEmail:
+            orderWithItems.didSendConfirmationEmail || false,
         });
 
         if (emailResults.confirmationSent) {
@@ -1095,15 +1105,15 @@ export const autoVerifyUnverifiedPayments = internalAction({
         }
 
         // Award loyalty points (idempotent — checks for existing reward by orderId)
-        const points = calculateRewardPoints(order.amount || 0);
+        const points = calculateRewardPoints(orderWithItems.amount || 0);
         const rewardResult = await ctx.runMutation(
           internal.storeFront.rewards.awardOrderPoints,
-          { orderId: order._id, points },
+          { orderId: orderWithItems._id, points },
         );
 
         if (rewardResult.success) {
           console.log(
-            `[AUTO-VERIFY] Awarded ${points} points for order ${order._id}`,
+            `[AUTO-VERIFY] Awarded ${points} points for order ${orderWithItems._id}`,
           );
         }
 
@@ -1121,14 +1131,14 @@ export const autoVerifyUnverifiedPayments = internalAction({
           await ctx.runMutation(
             internal.storeFront.checkoutSession.updateCheckoutSession,
             {
-              id: order.checkoutSessionId,
+              id: orderWithItems.checkoutSessionId,
               hasCompletedCheckoutSession: true,
             },
           ),
         ]);
 
         console.log(
-          `[AUTO-VERIFY] Verified payment | Reference: ${reference} | Order: ${order._id}`,
+          `[AUTO-VERIFY] Verified payment | Reference: ${reference} | Order: ${orderWithItems._id}`,
         );
         succeededCount += 1;
         stats.succeededCount += 1;

--- a/telemetry/delivery-runs/2026-08-28T15-53-13-432Z-codex-fix-storefront-webhook-order-lookup.json
+++ b/telemetry/delivery-runs/2026-08-28T15-53-13-432Z-codex-fix-storefront-webhook-order-lookup.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-28T15:53:13.432Z",
+  "branch": "codex/fix-storefront-webhook-order-lookup",
+  "headSha": "342850073464a2c9b6198d32d11475f5fa5cbe53",
+  "deliverableDiffFingerprint": "1e28ba290a82ce4601dcb7c208eed9eb2312a21164eb07378e785ed8387dc5a5",
+  "status": "pass",
+  "proofState": "proof_recorded",
+  "summary": {
+    "commandCount": 5,
+    "failedCommandCount": 0,
+    "duplicateCommandCount": 0,
+    "duplicatePackageSuiteCount": 0,
+    "providerSkippedCount": 3,
+    "gateDecisionCount": 2,
+    "totalDurationMs": 1114249.674334
+  },
+  "reviewLoop": {
+    "providerId": "ce-code-review",
+    "runId": "13698eb6-74ec-435c-843f-5d55763f9c0f",
+    "finalPassId": "final-frozen-977717a8",
+    "recordedAt": "2026-08-28T15:34:34.800Z",
+    "iterationCount": 2,
+    "findingCounts": {
+      "P0": 0,
+      "P1": 0,
+      "P2": 3,
+      "P3": 0
+    },
+    "deferredExpansionCount": 0,
+    "deferredIssueIds": []
+  }
+}

--- a/telemetry/delivery-runs/2026-08-28T16-26-56-147Z-codex-fix-storefront-webhook-order-lookup.json
+++ b/telemetry/delivery-runs/2026-08-28T16-26-56-147Z-codex-fix-storefront-webhook-order-lookup.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-28T16:26:56.147Z",
+  "branch": "codex/fix-storefront-webhook-order-lookup",
+  "headSha": "1b0d28c3c6c9eb3998dfd3d0a4a81721271c8eaf",
+  "deliverableDiffFingerprint": "1e28ba290a82ce4601dcb7c208eed9eb2312a21164eb07378e785ed8387dc5a5",
+  "status": "pass",
+  "proofState": "proof_recorded",
+  "summary": {
+    "commandCount": 5,
+    "failedCommandCount": 0,
+    "duplicateCommandCount": 0,
+    "duplicatePackageSuiteCount": 0,
+    "providerSkippedCount": 3,
+    "gateDecisionCount": 2,
+    "totalDurationMs": 1104432.879418
+  },
+  "reviewLoop": {
+    "providerId": "ce-code-review",
+    "runId": "13698eb6-74ec-435c-843f-5d55763f9c0f",
+    "finalPassId": "final-frozen-977717a8",
+    "recordedAt": "2026-08-28T15:34:34.800Z",
+    "iterationCount": 2,
+    "findingCounts": {
+      "P0": 0,
+      "P1": 0,
+      "P2": 3,
+      "P3": 0
+    },
+    "deferredExpansionCount": 0,
+    "deferredIssueIds": []
+  }
+}


### PR DESCRIPTION
## Summary

Storefront payment notifications now resolve newly created orders from Paystack checkout-session IDs and include complete line items when delayed auto-verification sends email.

- Guard direct Convex order reads with table-specific ID normalization before falling back to external-reference and checkout-session indexes.
- Rehydrate auto-verification candidates before amount validation and email assembly.
- Cover all lookup modes, item-dependent discount validation, and missing-order failure behavior with regressions.

## Why

Production order 274068 completed successfully, but the webhook notification stage threw when a checkout-session ID was used as an online-order ID. Its delayed fallback email then received a summary-only order row, producing an empty Items section despite correct totals. These fixes close both failure paths without changing payment or inventory accounting.

## Validation

- `CI=1 bunx vitest run` focused storefront slice: 12 files, 128 tests passed
- `audit:convex` and `lint:convex:changed`
- Evidence-bearing `ce-code-review`: final pass green
- `bun run pr:athena`: 5 commands, 0 failures, full webapp and root-script coverage
- Pre-push hook reused the exact `pr:athena` proof and passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol_(Max)-000000)

https://linear.app/v26-labs/issue/V26-1435/fix-storefront-webhook-order-lookup-and-empty-item-emails
