### PR TITLE
[V26-1444]: Stop reports sweep from rehydrating full closes

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 14636 nodes · 18317 edges · 3169 communities detected
+- 14635 nodes · 18315 edges · 3169 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -4351,160 +4351,160 @@ Cohesion: 0.24
 Nodes (5): createTerminalRecoveryCommandReadRepository(), createTerminalRecoveryCommandRepository(), dedupeRecoveryConflictsById(), listTerminalRecoveryConflictsForRepair(), listTerminalRecoveryConflictSources()
 
 ### Community 286 - "Community 286"
-Cohesion: 0.36
-Nodes (10): anchorDate(), buildOverviewData(), comparisonBp(), emptySnapshot(), isUnsettled(), readRecentDays(), readTrendTransactionCounts(), rebuildStoreOverview() (+2 more)
-
-### Community 287 - "Community 287"
 Cohesion: 0.47
 Nodes (10): getTerminalRuntimeMaterialSignature(), projectActiveRegisterSession(), projectAppUpdate(), projectDrawerAuthority(), projectLocalStore(), projectStaffAuthority(), projectStatus(), projectSync() (+2 more)
 
-### Community 288 - "Community 288"
+### Community 287 - "Community 287"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 289 - "Community 289"
+### Community 288 - "Community 288"
 Cohesion: 0.29
 Nodes (7): asPreview(), asTrail(), asUnavailable(), asView(), deriveAthenaProvisionalState(), useAthenaAgentNarrativeTrail(), useAthenaAgentRun()
 
-### Community 290 - "Community 290"
+### Community 289 - "Community 289"
 Cohesion: 0.22
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 0.25
 Nodes (6): getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.24
 Nodes (5): getSharedDemoRegisterNumber(), getSharedDemoRegisterNumberCandidates(), getSharedDemoRestoreEpochStorageKey(), provisionSharedDemoRegister(), resetSharedDemoFirstVisitBrowserState()
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.31
 Nodes (8): deliveryReportMetaFromFile(), firstHeading(), parseInlineList(), parseSolutionFrontmatter(), solutionDocMetaFromFile(), stripFrontmatter(), titleCaseFromSlug(), unquote()
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 0.35
 Nodes (9): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), findDrawerAuthorityBlockForReview(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason() (+1 more)
 
-### Community 296 - "Community 296"
+### Community 295 - "Community 295"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 297 - "Community 297"
+### Community 296 - "Community 296"
 Cohesion: 0.2
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 298 - "Community 298"
+### Community 297 - "Community 297"
 Cohesion: 0.2
 Nodes (2): formatHeaderCount(), formatSkuActivityHeaderTitle()
 
-### Community 299 - "Community 299"
+### Community 298 - "Community 298"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 300 - "Community 300"
+### Community 299 - "Community 299"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 301 - "Community 301"
+### Community 300 - "Community 300"
 Cohesion: 0.2
 Nodes (3): build(), forward(), ResizeObserverStub
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 0.29
 Nodes (8): changedPathsForFixture(), createTempRoot(), forBranch(), git(), ledger(), recordAfterLedger(), repoFixture(), writeLedger()
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.33
 Nodes (9): auditHarnessBlockerInventory(), boundarySource(), collectMatches(), collectRemediationLiterals(), discoverHarnessBlockerInventory(), inspectHarnessBlockerShapes(), inspectHarnessCliBoundary(), inspectRenderNonZeroSuppression() (+1 more)
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 0.25
 Nodes (7): authoritativeLedger(), createDecisionEventFixture(), gateEventHarness(), gitFixtureEnv(), ledgerEvent(), run(), runGit()
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 0.44
 Nodes (9): cancelActiveRunsForProfileWithCtx(), describeDeploymentStateWithCtx(), fenceForDeployWithCtx(), loadSwitch(), narrower(), resolveDurableEnablementWithCtx(), setCapabilityEnablementWithCtx(), setProfileEnablementWithCtx() (+1 more)
 
-### Community 308 - "Community 308"
+### Community 307 - "Community 307"
 Cohesion: 0.42
 Nodes (8): asManifest(), describeCapability(), discoverCapabilities(), grantedCapabilityIds(), projectDeclaration(), projectRunDeclarations(), projectRunFacadeShape(), schemasOf()
 
-### Community 309 - "Community 309"
+### Community 308 - "Community 308"
 Cohesion: 0.33
 Nodes (6): covers(), describeProviderSelectionForEvidence(), normalizeEgressClass(), permittedFailovers(), resolveTurnEgressClass(), selectProviderForEgress()
 
-### Community 310 - "Community 310"
+### Community 309 - "Community 309"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 311 - "Community 311"
+### Community 310 - "Community 310"
 Cohesion: 0.27
 Nodes (4): getStorefrontActorFromRequest(), getStorefrontClaimFromRequest(), getStorefrontUserFromRequest(), readVerifiedGuestIdFromRequest()
 
-### Community 312 - "Community 312"
+### Community 311 - "Community 311"
 Cohesion: 0.33
 Nodes (7): createAthenaProviderError(), createProviderFailureResult(), getProviderFailureDiagnostic(), invokeStructuredTextProvider(), isJsonObject(), isJsonValue(), sanitizeDiagnostic()
 
-### Community 313 - "Community 313"
+### Community 312 - "Community 312"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 314 - "Community 314"
+### Community 313 - "Community 313"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 315 - "Community 315"
+### Community 314 - "Community 314"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 316 - "Community 316"
+### Community 315 - "Community 315"
 Cohesion: 0.33
 Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 0.31
 Nodes (7): analyticsRead(), checkoutSessionOrderScope(), externalReferenceOrderScope(), idArg(), onlineOrderRead(), reviewRead(), storeFrontRead()
 
-### Community 318 - "Community 318"
+### Community 317 - "Community 317"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 319 - "Community 319"
+### Community 318 - "Community 318"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 320 - "Community 320"
+### Community 319 - "Community 319"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 322 - "Community 322"
+### Community 321 - "Community 321"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 323 - "Community 323"
+### Community 322 - "Community 322"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 324 - "Community 324"
+### Community 323 - "Community 323"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
+
+### Community 324 - "Community 324"
+Cohesion: 0.4
+Nodes (9): anchorDate(), buildOverviewData(), comparisonBp(), emptySnapshot(), isUnsettled(), readRecentDays(), rebuildStoreOverview(), snapshotForDays() (+1 more)
 
 ### Community 325 - "Community 325"
 Cohesion: 0.2
@@ -4783,24 +4783,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 394 - "Community 394"
-Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
-
-### Community 395 - "Community 395"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 396 - "Community 396"
+### Community 395 - "Community 395"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 397 - "Community 397"
+### Community 396 - "Community 396"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 398 - "Community 398"
+### Community 397 - "Community 397"
 Cohesion: 0.31
 Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
+
+### Community 398 - "Community 398"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.39
@@ -6759,40 +6759,40 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 888 - "Community 888"
-Cohesion: 0.5
-Nodes (1): buildCtx()
-
-### Community 889 - "Community 889"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 890 - "Community 890"
+### Community 889 - "Community 889"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 891 - "Community 891"
+### Community 890 - "Community 890"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 892 - "Community 892"
+### Community 891 - "Community 891"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 893 - "Community 893"
+### Community 892 - "Community 892"
 Cohesion: 0.67
 Nodes (2): buildActivity(), buildReport()
 
-### Community 894 - "Community 894"
+### Community 893 - "Community 893"
 Cohesion: 0.83
 Nodes (3): advanceRegisterCatalogRevision(), readRegisterCatalogRevision(), readRegisterCatalogRevisionRow()
 
-### Community 895 - "Community 895"
+### Community 894 - "Community 894"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 896 - "Community 896"
+### Community 895 - "Community 895"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 896 - "Community 896"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 897 - "Community 897"
 Cohesion: 0.5
@@ -6808,7 +6808,7 @@ Nodes (0):
 
 ### Community 900 - "Community 900"
 Cohesion: 0.5
-Nodes (0):
+Nodes (1): buildCtx()
 
 ### Community 901 - "Community 901"
 Cohesion: 0.5

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -42935,7 +42935,7 @@
       "relation": "calls",
       "source": "overview_anchordate",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L175",
+      "source_location": "L172",
       "target": "overview_buildoverviewdata",
       "weight": 1
     },
@@ -42959,7 +42959,7 @@
       "relation": "calls",
       "source": "overview_emptysnapshot",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L181",
+      "source_location": "L178",
       "target": "overview_buildoverviewdata",
       "weight": 1
     },
@@ -42971,7 +42971,7 @@
       "relation": "calls",
       "source": "overview_snapshotfordays",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L261",
+      "source_location": "L258",
       "target": "overview_buildoverviewdata",
       "weight": 1
     },
@@ -42995,7 +42995,7 @@
       "relation": "calls",
       "source": "overview_buildoverviewdata",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L355",
+      "source_location": "L325",
       "target": "overview_rebuildstoreoverview",
       "weight": 1
     },
@@ -43007,19 +43007,7 @@
       "relation": "calls",
       "source": "overview_readrecentdays",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L352",
-      "target": "overview_rebuildstoreoverview",
-      "weight": 1
-    },
-    {
-      "_src": "overview_rebuildstoreoverview",
-      "_tgt": "overview_readtrendtransactioncounts",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "calls",
-      "source": "overview_readtrendtransactioncounts",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L359",
+      "source_location": "L322",
       "target": "overview_rebuildstoreoverview",
       "weight": 1
     },
@@ -43031,7 +43019,7 @@
       "relation": "calls",
       "source": "overview_emptysnapshot",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L87",
+      "source_location": "L86",
       "target": "overview_snapshotfordays",
       "weight": 1
     },
@@ -43043,7 +43031,7 @@
       "relation": "calls",
       "source": "overview_isunsettled",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L105",
+      "source_location": "L104",
       "target": "overview_snapshotfordays",
       "weight": 1
     },
@@ -93911,7 +93899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L157",
+      "source_location": "L156",
       "target": "overview_anchordate",
       "weight": 1
     },
@@ -93923,7 +93911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L167",
+      "source_location": "L166",
       "target": "overview_buildoverviewdata",
       "weight": 1
     },
@@ -93935,7 +93923,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L123",
+      "source_location": "L122",
       "target": "overview_comparisonbp",
       "weight": 1
     },
@@ -93947,7 +93935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L57",
+      "source_location": "L56",
       "target": "overview_emptysnapshot",
       "weight": 1
     },
@@ -93959,7 +93947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L68",
+      "source_location": "L67",
       "target": "overview_isunsettled",
       "weight": 1
     },
@@ -93977,25 +93965,13 @@
     },
     {
       "_src": "packages_athena_webapp_convex_reports_overview_ts",
-      "_tgt": "overview_readtrendtransactioncounts",
-      "confidence": "EXTRACTED",
-      "confidence_score": 1,
-      "relation": "contains",
-      "source": "packages_athena_webapp_convex_reports_overview_ts",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L324",
-      "target": "overview_readtrendtransactioncounts",
-      "weight": 1
-    },
-    {
-      "_src": "packages_athena_webapp_convex_reports_overview_ts",
       "_tgt": "overview_rebuildstoreoverview",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L347",
+      "source_location": "L317",
       "target": "overview_rebuildstoreoverview",
       "weight": 1
     },
@@ -94007,7 +93983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L84",
+      "source_location": "L83",
       "target": "overview_snapshotfordays",
       "weight": 1
     },
@@ -94019,7 +93995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_reports_overview_ts",
       "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L128",
+      "source_location": "L127",
       "target": "overview_trustsummaryfordays",
       "weight": 1
     },
