### PR TITLE
[V26-1439]: Replace plan-local shorthand in portable workflow source

### DIFF
--- a/.agents/portable-overlay-map.json
+++ b/.agents/portable-overlay-map.json
@@ -139,7 +139,7 @@
     {
       "id": "compound-reviewer-prompt-graph",
       "classification": "excluded",
-      "rationale": "The full Athena persona graph remains a research source; U13 must bundle a smaller host-neutral reviewer contract.",
+      "rationale": "The full Athena persona graph remains a research source; the portable review workflow must bundle a smaller host-neutral reviewer contract.",
       "assertionIds": ["review-selects-core-and-risk-lenses"]
     },
     {

--- a/docs/reports/2026-08-28-portable-workflow-baseline-report.html
+++ b/docs/reports/2026-08-28-portable-workflow-baseline-report.html
@@ -37,7 +37,7 @@
   <section data-report-section="mental-model">
     <h2>Mental model: a certified survey map</h2>
       <p>Think of the baseline as a survey completed before construction. The JSON artifacts mark the approved boundaries. The checker compares those boundaries with the current repository. The fixtures prove representative routes through the map.</p>
-      <p>Workflow rules may be portable candidate, optional adapter, retained Athena overlay, or excluded. Bounded closure members use the narrower U11 taxonomy of portable candidate, retained overlay, or excluded. These labels guide later work; they are not migration actions in this ticket.</p>
+      <p>Workflow rules may be portable candidate, optional adapter, retained Athena overlay, or excluded. Bounded closure members use the approved baseline classification taxonomy of portable candidate, retained overlay, or excluded. These labels guide later work; they are not migration actions in this ticket.</p>
   </section>
   <section data-report-section="before-after">
     <h2>Before and after</h2>

--- a/scripts/portable-baseline-check.test.ts
+++ b/scripts/portable-baseline-check.test.ts
@@ -832,7 +832,7 @@ describe("portable workflow characterization baseline", () => {
     ).toEqual([true, true]);
   });
 
-  it("restricts bounded members to the adjudicated U11 taxonomy", async () => {
+  it("restricts bounded members to the approved baseline classification taxonomy", async () => {
     const documents = await loadPortableBaselineDocuments(REPO_ROOT);
     const expectedAdjudications = {
       "ce-commit-push-pr-source-bundle": "excluded",

--- a/scripts/portable-baseline-contracts.ts
+++ b/scripts/portable-baseline-contracts.ts
@@ -1152,7 +1152,7 @@ export const RULE_IDENTITY_CONTRACTS = new Map<string, RuleIdentityContract>([
     {
       classification: "excluded",
       rationale:
-        "The full Athena persona graph remains a research source; U13 must bundle a smaller host-neutral reviewer contract.",
+        "The full Athena persona graph remains a research source; the portable review workflow must bundle a smaller host-neutral reviewer contract.",
       assertionIds: ["review-selects-core-and-risk-lenses"],
     },
   ],


### PR DESCRIPTION
## Summary

- replace four plan-local unit references in durable portable-workflow source and report prose with semantic language
- preserve the accepted historical plan and Linear mapping unchanged
- keep runtime behavior, Linear capability, shadow/canary sequencing, and delivery infrastructure unchanged

## Why

Future readers should understand the portable workflow contracts without needing the delivery plan’s temporary unit numbering. This closes the source-language gap found by the V26-1412 completion audit with the smallest possible change.

## Validation

- `bun run pr:athena`
- focused portable baseline, canary, batch rollback, harness, report-presentation, landed-report, and Graphify checks
- independent correctness and simplicity reviews: approved, no findings
- pre-push reused the exact current `pr:athena` proof
- no deployment performed (infrastructure-only delivery; deployment remains deferred)

https://linear.app/v26-labs/issue/V26-1439/replace-plan-local-shorthand-in-portable-workflow-source