@@ -286116,101 +286092,101 @@
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_anchordate",
-      "label": "anchorDate()",
-      "norm_label": "anchordate()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L157"
+      "id": "packages_athena_webapp_shared_pos_terminalruntimematerial_ts",
+      "label": "terminalRuntimeMaterial.ts",
+      "norm_label": "terminalruntimematerial.ts",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L1"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_buildoverviewdata",
-      "label": "buildOverviewData()",
-      "norm_label": "buildoverviewdata()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L167"
+      "id": "terminalruntimematerial_getterminalruntimematerialsignature",
+      "label": "getTerminalRuntimeMaterialSignature()",
+      "norm_label": "getterminalruntimematerialsignature()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L33"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_comparisonbp",
-      "label": "comparisonBp()",
-      "norm_label": "comparisonbp()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L123"
+      "id": "terminalruntimematerial_projectactiveregistersession",
+      "label": "projectActiveRegisterSession()",
+      "norm_label": "projectactiveregistersession()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L39"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_emptysnapshot",
-      "label": "emptySnapshot()",
-      "norm_label": "emptysnapshot()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L57"
+      "id": "terminalruntimematerial_projectappupdate",
+      "label": "projectAppUpdate()",
+      "norm_label": "projectappupdate()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L50"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_isunsettled",
-      "label": "isUnsettled()",
-      "norm_label": "isunsettled()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L68"
+      "id": "terminalruntimematerial_projectdrawerauthority",
+      "label": "projectDrawerAuthority()",
+      "norm_label": "projectdrawerauthority()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L58"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_readrecentdays",
-      "label": "readRecentDays()",
-      "norm_label": "readrecentdays()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L303"
+      "id": "terminalruntimematerial_projectlocalstore",
+      "label": "projectLocalStore()",
+      "norm_label": "projectlocalstore()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L67"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_readtrendtransactioncounts",
-      "label": "readTrendTransactionCounts()",
-      "norm_label": "readtrendtransactioncounts()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L324"
+      "id": "terminalruntimematerial_projectstaffauthority",
+      "label": "projectStaffAuthority()",
+      "norm_label": "projectstaffauthority()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L89"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_rebuildstoreoverview",
-      "label": "rebuildStoreOverview()",
-      "norm_label": "rebuildstoreoverview()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L347"
-    },
-    {
-      "community": 286,
-      "file_type": "code",
-      "id": "overview_snapshotfordays",
-      "label": "snapshotForDays()",
-      "norm_label": "snapshotfordays()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "id": "terminalruntimematerial_projectstatus",
+      "label": "projectStatus()",
+      "norm_label": "projectstatus()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
       "source_location": "L84"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "overview_trustsummaryfordays",
-      "label": "trustSummaryForDays()",
-      "norm_label": "trustsummaryfordays()",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L128"
+      "id": "terminalruntimematerial_projectsync",
+      "label": "projectSync()",
+      "norm_label": "projectsync()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L97"
     },
     {
       "community": 286,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_overview_ts",
-      "label": "overview.ts",
-      "norm_label": "overview.ts",
-      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
-      "source_location": "L1"
+      "id": "terminalruntimematerial_projectterminalruntimematerial",
+      "label": "projectTerminalRuntimeMaterial()",
+      "norm_label": "projectterminalruntimematerial()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L15"
+    },
+    {
+      "community": 286,
+      "file_type": "code",
+      "id": "terminalruntimematerial_stripundefined",
+      "label": "stripUndefined()",
+      "norm_label": "stripundefined()",
+      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "source_location": "L109"
     },
     {
       "community": 2860,
@@ -286305,101 +286281,101 @@
     {
       "community": 287,
       "file_type": "code",
-      "id": "packages_athena_webapp_shared_pos_terminalruntimematerial_ts",
-      "label": "terminalRuntimeMaterial.ts",
-      "norm_label": "terminalruntimematerial.ts",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
+      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
+      "label": "OrdersTableToolbarProvider()",
+      "norm_label": "orderstabletoolbarprovider()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L16"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "data_table_toolbar_provider_useorderstabletoolbar",
+      "label": "useOrdersTableToolbar()",
+      "norm_label": "useorderstabletoolbar()",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L46"
+    },
+    {
+      "community": 287,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
       "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_getterminalruntimematerialsignature",
-      "label": "getTerminalRuntimeMaterialSignature()",
-      "norm_label": "getterminalruntimematerialsignature()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L33"
+      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectactiveregistersession",
-      "label": "projectActiveRegisterSession()",
-      "norm_label": "projectactiveregistersession()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L39"
+      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectappupdate",
-      "label": "projectAppUpdate()",
-      "norm_label": "projectappupdate()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L50"
+      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectdrawerauthority",
-      "label": "projectDrawerAuthority()",
-      "norm_label": "projectdrawerauthority()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L58"
+      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectlocalstore",
-      "label": "projectLocalStore()",
-      "norm_label": "projectlocalstore()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L67"
+      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectstaffauthority",
-      "label": "projectStaffAuthority()",
-      "norm_label": "projectstaffauthority()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L89"
+      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectstatus",
-      "label": "projectStatus()",
-      "norm_label": "projectstatus()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L84"
+      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 287,
       "file_type": "code",
-      "id": "terminalruntimematerial_projectsync",
-      "label": "projectSync()",
-      "norm_label": "projectsync()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "terminalruntimematerial_projectterminalruntimematerial",
-      "label": "projectTerminalRuntimeMaterial()",
-      "norm_label": "projectterminalruntimematerial()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L15"
-    },
-    {
-      "community": 287,
-      "file_type": "code",
-      "id": "terminalruntimematerial_stripundefined",
-      "label": "stripUndefined()",
-      "norm_label": "stripundefined()",
-      "source_file": "packages/athena-webapp/shared/pos/terminalRuntimeMaterial.ts",
-      "source_location": "L109"
+      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
+      "label": "data-table-toolbar-provider.tsx",
+      "norm_label": "data-table-toolbar-provider.tsx",
+      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
+      "source_location": "L1"
     },
     {
       "community": 2870,
@@ -286494,101 +286470,101 @@
     {
       "community": 288,
       "file_type": "code",
-      "id": "data_table_toolbar_provider_orderstabletoolbarprovider",
-      "label": "OrdersTableToolbarProvider()",
-      "norm_label": "orderstabletoolbarprovider()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L16"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "data_table_toolbar_provider_useorderstabletoolbar",
-      "label": "useOrdersTableToolbar()",
-      "norm_label": "useorderstabletoolbar()",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L46"
-    },
-    {
-      "community": 288,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/add-product/copy-images/table/data-table-toolbar-provider.tsx",
+      "id": "packages_athena_webapp_src_components_agent_useathenaagentrun_ts",
+      "label": "useAthenaAgentRun.ts",
+      "norm_label": "useathenaagentrun.ts",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
       "source_location": "L1"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/analytics/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_aspreview",
+      "label": "asPreview()",
+      "norm_label": "aspreview()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L428"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_assets_assets_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/assets/assets-table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_astrail",
+      "label": "asTrail()",
+      "norm_label": "astrail()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L378"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/base/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_asunavailable",
+      "label": "asUnavailable()",
+      "norm_label": "asunavailable()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L434"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_orders_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/orders/orders-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_asview",
+      "label": "asView()",
+      "norm_label": "asview()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L422"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_invites_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/invites-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_defaultturnkey",
+      "label": "defaultTurnKey()",
+      "norm_label": "defaultturnkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L328"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_organization_members_members_table_components_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/organization-members/members-table/components/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_deriveathenaprovisionalstate",
+      "label": "deriveAthenaProvisionalState()",
+      "norm_label": "deriveathenaprovisionalstate()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L184"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/promo-codes/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_newthreadtoken",
+      "label": "newThreadToken()",
+      "norm_label": "newthreadtoken()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L333"
     },
     {
       "community": 288,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_provider_tsx",
-      "label": "data-table-toolbar-provider.tsx",
-      "norm_label": "data-table-toolbar-provider.tsx",
-      "source_file": "packages/athena-webapp/src/components/user-bags/table/data-table-toolbar-provider.tsx",
-      "source_location": "L1"
+      "id": "useathenaagentrun_toprovisionaldrafts",
+      "label": "toProvisionalDrafts()",
+      "norm_label": "toprovisionaldrafts()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L384"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "useathenaagentrun_useathenaagentnarrativetrail",
+      "label": "useAthenaAgentNarrativeTrail()",
+      "norm_label": "useathenaagentnarrativetrail()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L396"
+    },
+    {
+      "community": 288,
+      "file_type": "code",
+      "id": "useathenaagentrun_useathenaagentrun",
+      "label": "useAthenaAgentRun()",
+      "norm_label": "useathenaagentrun()",
+      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "source_location": "L442"
     },
     {
       "community": 2880,
@@ -286683,101 +286659,101 @@
     {
       "community": 289,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_agent_useathenaagentrun_ts",
-      "label": "useAthenaAgentRun.ts",
-      "norm_label": "useathenaagentrun.ts",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
+      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
+      "label": "RegisterSessionsView.tsx",
+      "norm_label": "registersessionsview.tsx",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
       "source_location": "L1"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_aspreview",
-      "label": "asPreview()",
-      "norm_label": "aspreview()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L428"
+      "id": "registersessionsview_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L45"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_astrail",
-      "label": "asTrail()",
-      "norm_label": "astrail()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L378"
+      "id": "registersessionsview_formatduration",
+      "label": "formatDuration()",
+      "norm_label": "formatduration()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L93"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_asunavailable",
-      "label": "asUnavailable()",
-      "norm_label": "asunavailable()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L434"
+      "id": "registersessionsview_formatfinanciallabel",
+      "label": "formatFinancialLabel()",
+      "norm_label": "formatfinanciallabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L55"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_asview",
-      "label": "asView()",
-      "norm_label": "asview()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L422"
+      "id": "registersessionsview_formatregistername",
+      "label": "formatRegisterName()",
+      "norm_label": "formatregistername()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L67"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_defaultturnkey",
-      "label": "defaultTurnKey()",
-      "norm_label": "defaultturnkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L328"
+      "id": "registersessionsview_formatstatuslabel",
+      "label": "formatStatusLabel()",
+      "norm_label": "formatstatuslabel()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L78"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_deriveathenaprovisionalstate",
-      "label": "deriveAthenaProvisionalState()",
-      "norm_label": "deriveathenaprovisionalstate()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L184"
+      "id": "registersessionsview_formattimelinerange",
+      "label": "formatTimelineRange()",
+      "norm_label": "formattimelinerange()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L113"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_newthreadtoken",
-      "label": "newThreadToken()",
-      "norm_label": "newthreadtoken()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L333"
+      "id": "registersessionsview_formattimelinetime",
+      "label": "formatTimelineTime()",
+      "norm_label": "formattimelinetime()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L86"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_toprovisionaldrafts",
-      "label": "toProvisionalDrafts()",
-      "norm_label": "toprovisionaldrafts()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L384"
+      "id": "registersessionsview_getstaffname",
+      "label": "getStaffName()",
+      "norm_label": "getstaffname()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L139"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_useathenaagentnarrativetrail",
-      "label": "useAthenaAgentNarrativeTrail()",
-      "norm_label": "useathenaagentnarrativetrail()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L396"
+      "id": "registersessionsview_getvariancecaption",
+      "label": "getVarianceCaption()",
+      "norm_label": "getvariancecaption()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L131"
     },
     {
       "community": 289,
       "file_type": "code",
-      "id": "useathenaagentrun_useathenaagentrun",
-      "label": "useAthenaAgentRun()",
-      "norm_label": "useathenaagentrun()",
-      "source_file": "packages/athena-webapp/src/components/agent/useAthenaAgentRun.ts",
-      "source_location": "L442"
+      "id": "registersessionsview_getvariancetone",
+      "label": "getVarianceTone()",
+      "norm_label": "getvariancetone()",
+      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "source_location": "L123"
     },
     {
       "community": 2890,
@@ -287223,101 +287199,101 @@
     {
       "community": 290,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_cash_controls_registersessionsview_tsx",
-      "label": "RegisterSessionsView.tsx",
-      "norm_label": "registersessionsview.tsx",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
+      "id": "packages_athena_webapp_src_components_orders_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L45"
+      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L1"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formatduration",
-      "label": "formatDuration()",
-      "norm_label": "formatduration()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L93"
+      "id": "utils_formatdeliveryaddress",
+      "label": "formatDeliveryAddress()",
+      "norm_label": "formatdeliveryaddress()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L74"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formatfinanciallabel",
-      "label": "formatFinancialLabel()",
-      "norm_label": "formatfinanciallabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L55"
+      "id": "utils_getamountpaidfororder",
+      "label": "getAmountPaidForOrder()",
+      "norm_label": "getamountpaidfororder()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L152"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formatregistername",
-      "label": "formatRegisterName()",
-      "norm_label": "formatregistername()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L67"
+      "id": "utils_getdiscountvalue",
+      "label": "getDiscountValue()",
+      "norm_label": "getdiscountvalue()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L17"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formatstatuslabel",
-      "label": "formatStatusLabel()",
-      "norm_label": "formatstatuslabel()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L78"
+      "id": "utils_getonlineorderplacedat",
+      "label": "getOnlineOrderPlacedAt()",
+      "norm_label": "getonlineorderplacedat()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L3"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formattimelinerange",
-      "label": "formatTimelineRange()",
-      "norm_label": "formattimelinerange()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L113"
+      "id": "utils_getorderamount",
+      "label": "getOrderAmount()",
+      "norm_label": "getorderamount()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L51"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_formattimelinetime",
-      "label": "formatTimelineTime()",
-      "norm_label": "formattimelinetime()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L86"
+      "id": "utils_getorderstate",
+      "label": "getOrderState()",
+      "norm_label": "getorderstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L44"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_getstaffname",
-      "label": "getStaffName()",
-      "norm_label": "getstaffname()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L139"
+      "id": "utils_getpickupactionstate",
+      "label": "getPickupActionState()",
+      "norm_label": "getpickupactionstate()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L106"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_getvariancecaption",
-      "label": "getVarianceCaption()",
-      "norm_label": "getvariancecaption()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L131"
+      "id": "utils_getpotentialpoints",
+      "label": "getPotentialPoints()",
+      "norm_label": "getpotentialpoints()",
+      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 290,
       "file_type": "code",
-      "id": "registersessionsview_getvariancetone",
-      "label": "getVarianceTone()",
-      "norm_label": "getvariancetone()",
-      "source_file": "packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx",
-      "source_location": "L123"
+      "id": "utils_shouldshowpickupexceptionaction",
+      "label": "shouldShowPickupExceptionAction()",
+      "norm_label": "shouldshowpickupexceptionaction()",
+      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "source_location": "L120"
     },
     {
       "community": 2900,
@@ -287412,101 +287388,101 @@
     {
       "community": 291,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_orders_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
+      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
+      "label": "RegisterCustomerAttribution.tsx",
+      "norm_label": "registercustomerattribution.tsx",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
       "source_location": "L1"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_checkout_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L1"
+      "id": "registercustomerattribution_buildcustomercreateinput",
+      "label": "buildCustomerCreateInput()",
+      "norm_label": "buildcustomercreateinput()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L48"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_formatdeliveryaddress",
-      "label": "formatDeliveryAddress()",
-      "norm_label": "formatdeliveryaddress()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L74"
+      "id": "registercustomerattribution_cancelpendingadd",
+      "label": "cancelPendingAdd()",
+      "norm_label": "cancelpendingadd()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L126"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getamountpaidfororder",
-      "label": "getAmountPaidForOrder()",
-      "norm_label": "getamountpaidfororder()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L152"
+      "id": "registercustomerattribution_cn",
+      "label": "cn()",
+      "norm_label": "cn()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L368"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getdiscountvalue",
-      "label": "getDiscountValue()",
-      "norm_label": "getdiscountvalue()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L17"
+      "id": "registercustomerattribution_commitcustomer",
+      "label": "commitCustomer()",
+      "norm_label": "commitcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L131"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getonlineorderplacedat",
-      "label": "getOnlineOrderPlacedAt()",
-      "norm_label": "getonlineorderplacedat()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L3"
+      "id": "registercustomerattribution_getsecondaryidentifier",
+      "label": "getSecondaryIdentifier()",
+      "norm_label": "getsecondaryidentifier()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L75"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getorderamount",
-      "label": "getOrderAmount()",
-      "norm_label": "getorderamount()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L51"
+      "id": "registercustomerattribution_handleaddfromsearch",
+      "label": "handleAddFromSearch()",
+      "norm_label": "handleaddfromsearch()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L160"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getorderstate",
-      "label": "getOrderState()",
-      "norm_label": "getorderstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L44"
+      "id": "registercustomerattribution_handleclearcustomer",
+      "label": "handleClearCustomer()",
+      "norm_label": "handleclearcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L148"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getpickupactionstate",
-      "label": "getPickupActionState()",
-      "norm_label": "getpickupactionstate()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L106"
+      "id": "registercustomerattribution_handleselectcustomer",
+      "label": "handleSelectCustomer()",
+      "norm_label": "handleselectcustomer()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L136"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_getpotentialpoints",
-      "label": "getPotentialPoints()",
-      "norm_label": "getpotentialpoints()",
-      "source_file": "packages/storefront-webapp/src/components/checkout/utils.ts",
-      "source_location": "L107"
+      "id": "registercustomerattribution_tocustomerinfo",
+      "label": "toCustomerInfo()",
+      "norm_label": "tocustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L79"
     },
     {
       "community": 291,
       "file_type": "code",
-      "id": "utils_shouldshowpickupexceptionaction",
-      "label": "shouldShowPickupExceptionAction()",
-      "norm_label": "shouldshowpickupexceptionaction()",
-      "source_file": "packages/athena-webapp/src/components/orders/utils.ts",
-      "source_location": "L120"
+      "id": "registercustomerattribution_trimcustomerinfo",
+      "label": "trimCustomerInfo()",
+      "norm_label": "trimcustomerinfo()",
+      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "source_location": "L39"
     },
     {
       "community": 2910,
@@ -287601,101 +287577,101 @@
     {
       "community": 292,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_pos_register_registercustomerattribution_tsx",
-      "label": "RegisterCustomerAttribution.tsx",
-      "norm_label": "registercustomerattribution.tsx",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
+      "id": "packages_athena_webapp_src_components_shared_demo_shareddemolocalbootstrap_ts",
+      "label": "sharedDemoLocalBootstrap.ts",
+      "norm_label": "shareddemolocalbootstrap.ts",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
       "source_location": "L1"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_buildcustomercreateinput",
-      "label": "buildCustomerCreateInput()",
-      "norm_label": "buildcustomercreateinput()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L48"
+      "id": "shareddemolocalbootstrap_getshareddemoregisternumber",
+      "label": "getSharedDemoRegisterNumber()",
+      "norm_label": "getshareddemoregisternumber()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L73"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_cancelpendingadd",
-      "label": "cancelPendingAdd()",
-      "norm_label": "cancelpendingadd()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L126"
+      "id": "shareddemolocalbootstrap_getshareddemoregisternumbercandidates",
+      "label": "getSharedDemoRegisterNumberCandidates()",
+      "norm_label": "getshareddemoregisternumbercandidates()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L55"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_cn",
-      "label": "cn()",
-      "norm_label": "cn()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L368"
+      "id": "shareddemolocalbootstrap_getshareddemorestoreepochstoragekey",
+      "label": "getSharedDemoRestoreEpochStorageKey()",
+      "norm_label": "getshareddemorestoreepochstoragekey()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L25"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_commitcustomer",
-      "label": "commitCustomer()",
-      "norm_label": "commitcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L131"
+      "id": "shareddemolocalbootstrap_getshareddemoterminalname",
+      "label": "getSharedDemoTerminalName()",
+      "norm_label": "getshareddemoterminalname()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L133"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_getsecondaryidentifier",
-      "label": "getSecondaryIdentifier()",
-      "norm_label": "getsecondaryidentifier()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L75"
+      "id": "shareddemolocalbootstrap_isshareddemoregisternumber",
+      "label": "isSharedDemoRegisterNumber()",
+      "norm_label": "isshareddemoregisternumber()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L77"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_handleaddfromsearch",
-      "label": "handleAddFromSearch()",
-      "norm_label": "handleaddfromsearch()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L160"
+      "id": "shareddemolocalbootstrap_planshareddemolocalbootstrap",
+      "label": "planSharedDemoLocalBootstrap()",
+      "norm_label": "planshareddemolocalbootstrap()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L143"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_handleclearcustomer",
-      "label": "handleClearCustomer()",
-      "norm_label": "handleclearcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L148"
+      "id": "shareddemolocalbootstrap_provisionshareddemoregister",
+      "label": "provisionSharedDemoRegister()",
+      "norm_label": "provisionshareddemoregister()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L83"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_handleselectcustomer",
-      "label": "handleSelectCustomer()",
-      "norm_label": "handleselectcustomer()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L136"
+      "id": "shareddemolocalbootstrap_resetshareddemofirstvisitbrowserstate",
+      "label": "resetSharedDemoFirstVisitBrowserState()",
+      "norm_label": "resetshareddemofirstvisitbrowserstate()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L29"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_tocustomerinfo",
-      "label": "toCustomerInfo()",
-      "norm_label": "tocustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L79"
+      "id": "shareddemolocalbootstrap_resolveshareddemoregisterbootstrapaction",
+      "label": "resolveSharedDemoRegisterBootstrapAction()",
+      "norm_label": "resolveshareddemoregisterbootstrapaction()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L167"
     },
     {
       "community": 292,
       "file_type": "code",
-      "id": "registercustomerattribution_trimcustomerinfo",
-      "label": "trimCustomerInfo()",
-      "norm_label": "trimcustomerinfo()",
-      "source_file": "packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx",
-      "source_location": "L39"
+      "id": "shareddemolocalbootstrap_resolveshareddemorestorebootstrapstatus",
+      "label": "resolveSharedDemoRestoreBootstrapStatus()",
+      "norm_label": "resolveshareddemorestorebootstrapstatus()",
+      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "source_location": "L17"
     },
     {
       "community": 2920,
@@ -287790,101 +287766,101 @@
     {
       "community": 293,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_shared_demo_shareddemolocalbootstrap_ts",
-      "label": "sharedDemoLocalBootstrap.ts",
-      "norm_label": "shareddemolocalbootstrap.ts",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "id": "packages_athena_webapp_src_lib_docs_parsing_ts",
+      "label": "parsing.ts",
+      "norm_label": "parsing.ts",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
       "source_location": "L1"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_getshareddemoregisternumber",
-      "label": "getSharedDemoRegisterNumber()",
-      "norm_label": "getshareddemoregisternumber()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L73"
+      "id": "parsing_comparebydatedesc",
+      "label": "compareByDateDesc()",
+      "norm_label": "comparebydatedesc()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L244"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_getshareddemoregisternumbercandidates",
-      "label": "getSharedDemoRegisterNumberCandidates()",
-      "norm_label": "getshareddemoregisternumbercandidates()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
+      "id": "parsing_deliveryreportmetafromfile",
+      "label": "deliveryReportMetaFromFile()",
+      "norm_label": "deliveryreportmetafromfile()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "parsing_firstheading",
+      "label": "firstHeading()",
+      "norm_label": "firstheading()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L120"
+    },
+    {
+      "community": 293,
+      "file_type": "code",
+      "id": "parsing_parseinlinelist",
+      "label": "parseInlineList()",
+      "norm_label": "parseinlinelist()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
       "source_location": "L55"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_getshareddemorestoreepochstoragekey",
-      "label": "getSharedDemoRestoreEpochStorageKey()",
-      "norm_label": "getshareddemorestoreepochstoragekey()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L25"
+      "id": "parsing_parsesolutionfrontmatter",
+      "label": "parseSolutionFrontmatter()",
+      "norm_label": "parsesolutionfrontmatter()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L68"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_getshareddemoterminalname",
-      "label": "getSharedDemoTerminalName()",
-      "norm_label": "getshareddemoterminalname()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L133"
+      "id": "parsing_resolvesolutiondoclink",
+      "label": "resolveSolutionDocLink()",
+      "norm_label": "resolvesolutiondoclink()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L202"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_isshareddemoregisternumber",
-      "label": "isSharedDemoRegisterNumber()",
-      "norm_label": "isshareddemoregisternumber()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L77"
+      "id": "parsing_solutiondocmetafromfile",
+      "label": "solutionDocMetaFromFile()",
+      "norm_label": "solutiondocmetafromfile()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L131"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_planshareddemolocalbootstrap",
-      "label": "planSharedDemoLocalBootstrap()",
-      "norm_label": "planshareddemolocalbootstrap()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L143"
+      "id": "parsing_stripfrontmatter",
+      "label": "stripFrontmatter()",
+      "norm_label": "stripfrontmatter()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L116"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_provisionshareddemoregister",
-      "label": "provisionSharedDemoRegister()",
-      "norm_label": "provisionshareddemoregister()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L83"
+      "id": "parsing_titlecasefromslug",
+      "label": "titleCaseFromSlug()",
+      "norm_label": "titlecasefromslug()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L125"
     },
     {
       "community": 293,
       "file_type": "code",
-      "id": "shareddemolocalbootstrap_resetshareddemofirstvisitbrowserstate",
-      "label": "resetSharedDemoFirstVisitBrowserState()",
-      "norm_label": "resetshareddemofirstvisitbrowserstate()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "shareddemolocalbootstrap_resolveshareddemoregisterbootstrapaction",
-      "label": "resolveSharedDemoRegisterBootstrapAction()",
-      "norm_label": "resolveshareddemoregisterbootstrapaction()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 293,
-      "file_type": "code",
-      "id": "shareddemolocalbootstrap_resolveshareddemorestorebootstrapstatus",
-      "label": "resolveSharedDemoRestoreBootstrapStatus()",
-      "norm_label": "resolveshareddemorestorebootstrapstatus()",
-      "source_file": "packages/athena-webapp/src/components/shared-demo/sharedDemoLocalBootstrap.ts",
-      "source_location": "L17"
+      "id": "parsing_unquote",
+      "label": "unquote()",
+      "norm_label": "unquote()",
+      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "source_location": "L43"
     },
     {
       "community": 2930,
@@ -287979,101 +287955,101 @@
     {
       "community": 294,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_docs_parsing_ts",
-      "label": "parsing.ts",
-      "norm_label": "parsing.ts",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
+      "id": "drawerauthorityreconciliation_assertposlocalstoreok",
+      "label": "assertPosLocalStoreOk()",
+      "norm_label": "assertposlocalstoreok()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L449"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_clearrecoverabledrawerauthorityforsyncedevents",
+      "label": "clearRecoverableDrawerAuthorityForSyncedEvents()",
+      "norm_label": "clearrecoverabledrawerauthorityforsyncedevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L118"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_clearsettledrecoverabledrawerauthorityblock",
+      "label": "clearSettledRecoverableDrawerAuthorityBlock()",
+      "norm_label": "clearsettledrecoverabledrawerauthorityblock()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L334"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_clearsupersededrecoverabledrawerauthorityblocks",
+      "label": "clearSupersededRecoverableDrawerAuthorityBlocks()",
+      "norm_label": "clearsupersededrecoverabledrawerauthorityblocks()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L203"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_drawerauthorityeventkey",
+      "label": "drawerAuthorityEventKey()",
+      "norm_label": "drawerauthorityeventkey()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L434"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_finddrawerauthorityblockforreview",
+      "label": "findDrawerAuthorityBlockForReview()",
+      "norm_label": "finddrawerauthorityblockforreview()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_isdrawerauthoritylifecycleevent",
+      "label": "isDrawerAuthorityLifecycleEvent()",
+      "norm_label": "isdrawerauthoritylifecycleevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L442"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_isrecoverabledrawerauthorityreason",
+      "label": "isRecoverableDrawerAuthorityReason()",
+      "norm_label": "isrecoverabledrawerauthorityreason()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L424"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_persistdrawerauthorityblockforreviewevents",
+      "label": "persistDrawerAuthorityBlockForReviewEvents()",
+      "norm_label": "persistdrawerauthorityblockforreviewevents()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "drawerauthorityreconciliation_readlatestruntimedrawerauthoritystate",
+      "label": "readLatestRuntimeDrawerAuthorityState()",
+      "norm_label": "readlatestruntimedrawerauthoritystate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "source_location": "L393"
+    },
+    {
+      "community": 294,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_drawerauthorityreconciliation_ts",
+      "label": "drawerAuthorityReconciliation.ts",
+      "norm_label": "drawerauthorityreconciliation.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_comparebydatedesc",
-      "label": "compareByDateDesc()",
-      "norm_label": "comparebydatedesc()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L244"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_deliveryreportmetafromfile",
-      "label": "deliveryReportMetaFromFile()",
-      "norm_label": "deliveryreportmetafromfile()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_firstheading",
-      "label": "firstHeading()",
-      "norm_label": "firstheading()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_parseinlinelist",
-      "label": "parseInlineList()",
-      "norm_label": "parseinlinelist()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_parsesolutionfrontmatter",
-      "label": "parseSolutionFrontmatter()",
-      "norm_label": "parsesolutionfrontmatter()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_resolvesolutiondoclink",
-      "label": "resolveSolutionDocLink()",
-      "norm_label": "resolvesolutiondoclink()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_solutiondocmetafromfile",
-      "label": "solutionDocMetaFromFile()",
-      "norm_label": "solutiondocmetafromfile()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_stripfrontmatter",
-      "label": "stripFrontmatter()",
-      "norm_label": "stripfrontmatter()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_titlecasefromslug",
-      "label": "titleCaseFromSlug()",
-      "norm_label": "titlecasefromslug()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 294,
-      "file_type": "code",
-      "id": "parsing_unquote",
-      "label": "unquote()",
-      "norm_label": "unquote()",
-      "source_file": "packages/athena-webapp/src/lib/docs/parsing.ts",
-      "source_location": "L43"
     },
     {
       "community": 2940,
@@ -288168,101 +288144,101 @@
     {
       "community": 295,
       "file_type": "code",
-      "id": "drawerauthorityreconciliation_assertposlocalstoreok",
-      "label": "assertPosLocalStoreOk()",
-      "norm_label": "assertposlocalstoreok()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_useposterminalappsessionrecovery_ts",
+      "label": "usePosTerminalAppSessionRecovery.ts",
+      "norm_label": "useposterminalappsessionrecovery.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_getbrowseronline",
+      "label": "getBrowserOnline()",
+      "norm_label": "getbrowseronline()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L498"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_isscopedrecoveryassertion",
+      "label": "isScopedRecoveryAssertion()",
+      "norm_label": "isscopedrecoveryassertion()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L485"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_readstoredposappaccountid",
+      "label": "readStoredPosAppAccountId()",
+      "norm_label": "readstoredposappaccountid()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L137"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_resetposterminalappsessionrecoveryruntimefortests",
+      "label": "resetPosTerminalAppSessionRecoveryRuntimeForTests()",
+      "norm_label": "resetposterminalappsessionrecoveryruntimefortests()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_resolverecoverytarget",
+      "label": "resolveRecoveryTarget()",
+      "norm_label": "resolverecoverytarget()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L386"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_runsharedrecovery",
+      "label": "runSharedRecovery()",
+      "norm_label": "runsharedrecovery()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L428"
+    },
+    {
+      "community": 295,
+      "file_type": "code",
+      "id": "useposterminalappsessionrecovery_runwithtimeout",
+      "label": "runWithTimeout()",
+      "norm_label": "runwithtimeout()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
       "source_location": "L449"
     },
     {
       "community": 295,
       "file_type": "code",
-      "id": "drawerauthorityreconciliation_clearrecoverabledrawerauthorityforsyncedevents",
-      "label": "clearRecoverableDrawerAuthorityForSyncedEvents()",
-      "norm_label": "clearrecoverabledrawerauthorityforsyncedevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L118"
+      "id": "useposterminalappsessionrecovery_scheduleassertionexpiry",
+      "label": "scheduleAssertionExpiry()",
+      "norm_label": "scheduleassertionexpiry()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L507"
     },
     {
       "community": 295,
       "file_type": "code",
-      "id": "drawerauthorityreconciliation_clearsettledrecoverabledrawerauthorityblock",
-      "label": "clearSettledRecoverableDrawerAuthorityBlock()",
-      "norm_label": "clearsettledrecoverabledrawerauthorityblock()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L334"
+      "id": "useposterminalappsessionrecovery_schedulebrowserretry",
+      "label": "scheduleBrowserRetry()",
+      "norm_label": "schedulebrowserretry()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L502"
     },
     {
       "community": 295,
       "file_type": "code",
-      "id": "drawerauthorityreconciliation_clearsupersededrecoverabledrawerauthorityblocks",
-      "label": "clearSupersededRecoverableDrawerAuthorityBlocks()",
-      "norm_label": "clearsupersededrecoverabledrawerauthorityblocks()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L203"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "drawerauthorityreconciliation_drawerauthorityeventkey",
-      "label": "drawerAuthorityEventKey()",
-      "norm_label": "drawerauthorityeventkey()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L434"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "drawerauthorityreconciliation_finddrawerauthorityblockforreview",
-      "label": "findDrawerAuthorityBlockForReview()",
-      "norm_label": "finddrawerauthorityblockforreview()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "drawerauthorityreconciliation_isdrawerauthoritylifecycleevent",
-      "label": "isDrawerAuthorityLifecycleEvent()",
-      "norm_label": "isdrawerauthoritylifecycleevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L442"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "drawerauthorityreconciliation_isrecoverabledrawerauthorityreason",
-      "label": "isRecoverableDrawerAuthorityReason()",
-      "norm_label": "isrecoverabledrawerauthorityreason()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L424"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "drawerauthorityreconciliation_persistdrawerauthorityblockforreviewevents",
-      "label": "persistDrawerAuthorityBlockForReviewEvents()",
-      "norm_label": "persistdrawerauthorityblockforreviewevents()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "drawerauthorityreconciliation_readlatestruntimedrawerauthoritystate",
-      "label": "readLatestRuntimeDrawerAuthorityState()",
-      "norm_label": "readlatestruntimedrawerauthoritystate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L393"
-    },
-    {
-      "community": 295,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_drawerauthorityreconciliation_ts",
-      "label": "drawerAuthorityReconciliation.ts",
-      "norm_label": "drawerauthorityreconciliation.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts",
-      "source_location": "L1"
+      "id": "useposterminalappsessionrecovery_useposterminalappsessionrecovery",
+      "label": "usePosTerminalAppSessionRecovery()",
+      "norm_label": "useposterminalappsessionrecovery()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "source_location": "L158"
     },
     {
       "community": 2950,
@@ -288357,101 +288333,101 @@
     {
       "community": 296,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_terminal_useposterminalappsessionrecovery_ts",
-      "label": "usePosTerminalAppSessionRecovery.ts",
-      "norm_label": "useposterminalappsessionrecovery.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
+      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
+      "label": "useRegisterViewModel.test.ts",
+      "norm_label": "useregisterviewmodel.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
       "source_location": "L1"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_getbrowseronline",
-      "label": "getBrowserOnline()",
-      "norm_label": "getbrowseronline()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L498"
+      "id": "useregisterviewmodel_test_buildcashierpresence",
+      "label": "buildCashierPresence()",
+      "norm_label": "buildcashierpresence()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L544"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_isscopedrecoveryassertion",
-      "label": "isScopedRecoveryAssertion()",
-      "norm_label": "isscopedrecoveryassertion()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L485"
+      "id": "useregisterviewmodel_test_buildlocalevent",
+      "label": "buildLocalEvent()",
+      "norm_label": "buildlocalevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L464"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_readstoredposappaccountid",
-      "label": "readStoredPosAppAccountId()",
-      "norm_label": "readstoredposappaccountid()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L137"
+      "id": "useregisterviewmodel_test_buildmocklocalstore",
+      "label": "buildMockLocalStore()",
+      "norm_label": "buildmocklocalstore()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L364"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_resetposterminalappsessionrecoveryruntimefortests",
-      "label": "resetPosTerminalAppSessionRecoveryRuntimeForTests()",
-      "norm_label": "resetposterminalappsessionrecoveryruntimefortests()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L154"
+      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
+      "label": "buildRegisterCatalogAvailabilityRow()",
+      "norm_label": "buildregistercatalogavailabilityrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L452"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_resolverecoverytarget",
-      "label": "resolveRecoveryTarget()",
-      "norm_label": "resolverecoverytarget()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L386"
+      "id": "useregisterviewmodel_test_buildregistercatalogrow",
+      "label": "buildRegisterCatalogRow()",
+      "norm_label": "buildregistercatalogrow()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L429"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_runsharedrecovery",
-      "label": "runSharedRecovery()",
-      "norm_label": "runsharedrecovery()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L428"
+      "id": "useregisterviewmodel_test_buildstaffauthenticationresult",
+      "label": "buildStaffAuthenticationResult()",
+      "norm_label": "buildstaffauthenticationresult()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L490"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_runwithtimeout",
-      "label": "runWithTimeout()",
-      "norm_label": "runwithtimeout()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L449"
+      "id": "useregisterviewmodel_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L420"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_scheduleassertionexpiry",
-      "label": "scheduleAssertionExpiry()",
-      "norm_label": "scheduleassertionexpiry()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L507"
+      "id": "useregisterviewmodel_test_gettestoperatingdate",
+      "label": "getTestOperatingDate()",
+      "norm_label": "gettestoperatingdate()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L536"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_schedulebrowserretry",
-      "label": "scheduleBrowserRetry()",
-      "norm_label": "schedulebrowserretry()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L502"
+      "id": "useregisterviewmodel_test_resolveadditem",
+      "label": "resolveAddItem()",
+      "norm_label": "resolveadditem()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L11630"
     },
     {
       "community": 296,
       "file_type": "code",
-      "id": "useposterminalappsessionrecovery_useposterminalappsessionrecovery",
-      "label": "usePosTerminalAppSessionRecovery()",
-      "norm_label": "useposterminalappsessionrecovery()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts",
-      "source_location": "L158"
+      "id": "useregisterviewmodel_test_waitforlocalregistereffects",
+      "label": "waitForLocalRegisterEffects()",
+      "norm_label": "waitforlocalregistereffects()",
+      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "source_location": "L581"
     },
     {
       "community": 2960,
@@ -288546,101 +288522,101 @@
     {
       "community": 297,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_presentation_register_useregisterviewmodel_test_ts",
-      "label": "useRegisterViewModel.test.ts",
-      "norm_label": "useregisterviewmodel.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_tsx",
+      "label": "sku-activity.tsx",
+      "norm_label": "sku-activity.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
       "source_location": "L1"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildcashierpresence",
-      "label": "buildCashierPresence()",
-      "norm_label": "buildcashierpresence()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L544"
+      "id": "sku_activity_formatheadercount",
+      "label": "formatHeaderCount()",
+      "norm_label": "formatheadercount()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L58"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildlocalevent",
-      "label": "buildLocalEvent()",
-      "norm_label": "buildlocalevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L464"
+      "id": "sku_activity_formatskuactivityheaderdescription",
+      "label": "formatSkuActivityHeaderDescription()",
+      "norm_label": "formatskuactivityheaderdescription()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L72"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildmocklocalstore",
-      "label": "buildMockLocalStore()",
-      "norm_label": "buildmocklocalstore()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L364"
+      "id": "sku_activity_formatskuactivityheadertitle",
+      "label": "formatSkuActivityHeaderTitle()",
+      "norm_label": "formatskuactivityheadertitle()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L62"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogavailabilityrow",
-      "label": "buildRegisterCatalogAvailabilityRow()",
-      "norm_label": "buildregistercatalogavailabilityrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L452"
+      "id": "sku_activity_handlechangereviewstatus",
+      "label": "handleChangeReviewStatus()",
+      "norm_label": "handlechangereviewstatus()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L298"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildregistercatalogrow",
-      "label": "buildRegisterCatalogRow()",
-      "norm_label": "buildregistercatalogrow()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L429"
+      "id": "sku_activity_handlechangesourcefilter",
+      "label": "handleChangeSourceFilter()",
+      "norm_label": "handlechangesourcefilter()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L313"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_buildstaffauthenticationresult",
-      "label": "buildStaffAuthenticationResult()",
-      "norm_label": "buildstaffauthenticationresult()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L490"
+      "id": "sku_activity_handlechangetransactionpage",
+      "label": "handleChangeTransactionPage()",
+      "norm_label": "handlechangetransactionpage()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L341"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L420"
+      "id": "sku_activity_handleevidencesubmit",
+      "label": "handleEvidenceSubmit()",
+      "norm_label": "handleevidencesubmit()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L174"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_gettestoperatingdate",
-      "label": "getTestOperatingDate()",
-      "norm_label": "gettestoperatingdate()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L536"
+      "id": "sku_activity_handleloadmoresources",
+      "label": "handleLoadMoreSources()",
+      "norm_label": "handleloadmoresources()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L351"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_resolveadditem",
-      "label": "resolveAddItem()",
-      "norm_label": "resolveadditem()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L11630"
+      "id": "sku_activity_handleloadmoretransactions",
+      "label": "handleLoadMoreTransactions()",
+      "norm_label": "handleloadmoretransactions()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L363"
     },
     {
       "community": 297,
       "file_type": "code",
-      "id": "useregisterviewmodel_test_waitforlocalregistereffects",
-      "label": "waitForLocalRegisterEffects()",
-      "norm_label": "waitforlocalregistereffects()",
-      "source_file": "packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
-      "source_location": "L581"
+      "id": "sku_activity_handleselectsource",
+      "label": "handleSelectSource()",
+      "norm_label": "handleselectsource()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "source_location": "L327"
     },
     {
       "community": 2970,
@@ -288735,101 +288711,101 @@
     {
       "community": 298,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_operations_sku_activity_tsx",
-      "label": "sku-activity.tsx",
-      "norm_label": "sku-activity.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L1"
+      "id": "backend_test_completesession",
+      "label": "completeSession()",
+      "norm_label": "completesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L629"
     },
     {
       "community": 298,
       "file_type": "code",
-      "id": "sku_activity_formatheadercount",
-      "label": "formatHeaderCount()",
-      "norm_label": "formatheadercount()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
+      "id": "backend_test_createtransaction",
+      "label": "createTransaction()",
+      "norm_label": "createtransaction()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 298,
+      "file_type": "code",
+      "id": "backend_test_createtransactionitems",
+      "label": "createTransactionItems()",
+      "norm_label": "createtransactionitems()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L467"
+    },
+    {
+      "community": 298,
+      "file_type": "code",
+      "id": "backend_test_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 298,
+      "file_type": "code",
+      "id": "backend_test_handledatabaseerror",
+      "label": "handleDatabaseError()",
+      "norm_label": "handledatabaseerror()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L671"
+    },
+    {
+      "community": 298,
+      "file_type": "code",
+      "id": "backend_test_rollbackinventory",
+      "label": "rollbackInventory()",
+      "norm_label": "rollbackinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L692"
+    },
+    {
+      "community": 298,
+      "file_type": "code",
+      "id": "backend_test_updateinventory",
+      "label": "updateInventory()",
+      "norm_label": "updateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 298,
+      "file_type": "code",
+      "id": "backend_test_validateinventory",
+      "label": "validateInventory()",
+      "norm_label": "validateinventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
       "source_location": "L58"
     },
     {
       "community": 298,
       "file_type": "code",
-      "id": "sku_activity_formatskuactivityheaderdescription",
-      "label": "formatSkuActivityHeaderDescription()",
-      "norm_label": "formatskuactivityheaderdescription()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L72"
+      "id": "backend_test_validatesession",
+      "label": "validateSession()",
+      "norm_label": "validatesession()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L553"
     },
     {
       "community": 298,
       "file_type": "code",
-      "id": "sku_activity_formatskuactivityheadertitle",
-      "label": "formatSkuActivityHeaderTitle()",
-      "norm_label": "formatskuactivityheadertitle()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L62"
+      "id": "backend_test_validatesessioninventory",
+      "label": "validateSessionInventory()",
+      "norm_label": "validatesessioninventory()",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L593"
     },
     {
       "community": 298,
       "file_type": "code",
-      "id": "sku_activity_handlechangereviewstatus",
-      "label": "handleChangeReviewStatus()",
-      "norm_label": "handlechangereviewstatus()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L298"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sku_activity_handlechangesourcefilter",
-      "label": "handleChangeSourceFilter()",
-      "norm_label": "handlechangesourcefilter()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L313"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sku_activity_handlechangetransactionpage",
-      "label": "handleChangeTransactionPage()",
-      "norm_label": "handlechangetransactionpage()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L341"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sku_activity_handleevidencesubmit",
-      "label": "handleEvidenceSubmit()",
-      "norm_label": "handleevidencesubmit()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L174"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sku_activity_handleloadmoresources",
-      "label": "handleLoadMoreSources()",
-      "norm_label": "handleloadmoresources()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L351"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sku_activity_handleloadmoretransactions",
-      "label": "handleLoadMoreTransactions()",
-      "norm_label": "handleloadmoretransactions()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 298,
-      "file_type": "code",
-      "id": "sku_activity_handleselectsource",
-      "label": "handleSelectSource()",
-      "norm_label": "handleselectsource()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.tsx",
-      "source_location": "L327"
+      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
+      "label": "backend.test.ts",
+      "norm_label": "backend.test.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 2980,
@@ -288924,100 +288900,100 @@
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_completesession",
-      "label": "completeSession()",
-      "norm_label": "completesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L629"
+      "id": "offlinerouteaccess_spec_collectofflineappshelldiagnostics",
+      "label": "collectOfflineAppShellDiagnostics()",
+      "norm_label": "collectofflineappshelldiagnostics()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L167"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_createtransaction",
-      "label": "createTransaction()",
-      "norm_label": "createtransaction()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L391"
+      "id": "offlinerouteaccess_spec_expectnobusinesspayloadscached",
+      "label": "expectNoBusinessPayloadsCached()",
+      "norm_label": "expectnobusinesspayloadscached()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L122"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_createtransactionitems",
-      "label": "createTransactionItems()",
-      "norm_label": "createtransactionitems()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L467"
+      "id": "offlinerouteaccess_spec_expectposregisterroutechunkscached",
+      "label": "expectPosRegisterRouteChunksCached()",
+      "norm_label": "expectposregisterroutechunkscached()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L144"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L374"
+      "id": "offlinerouteaccess_spec_formatruntimesignals",
+      "label": "formatRuntimeSignals()",
+      "norm_label": "formatruntimesignals()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L190"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_handledatabaseerror",
-      "label": "handleDatabaseError()",
-      "norm_label": "handledatabaseerror()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L671"
+      "id": "offlinerouteaccess_spec_getposappshellcachedurls",
+      "label": "getPosAppShellCachedUrls()",
+      "norm_label": "getposappshellcachedurls()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L151"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_rollbackinventory",
-      "label": "rollbackInventory()",
-      "norm_label": "rollbackinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L692"
+      "id": "offlinerouteaccess_spec_waitforloadedshellassetscached",
+      "label": "waitForLoadedShellAssetsCached()",
+      "norm_label": "waitforloadedshellassetscached()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L47"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_updateinventory",
-      "label": "updateInventory()",
-      "norm_label": "updateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L422"
+      "id": "offlinerouteaccess_spec_waitforposappshellcache",
+      "label": "waitForPosAppShellCache()",
+      "norm_label": "waitforposappshellcache()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L32"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_validateinventory",
-      "label": "validateInventory()",
-      "norm_label": "validateinventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L58"
+      "id": "offlinerouteaccess_spec_waitforposappshellserviceworkerready",
+      "label": "waitForPosAppShellServiceWorkerReady()",
+      "norm_label": "waitforposappshellserviceworkerready()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L5"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_validatesession",
-      "label": "validateSession()",
-      "norm_label": "validatesession()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L553"
+      "id": "offlinerouteaccess_spec_waitforrenderedappshell",
+      "label": "waitForRenderedAppShell()",
+      "norm_label": "waitforrenderedappshell()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L194"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "backend_test_validatesessioninventory",
-      "label": "validateSessionInventory()",
-      "norm_label": "validatesessioninventory()",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
-      "source_location": "L593"
+      "id": "offlinerouteaccess_spec_warmcurrentposappshell",
+      "label": "warmCurrentPosAppShell()",
+      "norm_label": "warmcurrentposappshell()",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "source_location": "L77"
     },
     {
       "community": 299,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_backend_test_ts",
-      "label": "backend.test.ts",
-      "norm_label": "backend.test.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/backend.test.ts",
+      "id": "packages_athena_webapp_src_tests_pos_offlinerouteaccess_spec_ts",
+      "label": "offlineRouteAccess.spec.ts",
+      "norm_label": "offlinerouteaccess.spec.ts",
+      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
       "source_location": "L1"
     },
     {
@@ -290265,101 +290241,101 @@
     {
       "community": 300,
       "file_type": "code",
-      "id": "offlinerouteaccess_spec_collectofflineappshelldiagnostics",
-      "label": "collectOfflineAppShellDiagnostics()",
-      "norm_label": "collectofflineappshelldiagnostics()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L167"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_expectnobusinesspayloadscached",
-      "label": "expectNoBusinessPayloadsCached()",
-      "norm_label": "expectnobusinesspayloadscached()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L122"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_expectposregisterroutechunkscached",
-      "label": "expectPosRegisterRouteChunksCached()",
-      "norm_label": "expectposregisterroutechunkscached()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_formatruntimesignals",
-      "label": "formatRuntimeSignals()",
-      "norm_label": "formatruntimesignals()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_getposappshellcachedurls",
-      "label": "getPosAppShellCachedUrls()",
-      "norm_label": "getposappshellcachedurls()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_waitforloadedshellassetscached",
-      "label": "waitForLoadedShellAssetsCached()",
-      "norm_label": "waitforloadedshellassetscached()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_waitforposappshellcache",
-      "label": "waitForPosAppShellCache()",
-      "norm_label": "waitforposappshellcache()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_waitforposappshellserviceworkerready",
-      "label": "waitForPosAppShellServiceWorkerReady()",
-      "norm_label": "waitforposappshellserviceworkerready()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_waitforrenderedappshell",
-      "label": "waitForRenderedAppShell()",
-      "norm_label": "waitforrenderedappshell()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L194"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "offlinerouteaccess_spec_warmcurrentposappshell",
-      "label": "warmCurrentPosAppShell()",
-      "norm_label": "warmcurrentposappshell()",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 300,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_tests_pos_offlinerouteaccess_spec_ts",
-      "label": "offlineRouteAccess.spec.ts",
-      "norm_label": "offlinerouteaccess.spec.ts",
-      "source_file": "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+      "id": "packages_athena_webapp_vitest_setup_ts",
+      "label": "vitest.setup.ts",
+      "norm_label": "vitest.setup.ts",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_build",
+      "label": "build()",
+      "norm_label": "build()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_forward",
+      "label": "forward()",
+      "norm_label": "forward()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_lag",
+      "label": "lag()",
+      "norm_label": "lag()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_pointercapturestub",
+      "label": "pointerCaptureStub()",
+      "norm_label": "pointercapturestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_pointerreleasestub",
+      "label": "pointerReleaseStub()",
+      "norm_label": "pointerreleasestub()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L179"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub",
+      "label": "ResizeObserverStub",
+      "norm_label": "resizeobserverstub",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_disconnect",
+      "label": ".disconnect()",
+      "norm_label": ".disconnect()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L172"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_observe",
+      "label": ".observe()",
+      "norm_label": ".observe()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 300,
+      "file_type": "code",
+      "id": "vitest_setup_resizeobserverstub_unobserve",
+      "label": ".unobserve()",
+      "norm_label": ".unobserve()",
+      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "source_location": "L171"
     },
     {
       "community": 3000,
@@ -290454,101 +290430,101 @@
     {
       "community": 301,
       "file_type": "code",
-      "id": "packages_athena_webapp_vitest_setup_ts",
-      "label": "vitest.setup.ts",
-      "norm_label": "vitest.setup.ts",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
+      "id": "navbarstyles_getbanneranimationdelay",
+      "label": "getBannerAnimationDelay()",
+      "norm_label": "getbanneranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getbannerbgclass",
+      "label": "getBannerBGClass()",
+      "norm_label": "getbannerbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L136"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getbannertextclass",
+      "label": "getBannerTextClass()",
+      "norm_label": "getbannertextclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_gethoverclass",
+      "label": "getHoverClass()",
+      "norm_label": "gethoverclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getmainwrapperclass",
+      "label": "getMainWrapperClass()",
+      "norm_label": "getmainwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbaranimationdelay",
+      "label": "getNavBarAnimationDelay()",
+      "norm_label": "getnavbaranimationdelay()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbarwrapperclass",
+      "label": "getNavBarWrapperClass()",
+      "norm_label": "getnavbarwrapperclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L163"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getnavbgclass",
+      "label": "getNavBGClass()",
+      "norm_label": "getnavbgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L43"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getoverlayclass",
+      "label": "getOverlayClass()",
+      "norm_label": "getoverlayclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L184"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "navbarstyles_getsubmenubgclass",
+      "label": "getSubmenuBGClass()",
+      "norm_label": "getsubmenubgclass()",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "source_location": "L93"
+    },
+    {
+      "community": 301,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
+      "label": "navBarStyles.ts",
+      "norm_label": "navbarstyles.ts",
+      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_build",
-      "label": "build()",
-      "norm_label": "build()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L113"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_forward",
-      "label": "forward()",
-      "norm_label": "forward()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_lag",
-      "label": "lag()",
-      "norm_label": "lag()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_pointercapturestub",
-      "label": "pointerCaptureStub()",
-      "norm_label": "pointercapturestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_pointerreleasestub",
-      "label": "pointerReleaseStub()",
-      "norm_label": "pointerreleasestub()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L179"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub",
-      "label": "ResizeObserverStub",
-      "norm_label": "resizeobserverstub",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L154"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_disconnect",
-      "label": ".disconnect()",
-      "norm_label": ".disconnect()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L172"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_observe",
-      "label": ".observe()",
-      "norm_label": ".observe()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 301,
-      "file_type": "code",
-      "id": "vitest_setup_resizeobserverstub_unobserve",
-      "label": ".unobserve()",
-      "norm_label": ".unobserve()",
-      "source_file": "packages/athena-webapp/vitest.setup.ts",
-      "source_location": "L171"
     },
     {
       "community": 3010,
@@ -290643,100 +290619,100 @@
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getbanneranimationdelay",
-      "label": "getBannerAnimationDelay()",
-      "norm_label": "getbanneranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L152"
+      "id": "delivery_run_telemetry_test_changedpathsforfixture",
+      "label": "changedPathsForFixture()",
+      "norm_label": "changedpathsforfixture()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L900"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getbannerbgclass",
-      "label": "getBannerBGClass()",
-      "norm_label": "getbannerbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L136"
+      "id": "delivery_run_telemetry_test_check",
+      "label": "check()",
+      "norm_label": "check()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L400"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getbannertextclass",
-      "label": "getBannerTextClass()",
-      "norm_label": "getbannertextclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L119"
+      "id": "delivery_run_telemetry_test_createtemproot",
+      "label": "createTempRoot()",
+      "norm_label": "createtemproot()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L34"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_gethoverclass",
-      "label": "getHoverClass()",
-      "norm_label": "gethoverclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L76"
+      "id": "delivery_run_telemetry_test_forbranch",
+      "label": "forBranch()",
+      "norm_label": "forbranch()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L223"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getmainwrapperclass",
-      "label": "getMainWrapperClass()",
-      "norm_label": "getmainwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L28"
+      "id": "delivery_run_telemetry_test_git",
+      "label": "git()",
+      "norm_label": "git()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L665"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getnavbaranimationdelay",
-      "label": "getNavBarAnimationDelay()",
-      "norm_label": "getnavbaranimationdelay()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L174"
+      "id": "delivery_run_telemetry_test_ledger",
+      "label": "ledger()",
+      "norm_label": "ledger()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L46"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getnavbarwrapperclass",
-      "label": "getNavBarWrapperClass()",
-      "norm_label": "getnavbarwrapperclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L163"
+      "id": "delivery_run_telemetry_test_recordafterledger",
+      "label": "recordAfterLedger()",
+      "norm_label": "recordafterledger()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L889"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getnavbgclass",
-      "label": "getNavBGClass()",
-      "norm_label": "getnavbgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L43"
+      "id": "delivery_run_telemetry_test_repofixture",
+      "label": "repoFixture()",
+      "norm_label": "repofixture()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L679"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getoverlayclass",
-      "label": "getOverlayClass()",
-      "norm_label": "getoverlayclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L184"
+      "id": "delivery_run_telemetry_test_shadowcomparisonfixture",
+      "label": "shadowComparisonFixture()",
+      "norm_label": "shadowcomparisonfixture()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L79"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "navbarstyles_getsubmenubgclass",
-      "label": "getSubmenuBGClass()",
-      "norm_label": "getsubmenubgclass()",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
-      "source_location": "L93"
+      "id": "delivery_run_telemetry_test_writeledger",
+      "label": "writeLedger()",
+      "norm_label": "writeledger()",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "source_location": "L692"
     },
     {
       "community": 302,
       "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_navigation_bar_navbarstyles_ts",
-      "label": "navBarStyles.ts",
-      "norm_label": "navbarstyles.ts",
-      "source_file": "packages/storefront-webapp/src/components/navigation-bar/navBarStyles.ts",
+      "id": "scripts_delivery_run_telemetry_test_ts",
+      "label": "delivery-run-telemetry.test.ts",
+      "norm_label": "delivery-run-telemetry.test.ts",
+      "source_file": "scripts/delivery-run-telemetry.test.ts",
       "source_location": "L1"
     },
     {
@@ -290832,100 +290808,100 @@
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_changedpathsforfixture",
-      "label": "changedPathsForFixture()",
-      "norm_label": "changedpathsforfixture()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L900"
+      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
+      "label": "buildAthenaRuntimeUrl()",
+      "norm_label": "buildathenaruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L165"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_check",
-      "label": "check()",
-      "norm_label": "check()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L400"
+      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
+      "label": "buildValkeyRuntimeUrl()",
+      "norm_label": "buildvalkeyruntimeurl()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L181"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_createtemproot",
-      "label": "createTempRoot()",
-      "norm_label": "createtemproot()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L34"
+      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
+      "label": "createAthenaRuntimeProcess()",
+      "norm_label": "createathenaruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L153"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_forbranch",
-      "label": "forBranch()",
-      "norm_label": "forbranch()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L223"
+      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
+      "label": "createStorefrontRuntimeProcesses()",
+      "norm_label": "createstorefrontruntimeprocesses()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L185"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_git",
-      "label": "git()",
-      "norm_label": "git()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L665"
+      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
+      "label": "createValkeyRuntimeProcess()",
+      "norm_label": "createvalkeyruntimeprocess()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L169"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_ledger",
-      "label": "ledger()",
-      "norm_label": "ledger()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L46"
+      "id": "harness_behavior_scenarios_diagnoseathenaqalivesmoke",
+      "label": "diagnoseAthenaQaLiveSmoke()",
+      "norm_label": "diagnoseathenaqalivesmoke()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L326"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_recordafterledger",
-      "label": "recordAfterLedger()",
-      "norm_label": "recordafterledger()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L889"
+      "id": "harness_behavior_scenarios_diagnosestorefrontbackendrequests",
+      "label": "diagnoseStorefrontBackendRequests()",
+      "norm_label": "diagnosestorefrontbackendrequests()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L240"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_repofixture",
-      "label": "repoFixture()",
-      "norm_label": "repofixture()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L679"
+      "id": "harness_behavior_scenarios_formatstorefrontbackenddiagnostic",
+      "label": "formatStorefrontBackendDiagnostic()",
+      "norm_label": "formatstorefrontbackenddiagnostic()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L386"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_shadowcomparisonfixture",
-      "label": "shadowComparisonFixture()",
-      "norm_label": "shadowcomparisonfixture()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L79"
+      "id": "harness_behavior_scenarios_isstorefrontbackendrequest",
+      "label": "isStorefrontBackendRequest()",
+      "norm_label": "isstorefrontbackendrequest()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L229"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "delivery_run_telemetry_test_writeledger",
-      "label": "writeLedger()",
-      "norm_label": "writeledger()",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
-      "source_location": "L692"
+      "id": "harness_behavior_scenarios_stripurlquery",
+      "label": "stripUrlQuery()",
+      "norm_label": "stripurlquery()",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "source_location": "L311"
     },
     {
       "community": 303,
       "file_type": "code",
-      "id": "scripts_delivery_run_telemetry_test_ts",
-      "label": "delivery-run-telemetry.test.ts",
-      "norm_label": "delivery-run-telemetry.test.ts",
-      "source_file": "scripts/delivery-run-telemetry.test.ts",
+      "id": "scripts_harness_behavior_scenarios_ts",
+      "label": "harness-behavior-scenarios.ts",
+      "norm_label": "harness-behavior-scenarios.ts",
+      "source_file": "scripts/harness-behavior-scenarios.ts",
       "source_location": "L1"
     },
     {
@@ -291021,100 +290997,100 @@
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildathenaruntimeurl",
-      "label": "buildAthenaRuntimeUrl()",
-      "norm_label": "buildathenaruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L165"
+      "id": "harness_blocker_inventory_auditharnessblockerinventory",
+      "label": "auditHarnessBlockerInventory()",
+      "norm_label": "auditharnessblockerinventory()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L411"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_buildvalkeyruntimeurl",
-      "label": "buildValkeyRuntimeUrl()",
-      "norm_label": "buildvalkeyruntimeurl()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L181"
+      "id": "harness_blocker_inventory_boundarysource",
+      "label": "boundarySource()",
+      "norm_label": "boundarysource()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L235"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createathenaruntimeprocess",
-      "label": "createAthenaRuntimeProcess()",
-      "norm_label": "createathenaruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L153"
+      "id": "harness_blocker_inventory_collectmatches",
+      "label": "collectMatches()",
+      "norm_label": "collectmatches()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L124"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createstorefrontruntimeprocesses",
-      "label": "createStorefrontRuntimeProcesses()",
-      "norm_label": "createstorefrontruntimeprocesses()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L185"
+      "id": "harness_blocker_inventory_collectremediationliterals",
+      "label": "collectRemediationLiterals()",
+      "norm_label": "collectremediationliterals()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L401"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_createvalkeyruntimeprocess",
-      "label": "createValkeyRuntimeProcess()",
-      "norm_label": "createvalkeyruntimeprocess()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L169"
+      "id": "harness_blocker_inventory_discoverharnessblockerinventory",
+      "label": "discoverHarnessBlockerInventory()",
+      "norm_label": "discoverharnessblockerinventory()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L133"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_diagnoseathenaqalivesmoke",
-      "label": "diagnoseAthenaQaLiveSmoke()",
-      "norm_label": "diagnoseathenaqalivesmoke()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L326"
+      "id": "harness_blocker_inventory_inspectharnessblockershapes",
+      "label": "inspectHarnessBlockerShapes()",
+      "norm_label": "inspectharnessblockershapes()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L318"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_diagnosestorefrontbackendrequests",
-      "label": "diagnoseStorefrontBackendRequests()",
-      "norm_label": "diagnosestorefrontbackendrequests()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "id": "harness_blocker_inventory_inspectharnesscliboundary",
+      "label": "inspectHarnessCliBoundary()",
+      "norm_label": "inspectharnesscliboundary()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
       "source_location": "L240"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_formatstorefrontbackenddiagnostic",
-      "label": "formatStorefrontBackendDiagnostic()",
-      "norm_label": "formatstorefrontbackenddiagnostic()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L386"
+      "id": "harness_blocker_inventory_inspectrendernonzerosuppression",
+      "label": "inspectRenderNonZeroSuppression()",
+      "norm_label": "inspectrendernonzerosuppression()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L366"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_isstorefrontbackendrequest",
-      "label": "isStorefrontBackendRequest()",
-      "norm_label": "isstorefrontbackendrequest()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L229"
+      "id": "harness_blocker_inventory_isregistryownedsource",
+      "label": "isRegistryOwnedSource()",
+      "norm_label": "isregistryownedsource()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L291"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "harness_behavior_scenarios_stripurlquery",
-      "label": "stripUrlQuery()",
-      "norm_label": "stripurlquery()",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
-      "source_location": "L311"
+      "id": "harness_blocker_inventory_normalizescripttarget",
+      "label": "normalizeScriptTarget()",
+      "norm_label": "normalizescripttarget()",
+      "source_file": "scripts/harness-blocker-inventory.ts",
+      "source_location": "L120"
     },
     {
       "community": 304,
       "file_type": "code",
-      "id": "scripts_harness_behavior_scenarios_ts",
-      "label": "harness-behavior-scenarios.ts",
-      "norm_label": "harness-behavior-scenarios.ts",
-      "source_file": "scripts/harness-behavior-scenarios.ts",
+      "id": "scripts_harness_blocker_inventory_ts",
+      "label": "harness-blocker-inventory.ts",
+      "norm_label": "harness-blocker-inventory.ts",
+      "source_file": "scripts/harness-blocker-inventory.ts",
       "source_location": "L1"
     },
     {
@@ -291210,100 +291186,100 @@
     {
       "community": 305,
       "file_type": "code",
-      "id": "harness_blocker_inventory_auditharnessblockerinventory",
-      "label": "auditHarnessBlockerInventory()",
-      "norm_label": "auditharnessblockerinventory()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L411"
+      "id": "pr_athena_delivery_run_test_authoritativeledger",
+      "label": "authoritativeLedger()",
+      "norm_label": "authoritativeledger()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L130"
     },
     {
       "community": 305,
       "file_type": "code",
-      "id": "harness_blocker_inventory_boundarysource",
-      "label": "boundarySource()",
-      "norm_label": "boundarysource()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
+      "id": "pr_athena_delivery_run_test_createdecisioneventfixture",
+      "label": "createDecisionEventFixture()",
+      "norm_label": "createdecisioneventfixture()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L255"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_gateeventharness",
+      "label": "gateEventHarness()",
+      "norm_label": "gateeventharness()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L79"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_gitfixtureenv",
+      "label": "gitFixtureEnv()",
+      "norm_label": "gitfixtureenv()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_ledgerevent",
+      "label": "ledgerEvent()",
+      "norm_label": "ledgerevent()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_persistedevent",
+      "label": "persistedEvent()",
+      "norm_label": "persistedevent()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L177"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_reusableproof",
+      "label": "reusableProof()",
+      "norm_label": "reusableproof()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L111"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_run",
+      "label": "run()",
+      "norm_label": "run()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L1285"
+    },
+    {
+      "community": 305,
+      "file_type": "code",
+      "id": "pr_athena_delivery_run_test_rungit",
+      "label": "runGit()",
+      "norm_label": "rungit()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
       "source_location": "L235"
     },
     {
       "community": 305,
       "file_type": "code",
-      "id": "harness_blocker_inventory_collectmatches",
-      "label": "collectMatches()",
-      "norm_label": "collectmatches()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L124"
+      "id": "pr_athena_delivery_run_test_writedecisionevent",
+      "label": "writeDecisionEvent()",
+      "norm_label": "writedecisionevent()",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "source_location": "L276"
     },
     {
       "community": 305,
       "file_type": "code",
-      "id": "harness_blocker_inventory_collectremediationliterals",
-      "label": "collectRemediationLiterals()",
-      "norm_label": "collectremediationliterals()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L401"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "harness_blocker_inventory_discoverharnessblockerinventory",
-      "label": "discoverHarnessBlockerInventory()",
-      "norm_label": "discoverharnessblockerinventory()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "harness_blocker_inventory_inspectharnessblockershapes",
-      "label": "inspectHarnessBlockerShapes()",
-      "norm_label": "inspectharnessblockershapes()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "harness_blocker_inventory_inspectharnesscliboundary",
-      "label": "inspectHarnessCliBoundary()",
-      "norm_label": "inspectharnesscliboundary()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L240"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "harness_blocker_inventory_inspectrendernonzerosuppression",
-      "label": "inspectRenderNonZeroSuppression()",
-      "norm_label": "inspectrendernonzerosuppression()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L366"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "harness_blocker_inventory_isregistryownedsource",
-      "label": "isRegistryOwnedSource()",
-      "norm_label": "isregistryownedsource()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L291"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "harness_blocker_inventory_normalizescripttarget",
-      "label": "normalizeScriptTarget()",
-      "norm_label": "normalizescripttarget()",
-      "source_file": "scripts/harness-blocker-inventory.ts",
-      "source_location": "L120"
-    },
-    {
-      "community": 305,
-      "file_type": "code",
-      "id": "scripts_harness_blocker_inventory_ts",
-      "label": "harness-blocker-inventory.ts",
-      "norm_label": "harness-blocker-inventory.ts",
-      "source_file": "scripts/harness-blocker-inventory.ts",
+      "id": "scripts_pr_athena_delivery_run_test_ts",
+      "label": "pr-athena-delivery-run.test.ts",
+      "norm_label": "pr-athena-delivery-run.test.ts",
+      "source_file": "scripts/pr-athena-delivery-run.test.ts",
       "source_location": "L1"
     },
     {
@@ -291399,100 +291375,91 @@
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_authoritativeledger",
-      "label": "authoritativeLedger()",
-      "norm_label": "authoritativeledger()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L130"
+      "id": "deploymentstate_cancelactiverunsforprofilewithctx",
+      "label": "cancelActiveRunsForProfileWithCtx()",
+      "norm_label": "cancelactiverunsforprofilewithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L167"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_createdecisioneventfixture",
-      "label": "createDecisionEventFixture()",
-      "norm_label": "createdecisioneventfixture()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L255"
+      "id": "deploymentstate_describedeploymentstatewithctx",
+      "label": "describeDeploymentStateWithCtx()",
+      "norm_label": "describedeploymentstatewithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L254"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_gateeventharness",
-      "label": "gateEventHarness()",
-      "norm_label": "gateeventharness()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L79"
+      "id": "deploymentstate_fencefordeploywithctx",
+      "label": "fenceForDeployWithCtx()",
+      "norm_label": "fencefordeploywithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L213"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_gitfixtureenv",
-      "label": "gitFixtureEnv()",
-      "norm_label": "gitfixtureenv()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L249"
+      "id": "deploymentstate_loadswitch",
+      "label": "loadSwitch()",
+      "norm_label": "loadswitch()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L63"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_ledgerevent",
-      "label": "ledgerEvent()",
-      "norm_label": "ledgerevent()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "id": "deploymentstate_narrower",
+      "label": "narrower()",
+      "norm_label": "narrower()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
       "source_location": "L49"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_persistedevent",
-      "label": "persistedEvent()",
-      "norm_label": "persistedevent()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L177"
+      "id": "deploymentstate_resolvedurableenablementwithctx",
+      "label": "resolveDurableEnablementWithCtx()",
+      "norm_label": "resolvedurableenablementwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L74"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_reusableproof",
-      "label": "reusableProof()",
-      "norm_label": "reusableproof()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L111"
+      "id": "deploymentstate_setcapabilityenablementwithctx",
+      "label": "setCapabilityEnablementWithCtx()",
+      "norm_label": "setcapabilityenablementwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L145"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_run",
-      "label": "run()",
-      "norm_label": "run()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L1285"
+      "id": "deploymentstate_setprofileenablementwithctx",
+      "label": "setProfileEnablementWithCtx()",
+      "norm_label": "setprofileenablementwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L125"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_rungit",
-      "label": "runGit()",
-      "norm_label": "rungit()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L235"
+      "id": "deploymentstate_writeswitch",
+      "label": "writeSwitch()",
+      "norm_label": "writeswitch()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "source_location": "L98"
     },
     {
       "community": 306,
       "file_type": "code",
-      "id": "pr_athena_delivery_run_test_writedecisionevent",
-      "label": "writeDecisionEvent()",
-      "norm_label": "writedecisionevent()",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 306,
-      "file_type": "code",
-      "id": "scripts_pr_athena_delivery_run_test_ts",
-      "label": "pr-athena-delivery-run.test.ts",
-      "norm_label": "pr-athena-delivery-run.test.ts",
-      "source_file": "scripts/pr-athena-delivery-run.test.ts",
+      "id": "packages_athena_webapp_convex_agentharness_deploymentstate_ts",
+      "label": "deploymentState.ts",
+      "norm_label": "deploymentstate.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
       "source_location": "L1"
     },
     {
@@ -291588,91 +291555,91 @@
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_cancelactiverunsforprofilewithctx",
-      "label": "cancelActiveRunsForProfileWithCtx()",
-      "norm_label": "cancelactiverunsforprofilewithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L167"
+      "id": "discovery_asmanifest",
+      "label": "asManifest()",
+      "norm_label": "asmanifest()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L261"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_describedeploymentstatewithctx",
-      "label": "describeDeploymentStateWithCtx()",
-      "norm_label": "describedeploymentstatewithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L254"
+      "id": "discovery_createrundiscoverysurface",
+      "label": "createRunDiscoverySurface()",
+      "norm_label": "createrundiscoverysurface()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L162"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_fencefordeploywithctx",
-      "label": "fenceForDeployWithCtx()",
-      "norm_label": "fencefordeploywithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L213"
+      "id": "discovery_describecapability",
+      "label": "describeCapability()",
+      "norm_label": "describecapability()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L131"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_loadswitch",
-      "label": "loadSwitch()",
-      "norm_label": "loadswitch()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L63"
+      "id": "discovery_discovercapabilities",
+      "label": "discoverCapabilities()",
+      "norm_label": "discovercapabilities()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L96"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_narrower",
-      "label": "narrower()",
-      "norm_label": "narrower()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L49"
+      "id": "discovery_grantedcapabilityids",
+      "label": "grantedCapabilityIds()",
+      "norm_label": "grantedcapabilityids()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L77"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_resolvedurableenablementwithctx",
-      "label": "resolveDurableEnablementWithCtx()",
-      "norm_label": "resolvedurableenablementwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L74"
+      "id": "discovery_projectdeclaration",
+      "label": "projectDeclaration()",
+      "norm_label": "projectdeclaration()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L265"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_setcapabilityenablementwithctx",
-      "label": "setCapabilityEnablementWithCtx()",
-      "norm_label": "setcapabilityenablementwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L145"
+      "id": "discovery_projectrundeclarations",
+      "label": "projectRunDeclarations()",
+      "norm_label": "projectrundeclarations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L110"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_setprofileenablementwithctx",
-      "label": "setProfileEnablementWithCtx()",
-      "norm_label": "setprofileenablementwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L125"
+      "id": "discovery_projectrunfacadeshape",
+      "label": "projectRunFacadeShape()",
+      "norm_label": "projectrunfacadeshape()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L205"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "deploymentstate_writeswitch",
-      "label": "writeSwitch()",
-      "norm_label": "writeswitch()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
-      "source_location": "L98"
+      "id": "discovery_schemasof",
+      "label": "schemasOf()",
+      "norm_label": "schemasof()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "source_location": "L68"
     },
     {
       "community": 307,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_deploymentstate_ts",
-      "label": "deploymentState.ts",
-      "norm_label": "deploymentstate.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/deploymentState.ts",
+      "id": "packages_athena_webapp_convex_agentharness_discovery_ts",
+      "label": "discovery.ts",
+      "norm_label": "discovery.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
       "source_location": "L1"
     },
     {
@@ -291768,91 +291735,91 @@
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_asmanifest",
-      "label": "asManifest()",
-      "norm_label": "asmanifest()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L261"
+      "id": "egresspolicy_covers",
+      "label": "covers()",
+      "norm_label": "covers()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L50"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_createrundiscoverysurface",
-      "label": "createRunDiscoverySurface()",
-      "norm_label": "createrundiscoverysurface()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L162"
+      "id": "egresspolicy_createmodelselectionlock",
+      "label": "createModelSelectionLock()",
+      "norm_label": "createmodelselectionlock()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L100"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_describecapability",
-      "label": "describeCapability()",
-      "norm_label": "describecapability()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "id": "egresspolicy_describeproviderselectionforevidence",
+      "label": "describeProviderSelectionForEvidence()",
+      "norm_label": "describeproviderselectionforevidence()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
       "source_location": "L131"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_discovercapabilities",
-      "label": "discoverCapabilities()",
-      "norm_label": "discovercapabilities()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L96"
+      "id": "egresspolicy_normalizeegressclass",
+      "label": "normalizeEgressClass()",
+      "norm_label": "normalizeegressclass()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L19"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_grantedcapabilityids",
-      "label": "grantedCapabilityIds()",
-      "norm_label": "grantedcapabilityids()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "id": "egresspolicy_permittedfailovers",
+      "label": "permittedFailovers()",
+      "norm_label": "permittedfailovers()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
       "source_location": "L77"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_projectdeclaration",
-      "label": "projectDeclaration()",
-      "norm_label": "projectdeclaration()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L265"
+      "id": "egresspolicy_redactprovidersecrets",
+      "label": "redactProviderSecrets()",
+      "norm_label": "redactprovidersecrets()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L153"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_projectrundeclarations",
-      "label": "projectRunDeclarations()",
-      "norm_label": "projectrundeclarations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L110"
+      "id": "egresspolicy_resolveturnegressclass",
+      "label": "resolveTurnEgressClass()",
+      "norm_label": "resolveturnegressclass()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L32"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_projectrunfacadeshape",
-      "label": "projectRunFacadeShape()",
-      "norm_label": "projectrunfacadeshape()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L205"
+      "id": "egresspolicy_sameselection",
+      "label": "sameSelection()",
+      "norm_label": "sameselection()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L95"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "discovery_schemasof",
-      "label": "schemasOf()",
-      "norm_label": "schemasof()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
-      "source_location": "L68"
+      "id": "egresspolicy_selectproviderforegress",
+      "label": "selectProviderForEgress()",
+      "norm_label": "selectproviderforegress()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "source_location": "L55"
     },
     {
       "community": 308,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_discovery_ts",
-      "label": "discovery.ts",
-      "norm_label": "discovery.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/discovery.ts",
+      "id": "packages_athena_webapp_convex_agentharness_egresspolicy_ts",
+      "label": "egressPolicy.ts",
+      "norm_label": "egresspolicy.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
       "source_location": "L1"
     },
     {
@@ -291948,92 +291915,92 @@
     {
       "community": 309,
       "file_type": "code",
-      "id": "egresspolicy_covers",
-      "label": "covers()",
-      "norm_label": "covers()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_createmodelselectionlock",
-      "label": "createModelSelectionLock()",
-      "norm_label": "createmodelselectionlock()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L100"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_describeproviderselectionforevidence",
-      "label": "describeProviderSelectionForEvidence()",
-      "norm_label": "describeproviderselectionforevidence()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L131"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_normalizeegressclass",
-      "label": "normalizeEgressClass()",
-      "norm_label": "normalizeegressclass()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L19"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_permittedfailovers",
-      "label": "permittedFailovers()",
-      "norm_label": "permittedfailovers()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_redactprovidersecrets",
-      "label": "redactProviderSecrets()",
-      "norm_label": "redactprovidersecrets()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_resolveturnegressclass",
-      "label": "resolveTurnEgressClass()",
-      "norm_label": "resolveturnegressclass()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L32"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_sameselection",
-      "label": "sameSelection()",
-      "norm_label": "sameselection()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "egresspolicy_selectproviderforegress",
-      "label": "selectProviderForEgress()",
-      "norm_label": "selectproviderforegress()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 309,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_egresspolicy_ts",
-      "label": "egressPolicy.ts",
-      "norm_label": "egresspolicy.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/egressPolicy.ts",
+      "id": "packages_athena_webapp_convex_agentharness_turnbindings_ts",
+      "label": "turnBindings.ts",
+      "norm_label": "turnbindings.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_acknowledgeoperatorviewwithctx",
+      "label": "acknowledgeOperatorViewWithCtx()",
+      "norm_label": "acknowledgeoperatorviewwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L411"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_acknowledgeprovisionalviewwithctx",
+      "label": "acknowledgeProvisionalViewWithCtx()",
+      "norm_label": "acknowledgeprovisionalviewwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L453"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_advanceturnbindingwithctx",
+      "label": "advanceTurnBindingWithCtx()",
+      "norm_label": "advanceturnbindingwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L217"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_listturnbindingsforthread",
+      "label": "listTurnBindingsForThread()",
+      "norm_label": "listturnbindingsforthread()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L470"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_markprovisionalreleasewithctx",
+      "label": "markProvisionalReleaseWithCtx()",
+      "norm_label": "markprovisionalreleasewithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L436"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_recordturnintentwithctx",
+      "label": "recordTurnIntentWithCtx()",
+      "norm_label": "recordturnintentwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L110"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_resolveturnwithctx",
+      "label": "resolveTurnWithCtx()",
+      "norm_label": "resolveturnwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L324"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_resumeturnbindingwithctx",
+      "label": "resumeTurnBindingWithCtx()",
+      "norm_label": "resumeturnbindingwithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L356"
+    },
+    {
+      "community": 309,
+      "file_type": "code",
+      "id": "turnbindings_sweepstaleturnbindingswithctx",
+      "label": "sweepStaleTurnBindingsWithCtx()",
+      "norm_label": "sweepstaleturnbindingswithctx()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "source_location": "L510"
     },
     {
       "community": 3090,
@@ -292461,92 +292428,92 @@
     {
       "community": 310,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_turnbindings_ts",
-      "label": "turnBindings.ts",
-      "norm_label": "turnbindings.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
+      "id": "packages_athena_webapp_convex_http_utils_ts",
+      "label": "utils.ts",
+      "norm_label": "utils.ts",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
       "source_location": "L1"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_acknowledgeoperatorviewwithctx",
-      "label": "acknowledgeOperatorViewWithCtx()",
-      "norm_label": "acknowledgeoperatorviewwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L411"
+      "id": "utils_getstoredatafromrequest",
+      "label": "getStoreDataFromRequest()",
+      "norm_label": "getstoredatafromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L15"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_acknowledgeprovisionalviewwithctx",
-      "label": "acknowledgeProvisionalViewWithCtx()",
-      "norm_label": "acknowledgeprovisionalviewwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L453"
+      "id": "utils_getstorefrontactorfromrequest",
+      "label": "getStorefrontActorFromRequest()",
+      "norm_label": "getstorefrontactorfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L171"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_advanceturnbindingwithctx",
-      "label": "advanceTurnBindingWithCtx()",
-      "norm_label": "advanceturnbindingwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L217"
+      "id": "utils_getstorefrontclaimfromrequest",
+      "label": "getStorefrontClaimFromRequest()",
+      "norm_label": "getstorefrontclaimfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L210"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_listturnbindingsforthread",
-      "label": "listTurnBindingsForThread()",
-      "norm_label": "listturnbindingsforthread()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L470"
+      "id": "utils_getstorefrontuserfromrequest",
+      "label": "getStorefrontUserFromRequest()",
+      "norm_label": "getstorefrontuserfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L164"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_markprovisionalreleasewithctx",
-      "label": "markProvisionalReleaseWithCtx()",
-      "norm_label": "markprovisionalreleasewithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L436"
+      "id": "utils_hashguestmarker",
+      "label": "hashGuestMarker()",
+      "norm_label": "hashguestmarker()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L121"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_recordturnintentwithctx",
-      "label": "recordTurnIntentWithCtx()",
-      "norm_label": "recordturnintentwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L110"
+      "id": "utils_isrecoverableguestmarker",
+      "label": "isRecoverableGuestMarker()",
+      "norm_label": "isrecoverableguestmarker()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L107"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_resolveturnwithctx",
-      "label": "resolveTurnWithCtx()",
-      "norm_label": "resolveturnwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L324"
+      "id": "utils_readlegacyunsignedguestcookieforbootstrap",
+      "label": "readLegacyUnsignedGuestCookieForBootstrap()",
+      "norm_label": "readlegacyunsignedguestcookieforbootstrap()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L62"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_resumeturnbindingwithctx",
-      "label": "resumeTurnBindingWithCtx()",
-      "norm_label": "resumeturnbindingwithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L356"
+      "id": "utils_readverifiedguestidfromrequest",
+      "label": "readVerifiedGuestIdFromRequest()",
+      "norm_label": "readverifiedguestidfromrequest()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L35"
     },
     {
       "community": 310,
       "file_type": "code",
-      "id": "turnbindings_sweepstaleturnbindingswithctx",
-      "label": "sweepStaleTurnBindingsWithCtx()",
-      "norm_label": "sweepstaleturnbindingswithctx()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/turnBindings.ts",
-      "source_location": "L510"
+      "id": "utils_setsignedguestcookie",
+      "label": "setSignedGuestCookie()",
+      "norm_label": "setsignedguestcookie()",
+      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "source_location": "L148"
     },
     {
       "community": 3100,
@@ -292641,92 +292608,92 @@
     {
       "community": 311,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_utils_ts",
-      "label": "utils.ts",
-      "norm_label": "utils.ts",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
+      "id": "packages_athena_webapp_convex_intelligence_registry_ts",
+      "label": "registry.ts",
+      "norm_label": "registry.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
       "source_location": "L1"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_getstoredatafromrequest",
-      "label": "getStoreDataFromRequest()",
-      "norm_label": "getstoredatafromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L15"
+      "id": "registry_createathenaprovidererror",
+      "label": "createAthenaProviderError()",
+      "norm_label": "createathenaprovidererror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L21"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_getstorefrontactorfromrequest",
-      "label": "getStorefrontActorFromRequest()",
-      "norm_label": "getstorefrontactorfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L171"
+      "id": "registry_createathenaproviderregistry",
+      "label": "createAthenaProviderRegistry()",
+      "norm_label": "createathenaproviderregistry()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L82"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_getstorefrontclaimfromrequest",
-      "label": "getStorefrontClaimFromRequest()",
-      "norm_label": "getstorefrontclaimfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L210"
+      "id": "registry_createproviderfailureresult",
+      "label": "createProviderFailureResult()",
+      "norm_label": "createproviderfailureresult()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L47"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_getstorefrontuserfromrequest",
-      "label": "getStorefrontUserFromRequest()",
-      "norm_label": "getstorefrontuserfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L164"
+      "id": "registry_getproviderfailurediagnostic",
+      "label": "getProviderFailureDiagnostic()",
+      "norm_label": "getproviderfailurediagnostic()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L177"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_hashguestmarker",
-      "label": "hashGuestMarker()",
-      "norm_label": "hashguestmarker()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L121"
+      "id": "registry_invokestructuredtextprovider",
+      "label": "invokeStructuredTextProvider()",
+      "norm_label": "invokestructuredtextprovider()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L103"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_isrecoverableguestmarker",
-      "label": "isRecoverableGuestMarker()",
-      "norm_label": "isrecoverableguestmarker()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L107"
+      "id": "registry_isjsonobject",
+      "label": "isJsonObject()",
+      "norm_label": "isjsonobject()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L190"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_readlegacyunsignedguestcookieforbootstrap",
-      "label": "readLegacyUnsignedGuestCookieForBootstrap()",
-      "norm_label": "readlegacyunsignedguestcookieforbootstrap()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L62"
+      "id": "registry_isjsonvalue",
+      "label": "isJsonValue()",
+      "norm_label": "isjsonvalue()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L198"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_readverifiedguestidfromrequest",
-      "label": "readVerifiedGuestIdFromRequest()",
-      "norm_label": "readverifiedguestidfromrequest()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L35"
+      "id": "registry_listathenaproviderdescriptors",
+      "label": "listAthenaProviderDescriptors()",
+      "norm_label": "listathenaproviderdescriptors()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L97"
     },
     {
       "community": 311,
       "file_type": "code",
-      "id": "utils_setsignedguestcookie",
-      "label": "setSignedGuestCookie()",
-      "norm_label": "setsignedguestcookie()",
-      "source_file": "packages/athena-webapp/convex/http/utils.ts",
-      "source_location": "L148"
+      "id": "registry_sanitizediagnostic",
+      "label": "sanitizeDiagnostic()",
+      "norm_label": "sanitizediagnostic()",
+      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "source_location": "L183"
     },
     {
       "community": 3110,
@@ -292821,92 +292788,92 @@
     {
       "community": 312,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_registry_ts",
-      "label": "registry.ts",
-      "norm_label": "registry.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
+      "label": "resultTypes.ts",
+      "norm_label": "resulttypes.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L1"
     },
     {
       "community": 312,
       "file_type": "code",
-      "id": "registry_createathenaprovidererror",
-      "label": "createAthenaProviderError()",
-      "norm_label": "createathenaprovidererror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
+      "id": "resulttypes_error",
+      "label": "error()",
+      "norm_label": "error()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L28"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_expenseitemsuccess",
+      "label": "expenseItemSuccess()",
+      "norm_label": "expenseitemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_expensesessionsuccess",
+      "label": "expenseSessionSuccess()",
+      "norm_label": "expensesessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_iserror",
+      "label": "isError()",
+      "norm_label": "iserror()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L176"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_issuccess",
+      "label": "isSuccess()",
+      "norm_label": "issuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L167"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_itemsuccess",
+      "label": "itemSuccess()",
+      "norm_label": "itemsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L140"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_operationsuccess",
+      "label": "operationSuccess()",
+      "norm_label": "operationsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L150"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_sessionsuccess",
+      "label": "sessionSuccess()",
+      "norm_label": "sessionsuccess()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "source_location": "L157"
+    },
+    {
+      "community": 312,
+      "file_type": "code",
+      "id": "resulttypes_success",
+      "label": "success()",
+      "norm_label": "success()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
       "source_location": "L21"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_createathenaproviderregistry",
-      "label": "createAthenaProviderRegistry()",
-      "norm_label": "createathenaproviderregistry()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_createproviderfailureresult",
-      "label": "createProviderFailureResult()",
-      "norm_label": "createproviderfailureresult()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L47"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_getproviderfailurediagnostic",
-      "label": "getProviderFailureDiagnostic()",
-      "norm_label": "getproviderfailurediagnostic()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L177"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_invokestructuredtextprovider",
-      "label": "invokeStructuredTextProvider()",
-      "norm_label": "invokestructuredtextprovider()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_isjsonobject",
-      "label": "isJsonObject()",
-      "norm_label": "isjsonobject()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L190"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_isjsonvalue",
-      "label": "isJsonValue()",
-      "norm_label": "isjsonvalue()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L198"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_listathenaproviderdescriptors",
-      "label": "listAthenaProviderDescriptors()",
-      "norm_label": "listathenaproviderdescriptors()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L97"
-    },
-    {
-      "community": 312,
-      "file_type": "code",
-      "id": "registry_sanitizediagnostic",
-      "label": "sanitizeDiagnostic()",
-      "norm_label": "sanitizediagnostic()",
-      "source_file": "packages/athena-webapp/convex/intelligence/registry.ts",
-      "source_location": "L183"
     },
     {
       "community": 3120,
@@ -293001,92 +292968,92 @@
     {
       "community": 313,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_resulttypes_ts",
-      "label": "resultTypes.ts",
-      "norm_label": "resulttypes.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
+      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
+      "label": "sessionValidation.ts",
+      "norm_label": "sessionvalidation.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
       "source_location": "L1"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_error",
-      "label": "error()",
-      "norm_label": "error()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L28"
+      "id": "sessionvalidation_isvalidemail",
+      "label": "isValidEmail()",
+      "norm_label": "isvalidemail()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L301"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_expenseitemsuccess",
-      "label": "expenseItemSuccess()",
-      "norm_label": "expenseitemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L276"
+      "id": "sessionvalidation_validatecartitems",
+      "label": "validateCartItems()",
+      "norm_label": "validatecartitems()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L189"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_expensesessionsuccess",
-      "label": "expenseSessionSuccess()",
-      "norm_label": "expensesessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L286"
+      "id": "sessionvalidation_validatecustomerinfo",
+      "label": "validateCustomerInfo()",
+      "norm_label": "validatecustomerinfo()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L273"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_iserror",
-      "label": "isError()",
-      "norm_label": "iserror()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L176"
+      "id": "sessionvalidation_validateitembelongstosession",
+      "label": "validateItemBelongsToSession()",
+      "norm_label": "validateitembelongstosession()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L246"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_issuccess",
-      "label": "isSuccess()",
-      "norm_label": "issuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L167"
+      "id": "sessionvalidation_validatepaymentdetails",
+      "label": "validatePaymentDetails()",
+      "norm_label": "validatepaymentdetails()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L309"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_itemsuccess",
-      "label": "itemSuccess()",
-      "norm_label": "itemsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L140"
+      "id": "sessionvalidation_validatesessionactive",
+      "label": "validateSessionActive()",
+      "norm_label": "validatesessionactive()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L39"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_operationsuccess",
-      "label": "operationSuccess()",
-      "norm_label": "operationsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L150"
+      "id": "sessionvalidation_validatesessionexists",
+      "label": "validateSessionExists()",
+      "norm_label": "validatesessionexists()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L19"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_sessionsuccess",
-      "label": "sessionSuccess()",
-      "norm_label": "sessionsuccess()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L157"
+      "id": "sessionvalidation_validatesessionmodifiable",
+      "label": "validateSessionModifiable()",
+      "norm_label": "validatesessionmodifiable()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L93"
     },
     {
       "community": 313,
       "file_type": "code",
-      "id": "resulttypes_success",
-      "label": "success()",
-      "norm_label": "success()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/resultTypes.ts",
-      "source_location": "L21"
+      "id": "sessionvalidation_validatesessionownership",
+      "label": "validateSessionOwnership()",
+      "norm_label": "validatesessionownership()",
+      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "source_location": "L138"
     },
     {
       "community": 3130,
@@ -293181,92 +293148,92 @@
     {
       "community": 314,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_helpers_sessionvalidation_ts",
-      "label": "sessionValidation.ts",
-      "norm_label": "sessionvalidation.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
+      "id": "packages_athena_webapp_convex_inventory_storeschedule_test_ts",
+      "label": "storeSchedule.test.ts",
+      "norm_label": "storeschedule.test.ts",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
       "source_location": "L1"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_isvalidemail",
-      "label": "isValidEmail()",
-      "norm_label": "isvalidemail()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L301"
+      "id": "storeschedule_test_baseschedule",
+      "label": "baseSchedule()",
+      "norm_label": "baseschedule()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L37"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatecartitems",
-      "label": "validateCartItems()",
-      "norm_label": "validatecartitems()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L189"
+      "id": "storeschedule_test_createbackfillctx",
+      "label": "createBackfillCtx()",
+      "norm_label": "createbackfillctx()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L1004"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatecustomerinfo",
-      "label": "validateCustomerInfo()",
-      "norm_label": "validatecustomerinfo()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L273"
+      "id": "storeschedule_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L668"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validateitembelongstosession",
-      "label": "validateItemBelongsToSession()",
-      "norm_label": "validateitembelongstosession()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L246"
+      "id": "storeschedule_test_insertversion",
+      "label": "insertVersion()",
+      "norm_label": "insertversion()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L620"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatepaymentdetails",
-      "label": "validatePaymentDetails()",
-      "norm_label": "validatepaymentdetails()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L309"
+      "id": "storeschedule_test_listversions",
+      "label": "listVersions()",
+      "norm_label": "listversions()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L662"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatesessionactive",
-      "label": "validateSessionActive()",
-      "norm_label": "validatesessionactive()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L39"
+      "id": "storeschedule_test_policy",
+      "label": "policy()",
+      "norm_label": "policy()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L986"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatesessionexists",
-      "label": "validateSessionExists()",
-      "norm_label": "validatesessionexists()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L19"
+      "id": "storeschedule_test_readprojectfile",
+      "label": "readProjectFile()",
+      "norm_label": "readprojectfile()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L34"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatesessionmodifiable",
-      "label": "validateSessionModifiable()",
-      "norm_label": "validatesessionmodifiable()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L93"
+      "id": "storeschedule_test_resolveat",
+      "label": "resolveAt()",
+      "norm_label": "resolveat()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L653"
     },
     {
       "community": 314,
       "file_type": "code",
-      "id": "sessionvalidation_validatesessionownership",
-      "label": "validateSessionOwnership()",
-      "norm_label": "validatesessionownership()",
-      "source_file": "packages/athena-webapp/convex/inventory/helpers/sessionValidation.ts",
-      "source_location": "L138"
+      "id": "storeschedule_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "source_location": "L599"
     },
     {
       "community": 3140,
@@ -293361,92 +293328,92 @@
     {
       "community": 315,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_inventory_storeschedule_test_ts",
-      "label": "storeSchedule.test.ts",
-      "norm_label": "storeschedule.test.ts",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_baseschedule",
-      "label": "baseSchedule()",
-      "norm_label": "baseschedule()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L37"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_createbackfillctx",
-      "label": "createBackfillCtx()",
-      "norm_label": "createbackfillctx()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L1004"
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L668"
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_insertversion",
-      "label": "insertVersion()",
-      "norm_label": "insertversion()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L620"
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_listversions",
-      "label": "listVersions()",
-      "norm_label": "listversions()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L662"
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_policy",
-      "label": "policy()",
-      "norm_label": "policy()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L986"
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_readprojectfile",
-      "label": "readProjectFile()",
-      "norm_label": "readprojectfile()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L34"
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_resolveat",
-      "label": "resolveAt()",
-      "norm_label": "resolveat()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L653"
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
     },
     {
       "community": 315,
       "file_type": "code",
-      "id": "storeschedule_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/inventory/storeSchedule.test.ts",
-      "source_location": "L599"
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L95"
     },
     {
       "community": 3150,
@@ -293541,91 +293508,91 @@
     {
       "community": 316,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_domains_storefrontoperator_readdefinitions_ts",
+      "label": "storefrontOperator_readDefinitions.ts",
+      "norm_label": "storefrontoperator_readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
       "source_location": "L1"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
+      "id": "storefrontoperator_readdefinitions_analyticsread",
+      "label": "analyticsRead()",
+      "norm_label": "analyticsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L121"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
+      "id": "storefrontoperator_readdefinitions_checkoutsessionorderscope",
+      "label": "checkoutSessionOrderScope()",
+      "norm_label": "checkoutsessionorderscope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L70"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
+      "id": "storefrontoperator_readdefinitions_externalreferenceorderscope",
+      "label": "externalReferenceOrderScope()",
+      "norm_label": "externalreferenceorderscope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L80"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
+      "id": "storefrontoperator_readdefinitions_idarg",
+      "label": "idArg()",
+      "norm_label": "idarg()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L34"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
+      "id": "storefrontoperator_readdefinitions_onlineorderread",
+      "label": "onlineOrderRead()",
+      "norm_label": "onlineorderread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L202"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
+      "id": "storefrontoperator_readdefinitions_reviewread",
+      "label": "reviewRead()",
+      "norm_label": "reviewread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L263"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
+      "id": "storefrontoperator_readdefinitions_rowstorescope",
+      "label": "rowStoreScope()",
+      "norm_label": "rowstorescope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L40"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
+      "id": "storefrontoperator_readdefinitions_storefrontactorstorescope",
+      "label": "storeFrontActorStoreScope()",
+      "norm_label": "storefrontactorstorescope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L52"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "storefrontoperator_readdefinitions_storefrontread",
+      "label": "storeFrontRead()",
+      "norm_label": "storefrontread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
       "source_location": "L95"
     },
     {
@@ -293712,96 +293679,6 @@
     {
       "community": 317,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_domains_storefrontoperator_readdefinitions_ts",
-      "label": "storefrontOperator_readDefinitions.ts",
-      "norm_label": "storefrontoperator_readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_analyticsread",
-      "label": "analyticsRead()",
-      "norm_label": "analyticsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L121"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_checkoutsessionorderscope",
-      "label": "checkoutSessionOrderScope()",
-      "norm_label": "checkoutsessionorderscope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L70"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_externalreferenceorderscope",
-      "label": "externalReferenceOrderScope()",
-      "norm_label": "externalreferenceorderscope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L80"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_idarg",
-      "label": "idArg()",
-      "norm_label": "idarg()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_onlineorderread",
-      "label": "onlineOrderRead()",
-      "norm_label": "onlineorderread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L202"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_reviewread",
-      "label": "reviewRead()",
-      "norm_label": "reviewread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L263"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_rowstorescope",
-      "label": "rowStoreScope()",
-      "norm_label": "rowstorescope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_storefrontactorstorescope",
-      "label": "storeFrontActorStoreScope()",
-      "norm_label": "storefrontactorstorescope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 317,
-      "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_storefrontread",
-      "label": "storeFrontRead()",
-      "norm_label": "storefrontread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
       "id": "adjustmentreports_adjustmentappliedat",
       "label": "adjustmentAppliedAt()",
       "norm_label": "adjustmentappliedat()",
@@ -293809,7 +293686,7 @@
       "source_location": "L101"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_adjustmentsalesdelta",
       "label": "adjustmentSalesDelta()",
@@ -293818,7 +293695,7 @@
       "source_location": "L116"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_adjustmentsettlementamount",
       "label": "adjustmentSettlementAmount()",
@@ -293827,7 +293704,7 @@
       "source_location": "L143"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_adjustmenttransactionid",
       "label": "adjustmentTransactionId()",
@@ -293836,7 +293713,7 @@
       "source_location": "L110"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_buildadjustmentpaymenttotals",
       "label": "buildAdjustmentPaymentTotals()",
@@ -293845,7 +293722,7 @@
       "source_location": "L242"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_buildadjustmentreporttotals",
       "label": "buildAdjustmentReportTotals()",
@@ -293854,7 +293731,7 @@
       "source_location": "L275"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
       "label": "listAppliedTransactionAdjustmentsForDay()",
@@ -293863,7 +293740,7 @@
       "source_location": "L229"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
       "label": "readAppliedTransactionAdjustmentsForDay()",
@@ -293872,7 +293749,7 @@
       "source_location": "L173"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "adjustmentreports_sourcecompletenessentry",
       "label": "sourceCompletenessEntry()",
@@ -293881,7 +293758,7 @@
       "source_location": "L76"
     },
     {
-      "community": 318,
+      "community": 317,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
       "label": "adjustmentReports.ts",
@@ -293890,7 +293767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_assertnobusinesseventconflict",
       "label": "assertNoBusinessEventConflict()",
@@ -293899,7 +293776,7 @@
       "source_location": "L178"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_buildinventorymovement",
       "label": "buildInventoryMovement()",
@@ -293908,7 +293785,7 @@
       "source_location": "L124"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_buildskuactivityforinventorymovement",
       "label": "buildSkuActivityForInventoryMovement()",
@@ -293917,7 +293794,7 @@
       "source_location": "L66"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_getskuactivitytypeformovement",
       "label": "getSkuActivityTypeForMovement()",
@@ -293926,7 +293803,7 @@
       "source_location": "L49"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_matchesexistingmovement",
       "label": "matchesExistingMovement()",
@@ -293935,7 +293812,7 @@
       "source_location": "L150"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_recordinventorymovementwithctx",
       "label": "recordInventoryMovementWithCtx()",
@@ -293944,7 +293821,7 @@
       "source_location": "L200"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
       "label": "recordInventoryMovementWithDispositionWithCtx()",
@@ -293953,7 +293830,7 @@
       "source_location": "L245"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
       "label": "recordSkuActivityForInventoryMovementWithCtx()",
@@ -293962,7 +293839,7 @@
       "source_location": "L111"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "inventorymovements_summarizeinventorymovements",
       "label": "summarizeInventoryMovements()",
@@ -293971,12 +293848,102 @@
       "source_location": "L135"
     },
     {
-      "community": 319,
+      "community": 318,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
       "label": "inventoryMovements.ts",
       "norm_label": "inventorymovements.ts",
       "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L430"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L160"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L231"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L249"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L37"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L472"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L153"
+    },
+    {
+      "community": 319,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
     },
     {
@@ -294315,96 +294282,6 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L430"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L160"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L231"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L249"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L37"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L472"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 320,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
       "label": "registerSessionTracing.ts",
       "norm_label": "registersessiontracing.ts",
@@ -294412,7 +294289,7 @@
       "source_location": "L1"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_buildactorrefs",
       "label": "buildActorRefs()",
@@ -294421,7 +294298,7 @@
       "source_location": "L102"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_buildtraceevent",
       "label": "buildTraceEvent()",
@@ -294430,7 +294307,7 @@
       "source_location": "L197"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_buildtracerecord",
       "label": "buildTraceRecord()",
@@ -294439,7 +294316,7 @@
       "source_location": "L162"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_displaytraceamount",
       "label": "displayTraceAmount()",
@@ -294448,7 +294325,7 @@
       "source_location": "L115"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_formattransactionlabel",
       "label": "formatTransactionLabel()",
@@ -294457,7 +294334,7 @@
       "source_location": "L133"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_recordregistersessiontracebesteffort",
       "label": "recordRegisterSessionTraceBestEffort()",
@@ -294466,7 +294343,7 @@
       "source_location": "L415"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_resolveoccurredat",
       "label": "resolveOccurredAt()",
@@ -294475,7 +294352,7 @@
       "source_location": "L77"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_resolvestorecurrency",
       "label": "resolveStoreCurrency()",
@@ -294484,7 +294361,7 @@
       "source_location": "L147"
     },
     {
-      "community": 321,
+      "community": 320,
       "file_type": "code",
       "id": "registersessiontracing_safetracewrite",
       "label": "safeTraceWrite()",
@@ -294493,7 +294370,7 @@
       "source_location": "L93"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
       "label": "classifyFinalizedLineageRepairConflicts()",
@@ -294502,7 +294379,7 @@
       "source_location": "L222"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_classifyrepaircandidate",
       "label": "classifyRepairCandidate()",
@@ -294511,7 +294388,7 @@
       "source_location": "L164"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
       "label": "countRepairableFinalizedLineageLines()",
@@ -294520,7 +294397,7 @@
       "source_location": "L284"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_getprovisionalimportsku",
       "label": "getProvisionalImportSku()",
@@ -294529,7 +294406,7 @@
       "source_location": "L318"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
       "label": "isClosedRegisterRepairReplayConflict()",
@@ -294538,7 +294415,7 @@
       "source_location": "L273"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
       "label": "isFinalizedLineageRepairConflict()",
@@ -294547,7 +294424,7 @@
       "source_location": "L258"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
       "label": "isProvisionalRowChangedConflict()",
@@ -294556,7 +294433,7 @@
       "source_location": "L265"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
       "label": "recordFinalizedLineageRepairEvent()",
@@ -294565,7 +294442,7 @@
       "source_location": "L358"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "finalizedlineageremediation_skipped",
       "label": "skipped()",
@@ -294574,7 +294451,7 @@
       "source_location": "L346"
     },
     {
-      "community": 322,
+      "community": 321,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
       "label": "finalizedLineageRemediation.ts",
@@ -294583,7 +294460,7 @@
       "source_location": "L1"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_day",
       "label": "day()",
@@ -294592,7 +294469,7 @@
       "source_location": "L1308"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_fieldsof",
       "label": "fieldsOf()",
@@ -294601,7 +294478,7 @@
       "source_location": "L86"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_headerfor",
       "label": "headerFor()",
@@ -294610,7 +294487,7 @@
       "source_location": "L972"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_inclusivedays",
       "label": "inclusiveDays()",
@@ -294619,7 +294496,7 @@
       "source_location": "L1216"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_movementidentityargs",
       "label": "movementIdentityArgs()",
@@ -294628,7 +294505,7 @@
       "source_location": "L602"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_probe",
       "label": "probe()",
@@ -294637,7 +294514,7 @@
       "source_location": "L1312"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_seedproductsku",
       "label": "seedProductSku()",
@@ -294646,7 +294523,7 @@
       "source_location": "L561"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_seedstore",
       "label": "seedStore()",
@@ -294655,7 +294532,7 @@
       "source_location": "L542"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "contract_test_unionliterals",
       "label": "unionLiterals()",
@@ -294664,7 +294541,7 @@
       "source_location": "L92"
     },
     {
-      "community": 323,
+      "community": 322,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_contract_test_ts",
       "label": "contract.test.ts",
@@ -294673,7 +294550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_aggregateskudays",
       "label": "aggregateSkuDays()",
@@ -294682,7 +294559,7 @@
       "source_location": "L226"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_computerange",
       "label": "computeRange()",
@@ -294691,7 +294568,7 @@
       "source_location": "L262"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_computerequestkey",
       "label": "computeRequestKey()",
@@ -294700,7 +294577,7 @@
       "source_location": "L87"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_inclusivedayspan",
       "label": "inclusiveDaySpan()",
@@ -294709,7 +294586,7 @@
       "source_location": "L55"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_isvalidoperatingdate",
       "label": "isValidOperatingDate()",
@@ -294718,7 +294595,7 @@
       "source_location": "L38"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_requestrangecore",
       "label": "requestRangeCore()",
@@ -294727,7 +294604,7 @@
       "source_location": "L115"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_sumdays",
       "label": "sumDays()",
@@ -294736,7 +294613,7 @@
       "source_location": "L198"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_utcmillisforlabel",
       "label": "utcMillisForLabel()",
@@ -294745,7 +294622,7 @@
       "source_location": "L49"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "customrange_validaterangeargs",
       "label": "validateRangeArgs()",
@@ -294754,12 +294631,102 @@
       "source_location": "L61"
     },
     {
-      "community": 324,
+      "community": 323,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_customrange_ts",
       "label": "customRange.ts",
       "norm_label": "customrange.ts",
       "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_anchordate",
+      "label": "anchorDate()",
+      "norm_label": "anchordate()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L156"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_buildoverviewdata",
+      "label": "buildOverviewData()",
+      "norm_label": "buildoverviewdata()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L166"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_comparisonbp",
+      "label": "comparisonBp()",
+      "norm_label": "comparisonbp()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L122"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_emptysnapshot",
+      "label": "emptySnapshot()",
+      "norm_label": "emptysnapshot()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_isunsettled",
+      "label": "isUnsettled()",
+      "norm_label": "isunsettled()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L67"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_readrecentdays",
+      "label": "readRecentDays()",
+      "norm_label": "readrecentdays()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L303"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_rebuildstoreoverview",
+      "label": "rebuildStoreOverview()",
+      "norm_label": "rebuildstoreoverview()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L317"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_snapshotfordays",
+      "label": "snapshotForDays()",
+      "norm_label": "snapshotfordays()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "overview_trustsummaryfordays",
+      "label": "trustSummaryForDays()",
+      "norm_label": "trustsummaryfordays()",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 324,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_overview_ts",
+      "label": "overview.ts",
+      "norm_label": "overview.ts",
+      "source_file": "packages/athena-webapp/convex/reports/overview.ts",
       "source_location": "L1"
     },
     {
@@ -302766,87 +302733,6 @@
     {
       "community": 394,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_productutils_ts",
-      "label": "productUtils.ts",
-      "norm_label": "productutils.ts",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_getpreferredsku",
-      "label": "getPreferredSku()",
-      "norm_label": "getpreferredsku()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_getproductname",
-      "label": "getProductName()",
-      "norm_label": "getproductname()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L18"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_haslowstock",
-      "label": "hasLowStock()",
-      "norm_label": "haslowstock()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_issoldout",
-      "label": "isSoldOut()",
-      "norm_label": "issoldout()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_sortproduct",
-      "label": "sortProduct()",
-      "norm_label": "sortproduct()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L82"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_sortskusbyavailabilitythenlength",
-      "label": "sortSkusByAvailabilityThenLength()",
-      "norm_label": "sortskusbyavailabilitythenlength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L63"
-    },
-    {
-      "community": 394,
-      "file_type": "code",
-      "id": "productutils_sortskusbylength",
-      "label": "sortSkusByLength()",
-      "norm_label": "sortskusbylength()",
-      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
-      "source_location": "L59"
-    },
-    {
-      "community": 395,
-      "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
       "label": "applyAcceptedControlResult()",
       "norm_label": "applyacceptedcontrolresult()",
@@ -302854,7 +302740,7 @@
       "source_location": "L84"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applykeyevent",
       "label": "applyKeyEvent()",
@@ -302863,7 +302749,7 @@
       "source_location": "L155"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applypointerevent",
       "label": "applyPointerEvent()",
@@ -302872,7 +302758,7 @@
       "source_location": "L116"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
       "label": "applyRemoteAssistControlIntent()",
@@ -302881,7 +302767,7 @@
       "source_location": "L17"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
       "label": "getRecentControlResult()",
@@ -302890,7 +302776,7 @@
       "source_location": "L95"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
       "label": "getRemoteAssistControlTarget()",
@@ -302899,7 +302785,7 @@
       "source_location": "L145"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
       "label": "prepareRemoteAssistControlIntent()",
@@ -302908,7 +302794,7 @@
       "source_location": "L27"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "applyremoteassistcontrolintent_remembercontrolresult",
       "label": "rememberControlResult()",
@@ -302917,7 +302803,7 @@
       "source_location": "L101"
     },
     {
-      "community": 395,
+      "community": 394,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
       "label": "applyRemoteAssistControlIntent.ts",
@@ -302926,7 +302812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
       "label": "posOfflineReadiness.ts",
@@ -302935,7 +302821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_buildposofflinereadinesssummary",
       "label": "buildPosOfflineReadinessSummary()",
@@ -302944,7 +302830,7 @@
       "source_location": "L152"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_buildsignal",
       "label": "buildSignal()",
@@ -302953,7 +302839,7 @@
       "source_location": "L178"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_formatage",
       "label": "formatAge()",
@@ -302962,7 +302848,7 @@
       "source_location": "L290"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_getsignaldescription",
       "label": "getSignalDescription()",
@@ -302971,7 +302857,7 @@
       "source_location": "L221"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_getsignalstatus",
       "label": "getSignalStatus()",
@@ -302980,7 +302866,7 @@
       "source_location": "L201"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarydescription",
       "label": "getSummaryDescription()",
@@ -302989,7 +302875,7 @@
       "source_location": "L262"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_getsummarytitle",
       "label": "getSummaryTitle()",
@@ -302998,7 +302884,7 @@
       "source_location": "L256"
     },
     {
-      "community": 396,
+      "community": 395,
       "file_type": "code",
       "id": "posofflinereadiness_isreadylike",
       "label": "isReadyLike()",
@@ -303007,7 +302893,7 @@
       "source_location": "L286"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_colorrolecard",
       "label": "ColorRoleCard()",
@@ -303016,7 +302902,7 @@
       "source_location": "L222"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_densitycard",
       "label": "DensityCard()",
@@ -303025,7 +302911,7 @@
       "source_location": "L283"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_detailviewrolecard",
       "label": "DetailViewRoleCard()",
@@ -303034,7 +302920,7 @@
       "source_location": "L363"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_hslvar",
       "label": "hslVar()",
@@ -303043,7 +302929,7 @@
       "source_location": "L214"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_motioncard",
       "label": "MotionCard()",
@@ -303052,7 +302938,7 @@
       "source_location": "L342"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_spacetokenrow",
       "label": "SpaceTokenRow()",
@@ -303061,7 +302947,7 @@
       "source_location": "L265"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_textvar",
       "label": "textVar()",
@@ -303070,7 +302956,7 @@
       "source_location": "L218"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "foundations_content_typespecimencard",
       "label": "TypeSpecimenCard()",
@@ -303079,7 +302965,7 @@
       "source_location": "L246"
     },
     {
-      "community": 397,
+      "community": 396,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
       "label": "foundations-content.tsx",
@@ -303088,7 +302974,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "packages_athena_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -303097,7 +302983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
       "label": "versionChecker.ts",
@@ -303106,7 +302992,7 @@
       "source_location": "L1"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_buildidfromscripts",
       "label": "buildIdFromScripts()",
@@ -303115,7 +303001,7 @@
       "source_location": "L192"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_createversionchecker",
       "label": "createVersionChecker()",
@@ -303124,7 +303010,7 @@
       "source_location": "L16"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_getinitialdeploybuildid",
       "label": "getInitialDeployBuildId()",
@@ -303133,7 +303019,7 @@
       "source_location": "L135"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_readdeploybuildid",
       "label": "readDeployBuildId()",
@@ -303142,7 +303028,7 @@
       "source_location": "L141"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_readdocumentscriptsources",
       "label": "readDocumentScriptSources()",
@@ -303151,7 +303037,7 @@
       "source_location": "L174"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_readentryhtmlscripts",
       "label": "readEntryHtmlScripts()",
@@ -303160,13 +303046,94 @@
       "source_location": "L151"
     },
     {
-      "community": 398,
+      "community": 397,
       "file_type": "code",
       "id": "versionchecker_readscriptsources",
       "label": "readScriptSources()",
       "norm_label": "readscriptsources()",
       "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
       "source_location": "L182"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_productutils_ts",
+      "label": "productUtils.ts",
+      "norm_label": "productutils.ts",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_getpreferredsku",
+      "label": "getPreferredSku()",
+      "norm_label": "getpreferredsku()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L78"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_getproductname",
+      "label": "getProductName()",
+      "norm_label": "getproductname()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L18"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_haslowstock",
+      "label": "hasLowStock()",
+      "norm_label": "haslowstock()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_issoldout",
+      "label": "isSoldOut()",
+      "norm_label": "issoldout()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_sortproduct",
+      "label": "sortProduct()",
+      "norm_label": "sortproduct()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L82"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_sortskusbyavailabilitythenlength",
+      "label": "sortSkusByAvailabilityThenLength()",
+      "norm_label": "sortskusbyavailabilitythenlength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L63"
+    },
+    {
+      "community": 398,
+      "file_type": "code",
+      "id": "productutils_sortskusbylength",
+      "label": "sortSkusByLength()",
+      "norm_label": "sortskusbylength()",
+      "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
+      "source_location": "L59"
     },
     {
       "community": 399,
@@ -344679,42 +344646,6 @@
     {
       "community": 888,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
-      "label": "register.test.ts",
-      "norm_label": "register.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "register_test_buildctx",
-      "label": "buildCtx()",
-      "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 888,
-      "file_type": "code",
-      "id": "register_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 889,
-      "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_commands_register_ts",
       "label": "register.ts",
       "norm_label": "register.ts",
@@ -344722,7 +344653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 889,
+      "community": 888,
       "file_type": "code",
       "id": "register_mapopendrawerusererror",
       "label": "mapOpenDrawerUserError()",
@@ -344731,7 +344662,7 @@
       "source_location": "L34"
     },
     {
-      "community": 889,
+      "community": 888,
       "file_type": "code",
       "id": "register_normalizeregisternumber",
       "label": "normalizeRegisterNumber()",
@@ -344740,13 +344671,49 @@
       "source_location": "L29"
     },
     {
-      "community": 889,
+      "community": 888,
       "file_type": "code",
       "id": "register_opendrawer",
       "label": "openDrawer()",
       "norm_label": "opendrawer()",
       "source_file": "packages/athena-webapp/convex/pos/application/commands/register.ts",
       "source_location": "L56"
+    },
+    {
+      "community": 889,
+      "file_type": "code",
+      "id": "opendrawer_test_createdbgetmock",
+      "label": "createDbGetMock()",
+      "norm_label": "createdbgetmock()",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 889,
+      "file_type": "code",
+      "id": "opendrawer_test_createdbmock",
+      "label": "createDbMock()",
+      "norm_label": "createdbmock()",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L99"
+    },
+    {
+      "community": 889,
+      "file_type": "code",
+      "id": "opendrawer_test_createdbquerymock",
+      "label": "createDbQueryMock()",
+      "norm_label": "createdbquerymock()",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L74"
+    },
+    {
+      "community": 889,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
+      "label": "openDrawer.test.ts",
+      "norm_label": "opendrawer.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 89,
@@ -344958,42 +344925,6 @@
     {
       "community": 890,
       "file_type": "code",
-      "id": "opendrawer_test_createdbgetmock",
-      "label": "createDbGetMock()",
-      "norm_label": "createdbgetmock()",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L39"
-    },
-    {
-      "community": 890,
-      "file_type": "code",
-      "id": "opendrawer_test_createdbmock",
-      "label": "createDbMock()",
-      "norm_label": "createdbmock()",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L99"
-    },
-    {
-      "community": 890,
-      "file_type": "code",
-      "id": "opendrawer_test_createdbquerymock",
-      "label": "createDbQueryMock()",
-      "norm_label": "createdbquerymock()",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L74"
-    },
-    {
-      "community": 890,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_opendrawer_test_ts",
-      "label": "openDrawer.test.ts",
-      "norm_label": "opendrawer.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/openDrawer.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 891,
-      "file_type": "code",
       "id": "getregisterstate_buildregisterstate",
       "label": "buildRegisterState()",
       "norm_label": "buildregisterstate()",
@@ -345001,7 +344932,7 @@
       "source_location": "L21"
     },
     {
-      "community": 891,
+      "community": 890,
       "file_type": "code",
       "id": "getregisterstate_getactivesessionconflictforregisterstate",
       "label": "getActiveSessionConflictForRegisterState()",
@@ -345010,7 +344941,7 @@
       "source_location": "L42"
     },
     {
-      "community": 891,
+      "community": 890,
       "file_type": "code",
       "id": "getregisterstate_getregisterstate",
       "label": "getRegisterState()",
@@ -345019,7 +344950,7 @@
       "source_location": "L80"
     },
     {
-      "community": 891,
+      "community": 890,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_getregisterstate_ts",
       "label": "getRegisterState.ts",
@@ -345028,7 +344959,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 891,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_storepulse_test_ts",
       "label": "storePulse.test.ts",
@@ -345037,7 +344968,7 @@
       "source_location": "L1"
     },
     {
-      "community": 892,
+      "community": 891,
       "file_type": "code",
       "id": "storepulse_test_createdb",
       "label": "createDb()",
@@ -345046,7 +344977,7 @@
       "source_location": "L12"
     },
     {
-      "community": 892,
+      "community": 891,
       "file_type": "code",
       "id": "storepulse_test_item",
       "label": "item()",
@@ -345055,7 +344986,7 @@
       "source_location": "L127"
     },
     {
-      "community": 892,
+      "community": 891,
       "file_type": "code",
       "id": "storepulse_test_transaction",
       "label": "transaction()",
@@ -345064,7 +344995,7 @@
       "source_location": "L99"
     },
     {
-      "community": 893,
+      "community": 892,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_posregistersessionactivity_test_ts",
       "label": "posRegisterSessionActivity.test.ts",
@@ -345073,7 +345004,7 @@
       "source_location": "L1"
     },
     {
-      "community": 893,
+      "community": 892,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildactivity",
       "label": "buildActivity()",
@@ -345082,7 +345013,7 @@
       "source_location": "L457"
     },
     {
-      "community": 893,
+      "community": 892,
       "file_type": "code",
       "id": "posregistersessionactivity_test_buildreport",
       "label": "buildReport()",
@@ -345091,7 +345022,7 @@
       "source_location": "L436"
     },
     {
-      "community": 893,
+      "community": 892,
       "file_type": "code",
       "id": "posregistersessionactivity_test_createfakerepository",
       "label": "createFakeRepository()",
@@ -345100,7 +345031,7 @@
       "source_location": "L476"
     },
     {
-      "community": 894,
+      "community": 893,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_registercatalogrevision_ts",
       "label": "registerCatalogRevision.ts",
@@ -345109,7 +345040,7 @@
       "source_location": "L1"
     },
     {
-      "community": 894,
+      "community": 893,
       "file_type": "code",
       "id": "registercatalogrevision_advanceregistercatalogrevision",
       "label": "advanceRegisterCatalogRevision()",
@@ -345118,7 +345049,7 @@
       "source_location": "L24"
     },
     {
-      "community": 894,
+      "community": 893,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevision",
       "label": "readRegisterCatalogRevision()",
@@ -345127,7 +345058,7 @@
       "source_location": "L16"
     },
     {
-      "community": 894,
+      "community": 893,
       "file_type": "code",
       "id": "registercatalogrevision_readregistercatalogrevisionrow",
       "label": "readRegisterCatalogRevisionRow()",
@@ -345136,7 +345067,7 @@
       "source_location": "L6"
     },
     {
-      "community": 895,
+      "community": 894,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_sequencegappolicy_ts",
       "label": "sequenceGapPolicy.ts",
@@ -345145,7 +345076,7 @@
       "source_location": "L1"
     },
     {
-      "community": 895,
+      "community": 894,
       "file_type": "code",
       "id": "sequencegappolicy_decidesequencegapaction",
       "label": "decideSequenceGapAction()",
@@ -345154,7 +345085,7 @@
       "source_location": "L115"
     },
     {
-      "community": 895,
+      "community": 894,
       "file_type": "code",
       "id": "sequencegappolicy_issequencegapresolved",
       "label": "isSequenceGapResolved()",
@@ -345163,7 +345094,7 @@
       "source_location": "L219"
     },
     {
-      "community": 895,
+      "community": 894,
       "file_type": "code",
       "id": "sequencegappolicy_recordsequencegapobservation",
       "label": "recordSequenceGapObservation()",
@@ -345172,7 +345103,7 @@
       "source_location": "L190"
     },
     {
-      "community": 896,
+      "community": 895,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_sync_staffproof_ts",
       "label": "staffProof.ts",
@@ -345181,7 +345112,7 @@
       "source_location": "L1"
     },
     {
-      "community": 896,
+      "community": 895,
       "file_type": "code",
       "id": "staffproof_createposlocalstaffprooftoken",
       "label": "createPosLocalStaffProofToken()",
@@ -345190,7 +345121,7 @@
       "source_location": "L10"
     },
     {
-      "community": 896,
+      "community": 895,
       "file_type": "code",
       "id": "staffproof_hashposlocalstaffprooftoken",
       "label": "hashPosLocalStaffProofToken()",
@@ -345199,7 +345130,7 @@
       "source_location": "L16"
     },
     {
-      "community": 896,
+      "community": 895,
       "file_type": "code",
       "id": "staffproof_tohex",
       "label": "toHex()",
@@ -345208,7 +345139,7 @@
       "source_location": "L4"
     },
     {
-      "community": 897,
+      "community": 896,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildconflict",
       "label": "buildConflict()",
@@ -345217,7 +345148,7 @@
       "source_location": "L613"
     },
     {
-      "community": 897,
+      "community": 896,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_buildevent",
       "label": "buildEvent()",
@@ -345226,7 +345157,7 @@
       "source_location": "L633"
     },
     {
-      "community": 897,
+      "community": 896,
       "file_type": "code",
       "id": "cloudrepairpolicy_test_createrepairprojectionrepository",
       "label": "createRepairProjectionRepository()",
@@ -345235,7 +345166,7 @@
       "source_location": "L484"
     },
     {
-      "community": 897,
+      "community": 896,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_cloudrepairpolicy_test_ts",
       "label": "cloudRepairPolicy.test.ts",
@@ -345244,7 +345175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 897,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_terminalrecovery_terminalcommandservice_test_ts",
       "label": "terminalCommandService.test.ts",
@@ -345253,7 +345184,7 @@
       "source_location": "L1"
     },
     {
-      "community": 898,
+      "community": 897,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildcommand",
       "label": "buildCommand()",
@@ -345262,7 +345193,7 @@
       "source_location": "L1731"
     },
     {
-      "community": 898,
+      "community": 897,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildrepository",
       "label": "buildRepository()",
@@ -345271,7 +345202,7 @@
       "source_location": "L1666"
     },
     {
-      "community": 898,
+      "community": 897,
       "file_type": "code",
       "id": "terminalcommandservice_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -345280,7 +345211,7 @@
       "source_location": "L1755"
     },
     {
-      "community": 899,
+      "community": 898,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_sessioncommandrepository_ts",
       "label": "sessionCommandRepository.ts",
@@ -345289,7 +345220,7 @@
       "source_location": "L1"
     },
     {
-      "community": 899,
+      "community": 898,
       "file_type": "code",
       "id": "sessioncommandrepository_collectsessionitemsfrompages",
       "label": "collectSessionItemsFromPages()",
@@ -345298,7 +345229,7 @@
       "source_location": "L177"
     },
     {
-      "community": 899,
+      "community": 898,
       "file_type": "code",
       "id": "sessioncommandrepository_createsessioncommandrepository",
       "label": "createSessionCommandRepository()",
@@ -345307,13 +345238,49 @@
       "source_location": "L68"
     },
     {
-      "community": 899,
+      "community": 898,
       "file_type": "code",
       "id": "sessioncommandrepository_scansessionitembyskuinpages",
       "label": "scanSessionItemBySkuInPages()",
       "norm_label": "scansessionitembyskuinpages()",
       "source_file": "packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts",
       "source_location": "L195"
+    },
+    {
+      "community": 899,
+      "file_type": "code",
+      "id": "catalog_test_admittedctx",
+      "label": "admittedCtx()",
+      "norm_label": "admittedctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 899,
+      "file_type": "code",
+      "id": "catalog_test_buildctx",
+      "label": "buildCtx()",
+      "norm_label": "buildctx()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
+      "source_location": "L2658"
+    },
+    {
+      "community": 899,
+      "file_type": "code",
+      "id": "catalog_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 899,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_public_catalog_test_ts",
+      "label": "catalog.test.ts",
+      "norm_label": "catalog.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 9,
@@ -346155,38 +346122,38 @@
     {
       "community": 900,
       "file_type": "code",
-      "id": "catalog_test_admittedctx",
-      "label": "admittedCtx()",
-      "norm_label": "admittedctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
-      "source_location": "L135"
+      "id": "packages_athena_webapp_convex_pos_application_commands_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/commands/register.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 900,
       "file_type": "code",
-      "id": "catalog_test_buildctx",
+      "id": "packages_athena_webapp_convex_pos_public_register_test_ts",
+      "label": "register.test.ts",
+      "norm_label": "register.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 900,
+      "file_type": "code",
+      "id": "register_test_buildctx",
       "label": "buildCtx()",
       "norm_label": "buildctx()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
-      "source_location": "L2658"
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L48"
     },
     {
       "community": 900,
       "file_type": "code",
-      "id": "catalog_test_gethandler",
+      "id": "register_test_gethandler",
       "label": "getHandler()",
       "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 900,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_public_catalog_test_ts",
-      "label": "catalog.test.ts",
-      "norm_label": "catalog.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/public/catalog.test.ts",
-      "source_location": "L1"
+      "source_file": "packages/athena-webapp/convex/pos/public/register.test.ts",
+      "source_location": "L44"
     },
     {
       "community": 901,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 3245
-- Graph nodes: 14636
-- Graph edges: 18317
+- Graph nodes: 14635
+- Graph edges: 18315
 - Communities: 3169
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/reports/overview.test.ts
+++ b/packages/athena-webapp/convex/reports/overview.test.ts
@@ -187,8 +187,18 @@ describe("buildOverviewData", () => {
   const days = [
     day("2026-07-20", { netSalesMinor: 100, unitsSold: 1 }),
     day("2026-07-21", { netSalesMinor: 200, unitsSold: 2 }),
-    day("2026-07-26", { netSalesMinor: 300, unitsSold: 3 }),
-    day("2026-07-27", { netSalesMinor: 400, unitsSold: 4 }),
+    day("2026-07-26", {
+      closeId: "close-2026-07-26" as Id<"dailyClose">,
+      netSalesMinor: 300,
+      transactionCount: 3,
+      unitsSold: 3,
+    }),
+    day("2026-07-27", {
+      closeId: "close-2026-07-27" as Id<"dailyClose">,
+      netSalesMinor: 400,
+      transactionCount: 12,
+      unitsSold: 4,
+    }),
     day("2026-07-28", { status: "open", netSalesMinor: 500, unitsSold: 5 }),
   ];
 
@@ -197,10 +207,6 @@ describe("buildOverviewData", () => {
       days,
       fallbackCurrency: "GHS",
       now: 0,
-      transactionCountsByDate: new Map([
-        ["2026-07-26", 3],
-        ["2026-07-27", 12],
-      ]),
     });
 
     const countsByDate = new Map(
@@ -267,10 +273,14 @@ describe("buildOverviewData", () => {
       unitsSold: 5,
     });
     expect(
-      data.dailyTrend.every(
-        (point) => point.transactionCount === undefined,
-      ),
-    ).toBe(true);
+      data.dailyTrend.find((point) => point.operatingDate === "2026-07-26")
+        ?.transactionCount,
+    ).toBe(3);
+    expect(
+      data.dailyTrend.find((point) => point.operatingDate === "2026-07-27")
+        ?.transactionCount,
+    ).toBe(12);
+    expect(data.dailyTrend.at(-1)?.transactionCount).toBeUndefined();
     // The trailing-30 snapshot excludes the June day too.
     expect(data.trailing30.dayCount).toBe(5);
     expect(data.trailing30.netSalesMinor).toBe(1500);
@@ -487,7 +497,7 @@ describe("rebuildStoreOverview", () => {
     expect(overview?.priorTrailing6Months?.netSalesMinor).toBe(184);
   });
 
-  it("reads the trend's transaction counts from each day's register close", async () => {
+  it("reads the trend's settled transaction counts from reportDay", async () => {
     const t = convexTest(schema, modules);
 
     const { storeId } = await t.run(async (ctx) => {
@@ -520,7 +530,10 @@ describe("rebuildStoreOverview", () => {
           carryForwardCount: 0,
           readyCount: 0,
         },
-        summary: { transactionCount: 17 },
+        // The day projection below is the reporting authority. A conflicting
+        // close summary proves the overview rebuild does not hydrate the full
+        // close document to reconstruct a value the fold already persisted.
+        summary: { transactionCount: 99 },
         sourceSubjects: [],
         carryForwardWorkItemIds: [],
         createdAt: 0,
@@ -529,7 +542,10 @@ describe("rebuildStoreOverview", () => {
 
       // The closed day resolves a count; the open day has no close at all.
       await ctx.db.insert("reportDay", {
-        ...dayFields("2026-07-27", { netSalesMinor: 400 }),
+        ...dayFields("2026-07-27", {
+          netSalesMinor: 400,
+          transactionCount: 17,
+        }),
         closeId,
         storeId,
       });

--- a/packages/athena-webapp/convex/reports/overview.ts
+++ b/packages/athena-webapp/convex/reports/overview.ts
@@ -13,7 +13,6 @@ import {
   normalizeCurrencyCode,
 } from "../../shared/reportsContract";
 import { addDaysToDate } from "./rollups";
-import { transactionCountFromCloseSummary } from "./transactionCounts";
 
 /**
  * The overview document (slice C).
@@ -168,8 +167,6 @@ export function buildOverviewData(args: {
   days: readonly Doc<"reportDay">[];
   fallbackCurrency: string;
   now: number;
-  /** Settled transaction counts by operating date; absent days stay absent. */
-  transactionCountsByDate?: ReadonlyMap<string, number>;
 }): ReportOverviewData {
   const { days, now } = args;
   const anchor = anchorDate(days);
@@ -266,7 +263,10 @@ export function buildOverviewData(args: {
     netSalesMinor: day.netSalesMinor,
     status: day.status,
     unitsSold: day.unitsSold,
-    transactionCount: args.transactionCountsByDate?.get(day.operatingDate),
+    // A fact-derived count may already exist on an open/provisional day. The
+    // trend promises a settled count, so publish the folded value only once
+    // the day carries accepted-close authority.
+    transactionCount: day.closeId ? day.transactionCount : undefined,
   }));
 
   return {
@@ -313,36 +313,6 @@ export async function readRecentDays(
   return descending.reverse();
 }
 
-/**
- * Settled transaction counts for the trend window, keyed by operating date.
- *
- * Bounded by `OVERVIEW_TREND_DAYS` close lookups on top of the day scan, and
- * only for days that actually closed. Open days are omitted rather than
- * counted live: the sweep would then depend on fact volume, and the overview
- * exists precisely so the dashboard never pays that cost.
- */
-async function readTrendTransactionCounts(
-  ctx: MutationCtx,
-  days: readonly Doc<"reportDay">[],
-): Promise<Map<string, number>> {
-  const trendDays = days.slice(-OVERVIEW_TREND_DAYS).filter((day) => day.closeId);
-  const closes = await Promise.all(
-    trendDays.map((day) => ctx.db.get("dailyClose", day.closeId!)),
-  );
-
-  const counts = new Map<string, number>();
-  trendDays.forEach((day, index) => {
-    const close = closes[index];
-    if (!close) return;
-    counts.set(
-      day.operatingDate,
-      transactionCountFromCloseSummary(close.summary),
-    );
-  });
-
-  return counts;
-}
-
 /** Rebuild and upsert the store's singleton overview doc. */
 export async function rebuildStoreOverview(
   ctx: MutationCtx,
@@ -356,7 +326,6 @@ export async function rebuildStoreOverview(
     days,
     fallbackCurrency: normalizeCurrencyCode(store?.currency),
     now,
-    transactionCountsByDate: await readTrendTransactionCounts(ctx, days),
   });
 
   const existing = await ctx.db

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -3204,5 +3204,5 @@ describe("POSTerminalDetailView", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Replacement terminal reconnected",
     );
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

Reports sweep rebuilds now reuse the transaction count already persisted on each settled `reportDay`. The rebuild no longer hydrates up to 30 full `dailyClose` documents, which pushed the production sweep past Convex's 16 MiB transaction read limit.

The `closeId` gate preserves the existing settled-only trend contract: fact-derived counts on open or provisional days remain hidden until the close is accepted.

## Why

Wigclub's scheduled sweep was failing every 5 minutes after reading 17,239,245 bytes. The failed transaction rolled back its recovery path, leaving the same dirty marker to be retried indefinitely.

## Validation

- `bun run test -- convex/reports/overview.test.ts convex/reports/sweeper.test.ts` (71 tests passed)
- `bun run audit:convex`
- `bun run lint:convex:changed`
- `bun run graphify:rebuild && bun run graphify:check`
- `bun run pr:athena`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/gpt--5-Codex-000000)

https://linear.app/v26-labs/issue/V26-1444/stop-reports-sweep-from-rehydrating-full-closes-for-trend-counts
