### PR TITLE
[V26-1497]: Add persona references to Athena's policy lenses

### DIFF
--- a/.agents/policy/comparison-report.json
+++ b/.agents/policy/comparison-report.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": "athena-policy-comparison-report/1",
-  "comparedAt": "2026-08-30",
+  "comparedAt": "2026-08-31",
   "comparisonAuthority": "bun run pr:athena (unchanged legacy aggregate)",
   "mode": "read-only",
   "inputs": {
-    "repository-policy.json": "5206353be3ee1c55fb9c045914c5d96459ed2dbd0f5374318612ba2394591f7e",
+    "repository-policy.json": "c49f425be88ba67a6958e20ca8d68d52184f866d5fae748fce8dc08dedc05239",
     "adapters.json": "5f8aa52add535acf9d41696b2766e6891d64f3beff85712aa8727d0cbb334238",
     "pre-cutover-oracle.json": "76b3e7d79294ff910984435609e44c7fc80f0d52e7f1d2b9419df28488d29564",
-    "compiled-snapshot.json": "20a6c0c9ed57f29601299528927fd6eec9f96f390ed39bfbc74355c2f3752ef7",
-    "compiledDigest": "5421423d9153cf699a227f5e25a585de5bbe1aa05efc338b9ed6d48572e8b0a6"
+    "compiled-snapshot.json": "691b9c094f3721e59c63b5153b690936b9bcde92788df9d2174f4860bb9ccc12",
+    "compiledDigest": "170269c54fbfcbe1fef2442fcb40bbdc2d9e7f130505f7b8be95fc5605b1e0f5"
   },
   "results": {
-    "compile": "ok: the declarative document plus the twelve typed adapters compile through the harness policy compiler (agent-delivery-harness 981f39d) with zero rejections",
+    "compile": "ok: the declarative document plus the twelve typed adapters compile through the harness policy compiler (agent-delivery-harness a13ae38) with zero rejections, each lens resolving its reviewer charter by identity from the pinned composition archive 9ce12f12",
     "phaseParity": "ok: oracle phase vector matches the live pr:athena phase order and package.json script chain",
     "obligationParity": "ok: every live gate obligation (review.green, documentation.current, telemetry.recorded) is activated by the declarative document with matching activation semantics",
     "leafMapping": "ok: each proposed leaf maps to exactly one adapter; no adapter is mapped twice; the pr:athena aggregate is registered as no leaf",
@@ -83,6 +83,20 @@
       "observed": "Under the legacy authority the agent pushes delivery branches itself after the gates pass.",
       "projection": "The portable execution grant forbids git.push in every model-driven stage; in the managed model the push happens behind operation.pr-creation outside the model grant. Legacy behavior is unchanged until cutover; this difference is between projections, not a change to current authority.",
       "disposition": "accepted-projection",
+      "blocking": false
+    },
+    {
+      "id": "lens-persona-by-identity",
+      "observed": "Each lens must now name the reviewer charter it hands its reviewer. Athena's delivery review runs a correctness reviewer and an adversarial reviewer (ce-correctness-reviewer and ce-adversarial-reviewer in .agents/skills/ce-code-review/references/persona-catalog.md), and the review telemetry keys those two as correctness and adversarial.",
+      "projection": "lens.outcome-correctness references persona.outcome-correctness and lens.adversarial-testing references persona.adversarial, both by identity alone, so advancing the shipped charter set never edits this document. The charter bytes are bound in the compiled snapshot instead. lens.adversarial-testing keeps the testing-policy category, which remains a taxonomy slot forced by the closed category vocabulary and not a statement about which charter the lens hands out - see adversarial-lens-category.",
+      "disposition": "accepted-projection",
+      "blocking": false
+    },
+    {
+      "id": "shadow-activation-product-pin-predates-personas",
+      "observed": "shadow-activation.json pins the shadow-window product at agent-delivery-harness 8635ea8, which is an ancestor of a13ae38 and therefore carries no shipped charter set. The compile recorded here used the current compiler and its pinned composition, not the shadow window's older product pin.",
+      "projection": "The recorded snapshot is a compile against the current compiler, which is what the acceptance criteria ask for; the shadow window holds no delivery authority, so the lagging product pin changes no active gate. Advancing that pin is a separate deliberate re-pin, not a quiet edit folded into this one.",
+      "disposition": "deferred",
       "blocking": false
     }
   ]

--- a/.agents/policy/compiled-snapshot.json
+++ b/.agents/policy/compiled-snapshot.json
@@ -2,13 +2,19 @@
   "schemaVersion": "athena-compiled-policy-snapshot/1",
   "compiledWith": {
     "repository": "agent-delivery-harness",
-    "commit": "981f39d72520b25d962761898efb407c009b74d0",
+    "commit": "a13ae38046a1043deacbc80b7ad079abf81ea58a",
     "module": "packages/kernel/src/policy/compile.ts",
     "productTrustRevocationEpoch": 0,
-    "repositoryAuthorityRevocationEpoch": 0
+    "repositoryAuthorityRevocationEpoch": 0,
+    "personaSource": {
+      "form": "shipped-by-identity",
+      "composition": "qualifications/fixtures/agent-skills-core-v1-composition.zip",
+      "archiveSha256": "9ce12f12c4096e346154ef377fc89187c9168944d6e59b9d6596feb98e57d2ed",
+      "manifest": "personas/manifest.json"
+    }
   },
   "inputDigests": {
-    "repository-policy.json": "5206353be3ee1c55fb9c045914c5d96459ed2dbd0f5374318612ba2394591f7e",
+    "repository-policy.json": "c49f425be88ba67a6958e20ca8d68d52184f866d5fae748fce8dc08dedc05239",
     "adapters.json": "5f8aa52add535acf9d41696b2766e6891d64f3beff85712aa8727d0cbb334238"
   },
   "compiled": {
@@ -28,11 +34,15 @@
       "reviewLenses": [
         {
           "lensId": "lens.outcome-correctness",
-          "category": "outcome-correctness"
+          "category": "outcome-correctness",
+          "personaId": "persona.outcome-correctness",
+          "personaDigest": "a5d96a825150e40b840cd91b55c2d7480f5ee7e481004464062afb8ef5430e2c"
         },
         {
           "lensId": "lens.adversarial-testing",
-          "category": "testing-policy"
+          "category": "testing-policy",
+          "personaId": "persona.adversarial",
+          "personaDigest": "ae9969a9835d66a8fd0b4dca434915f23e2904b5f3865035f887583338571b0d"
         }
       ],
       "obligations": [
@@ -58,7 +68,7 @@
           "obligationId": "delivery.scorecard"
         }
       ],
-      "policyDigest": "42393e0feee0417063208d13cc5acd29393dc1e3ff70a1a318de6574578e8e44"
+      "policyDigest": "795c6433691852debe5b24c1e234735c90f3ed5481582945645adbf199d34236"
     },
     "capabilities": [
       {
@@ -269,6 +279,6 @@
     "approvals": [],
     "tracker": "absent",
     "trackerAbsenceFallback": "proceed-without-tracker",
-    "compiledDigest": "5421423d9153cf699a227f5e25a585de5bbe1aa05efc338b9ed6d48572e8b0a6"
+    "compiledDigest": "170269c54fbfcbe1fef2442fcb40bbdc2d9e7f130505f7b8be95fc5605b1e0f5"
   }
 }

--- a/.agents/policy/repository-policy.json
+++ b/.agents/policy/repository-policy.json
@@ -6,8 +6,16 @@
   "grantedAuthority": ["pr-creation"],
   "forbiddenAuthority": ["merge", "deploy"],
   "reviewLenses": [
-    { "lensId": "lens.outcome-correctness", "category": "outcome-correctness" },
-    { "lensId": "lens.adversarial-testing", "category": "testing-policy" }
+    {
+      "lensId": "lens.outcome-correctness",
+      "category": "outcome-correctness",
+      "personaId": "persona.outcome-correctness"
+    },
+    {
+      "lensId": "lens.adversarial-testing",
+      "category": "testing-policy",
+      "personaId": "persona.adversarial"
+    }
   ],
   "obligations": [
     { "obligationId": "preparation.current" },

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 14939 nodes · 18683 edges · 3252 communities detected
+- 14940 nodes · 18686 edges · 3252 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3746,40 +3746,40 @@ Cohesion: 0.16
 Nodes (18): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), formatConvexDnsFailure(), formatConvexTerminationFailure(), isGenericFetchFailure(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi() (+10 more)
 
 ### Community 114 - "Community 114"
-Cohesion: 0.18
-Nodes (16): collectSources(), findDisallowedImports(), findIndirectComponentMountViolations(), findKernelImportViolations(), findLeafImportViolations(), findProductSurfaceImports(), findProfileImportViolations(), findRegistrationShimViolations() (+8 more)
-
-### Community 115 - "Community 115"
 Cohesion: 0.16
 Nodes (17): AgentReadPortBindingError, computeReadResultHash(), contractViolation(), createAgentReadPortRegistry(), cursorBindingDigest(), dispatchAgentReadPort(), filterValueValid(), finishAgentReadEnvelope() (+9 more)
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.26
 Nodes (19): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), failRunBestEffort(), getBundleSnapshotFields(), getStoreInsightsSnapshotFallback(), isActivityTrend() (+11 more)
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.21
 Nodes (16): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+8 more)
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.12
 Nodes (6): allowlist(), metrics(), missingDayResult(), posture(), seedStoreWithDay(), seedWeeklyStore()
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.11
 Nodes (4): insertFact(), period(), receipt(), withCloses()
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.14
 Nodes (9): ensureDemoCredentialWithCtx(), ensureDemoRoleAssignmentWithCtx(), ensureDemoStaffAccessWithCtx(), ensureSharedDemoRegisterFoundationWithCtx(), ensureSharedDemoSeededTerminalWithCtx(), migrateSharedDemoStoryWithCtx(), reconcileSharedDemoCatalogWithCtx(), repairSharedDemoSeededTerminalBindingWithCtx() (+1 more)
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.16
 Nodes (14): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+6 more)
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.13
 Nodes (9): composeAthenaThreadKey(), describeAthenaTrailUnavailable(), describeAthenaUnavailable(), describeProvisionalWithdrawal(), encodeThreadKey(), hashToken(), isThreadKeySafeCharacter(), snapshotAthenaContext() (+1 more)
+
+### Community 122 - "Community 122"
+Cohesion: 0.18
+Nodes (16): collectSources(), findDisallowedImports(), findIndirectComponentMountViolations(), findKernelImportViolations(), findLeafImportViolations(), findProductSurfaceImports(), findProfileImportViolations(), findRegistrationShimViolations() (+8 more)
 
 ### Community 123 - "Community 123"
 Cohesion: 0.11
@@ -4894,24 +4894,24 @@ Cohesion: 0.25
 Nodes (2): enableLocalExpenseEventReplay(), seedActiveExpenseCart()
 
 ### Community 401 - "Community 401"
+Cohesion: 0.31
+Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+
+### Community 402 - "Community 402"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 403 - "Community 403"
+### Community 404 - "Community 404"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 404 - "Community 404"
-Cohesion: 0.31
-Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
-
 ### Community 405 - "Community 405"
 Cohesion: 0.31
-Nodes (5): getPreferredSku(), getProductName(), sortProduct(), sortSkusByAvailabilityThenLength(), sortSkusByLength()
+Nodes (5): createVersionChecker(), getInitialDeployBuildId(), readDocumentScriptSources(), readEntryHtmlScripts(), readScriptSources()
 
 ### Community 406 - "Community 406"
 Cohesion: 0.39
@@ -5526,120 +5526,120 @@ Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
 ### Community 559 - "Community 559"
+Cohesion: 0.38
+Nodes (3): readPolicyJson(), restampPolicyDigests(), writePolicyJson()
+
+### Community 560 - "Community 560"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 560 - "Community 560"
-Cohesion: 0.33
-Nodes (2): createFixtureRoot(), write()
-
 ### Community 561 - "Community 561"
 Cohesion: 0.33
-Nodes (0):
+Nodes (2): createFixtureRoot(), write()
 
 ### Community 562 - "Community 562"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 563 - "Community 563"
-Cohesion: 0.4
-Nodes (2): clampRunLimitsToEvidenceCeiling(), deriveExecutionCeilings()
-
-### Community 564 - "Community 564"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 564 - "Community 564"
+Cohesion: 0.4
+Nodes (2): clampRunLimitsToEvidenceCeiling(), deriveExecutionCeilings()
 
 ### Community 565 - "Community 565"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 566 - "Community 566"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 567 - "Community 567"
 Cohesion: 0.4
 Nodes (2): executor(), runtime()
 
-### Community 567 - "Community 567"
+### Community 568 - "Community 568"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 568 - "Community 568"
+### Community 569 - "Community 569"
 Cohesion: 0.33
 Nodes (1): AgentModelRegistryError
 
-### Community 569 - "Community 569"
+### Community 570 - "Community 570"
 Cohesion: 0.6
 Nodes (5): fitEncodedCallOutput(), measureEncodedBytes(), measureUtf8Bytes(), readCollection(), withCollection()
 
-### Community 570 - "Community 570"
+### Community 571 - "Community 571"
 Cohesion: 0.4
 Nodes (2): loadProvisionalNarrativeByBindingWithCtx(), upsertProvisionalNarrativeWithCtx()
 
-### Community 571 - "Community 571"
+### Community 572 - "Community 572"
 Cohesion: 0.4
 Nodes (2): createTurnHost(), productionHost()
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.53
 Nodes (4): bestEffortRecordScheduledRunEvidence(), buildScheduledRunKey(), recordScheduledRunEvidenceWithCtx(), resolveScheduledWindow()
 
-### Community 573 - "Community 573"
+### Community 574 - "Community 574"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 574 - "Community 574"
+### Community 575 - "Community 575"
 Cohesion: 0.67
 Nodes (5): closeoutVersionOf(), projectSession(), readRegisterSessionsHandler(), readSessionsForDate(), terminalLabelsFor()
 
-### Community 575 - "Community 575"
+### Community 576 - "Community 576"
 Cohesion: 0.6
 Nodes (5): appendContextEventWithCtx(), buildContextEventSemanticEnvelopeHash(), isAllowedGlobalContextEvent(), isContextEventWriteQuotaExceeded(), selectContextEventAppendQuotaDecision()
 
-### Community 576 - "Community 576"
+### Community 577 - "Community 577"
 Cohesion: 0.33
 Nodes (1): getHandler()
 
-### Community 577 - "Community 577"
+### Community 578 - "Community 578"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 578 - "Community 578"
+### Community 579 - "Community 579"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 580 - "Community 580"
-Cohesion: 0.4
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 581 - "Community 581"
 Cohesion: 0.4
-Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 582 - "Community 582"
 Cohesion: 0.4
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
 ### Community 583 - "Community 583"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 584 - "Community 584"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 585 - "Community 585"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 586 - "Community 586"
 Cohesion: 0.6
 Nodes (5): backfillStoreCurrencyCaseWithCtx(), boundedLimit(), needsNormalization(), storePage(), verifyStoreCurrencyCaseWithCtx()
 
-### Community 586 - "Community 586"
+### Community 587 - "Community 587"
 Cohesion: 0.47
 Nodes (4): findNotificationKind(), getNotificationKind(), isStaleDailyClosePayload(), requireStaleDailyClosePayload()
-
-### Community 587 - "Community 587"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 0.33
@@ -5650,40 +5650,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 590 - "Community 590"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 591 - "Community 591"
 Cohesion: 0.6
 Nodes (4): customerBehaviorRead(), resolveStoreFromStorefrontActor(), storefrontAccountRead(), storefrontRead()
 
-### Community 591 - "Community 591"
+### Community 592 - "Community 592"
 Cohesion: 0.53
 Nodes (4): evaluateOperationTargetGuards(), readIdArg(), resolveOperationTargetExternalRefs(), resolveOperationTargetIds()
 
-### Community 592 - "Community 592"
+### Community 593 - "Community 593"
 Cohesion: 0.47
 Nodes (3): listApprovalsHandler(), listAttentionHandler(), windowFallbackWarning()
 
-### Community 593 - "Community 593"
+### Community 594 - "Community 594"
 Cohesion: 0.53
 Nodes (4): consumeApprovalProofWithCtx(), getValidApprovalProof(), invalidApprovalProofResult(), validateApprovalProofWithCtx()
 
-### Community 594 - "Community 594"
+### Community 595 - "Community 595"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 595 - "Community 595"
+### Community 596 - "Community 596"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
-### Community 596 - "Community 596"
+### Community 597 - "Community 597"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 597 - "Community 597"
-Cohesion: 0.4
-Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 598 - "Community 598"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 599 - "Community 599"
 Cohesion: 0.33
@@ -5702,188 +5702,188 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 603 - "Community 603"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 604 - "Community 604"
 Cohesion: 0.47
 Nodes (3): foldDay(), revenueContribution(), zeroDayMetrics()
 
-### Community 604 - "Community 604"
+### Community 605 - "Community 605"
 Cohesion: 0.6
 Nodes (5): configuredTimezone(), isValidTimezone(), localDateLabel(), resolveOperatingDate(), resolveStoreTimezone()
 
-### Community 605 - "Community 605"
+### Community 606 - "Community 606"
 Cohesion: 0.67
 Nodes (4): backfillClosePage(), backfillCloseWeeklyPageWithCtx(), backfillDayPage(), ensureWork()
 
-### Community 606 - "Community 606"
+### Community 607 - "Community 607"
 Cohesion: 0.6
 Nodes (5): boundedCount(), ledgerOutcome(), recordPipelineBacklogWithCtx(), recordPipelineEvidenceWithCtx(), recordPipelineOutcomeWithCtx()
 
-### Community 607 - "Community 607"
+### Community 608 - "Community 608"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 608 - "Community 608"
-Cohesion: 0.6
-Nodes (5): activatePipelineWithCtx(), canonicalPage(), dayCoveragePage(), outstandingBasis(), stepPipelineMigrationWithCtx()
 
 ### Community 609 - "Community 609"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.6
+Nodes (5): activatePipelineWithCtx(), canonicalPage(), dayCoveragePage(), outstandingBasis(), stepPipelineMigrationWithCtx()
 
 ### Community 610 - "Community 610"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 611 - "Community 611"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 612 - "Community 612"
 Cohesion: 0.4
 Nodes (2): at(), seedFullDay()
 
-### Community 612 - "Community 612"
+### Community 613 - "Community 613"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 613 - "Community 613"
+### Community 614 - "Community 614"
 Cohesion: 0.47
 Nodes (3): projectFrozenWeeklyInventoryAttention(), projectLiveWeeklyInventoryAttention(), summarizeWeeklyInventoryAttention()
 
-### Community 614 - "Community 614"
+### Community 615 - "Community 615"
 Cohesion: 0.4
 Nodes (2): getHandler(), invoke()
 
-### Community 615 - "Community 615"
+### Community 616 - "Community 616"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 616 - "Community 616"
+### Community 617 - "Community 617"
 Cohesion: 0.53
 Nodes (4): provisionForScheduledWorkWithCtx(), runDailyRestoreWithCtx(), runHourlyProvisionHealWithCtx(), sharedDemoRestoreEnabled()
 
-### Community 617 - "Community 617"
+### Community 618 - "Community 618"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 618 - "Community 618"
+### Community 619 - "Community 619"
 Cohesion: 0.53
 Nodes (4): projectPosition(), readPositionsHandler(), stockStateOf(), variantLabelOf()
 
-### Community 619 - "Community 619"
+### Community 620 - "Community 620"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 620 - "Community 620"
+### Community 621 - "Community 621"
 Cohesion: 0.53
 Nodes (4): buildOnlineOrderReportedReturns(), buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 621 - "Community 621"
+### Community 622 - "Community 622"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 622 - "Community 622"
+### Community 623 - "Community 623"
 Cohesion: 0.4
 Nodes (2): localDate(), resolveStoreTimeAuthority()
 
-### Community 623 - "Community 623"
+### Community 624 - "Community 624"
 Cohesion: 0.53
 Nodes (4): buildPurchaseOrderTraceSeed(), compactDetails(), formatPurchaseOrderLabel(), normalizeLookup()
 
-### Community 624 - "Community 624"
+### Community 625 - "Community 625"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 625 - "Community 625"
+### Community 626 - "Community 626"
 Cohesion: 0.4
 Nodes (2): defineAgentProfile(), validateProfileDefinition()
 
-### Community 626 - "Community 626"
+### Community 627 - "Community 627"
 Cohesion: 0.47
 Nodes (4): isInternalFunctionPath(), sameSet(), validateReadPortDefinition(), validateReadPortIndex()
 
-### Community 627 - "Community 627"
+### Community 628 - "Community 628"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 628 - "Community 628"
+### Community 629 - "Community 629"
 Cohesion: 0.4
 Nodes (2): compareHomepageRankedItems(), getHomepageSortRank()
 
-### Community 629 - "Community 629"
+### Community 630 - "Community 630"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 630 - "Community 630"
+### Community 631 - "Community 631"
 Cohesion: 0.47
 Nodes (4): assertObjectKeysAreMinimized(), assertWorkflowTraceDetailsAreMinimized(), createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 631 - "Community 631"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 632 - "Community 632"
 Cohesion: 0.33
-Nodes (1): DataTableToolbar()
+Nodes (0):
 
 ### Community 633 - "Community 633"
 Cohesion: 0.33
-Nodes (1): SpyImage
+Nodes (1): DataTableToolbar()
 
 ### Community 634 - "Community 634"
-Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+Cohesion: 0.33
+Nodes (1): SpyImage
 
 ### Community 635 - "Community 635"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 636 - "Community 636"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 637 - "Community 637"
-Cohesion: 0.4
-Nodes (2): moveBestSeller(), saveOrder()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 638 - "Community 638"
 Cohesion: 0.4
-Nodes (2): moveFeaturedItem(), saveOrder()
+Nodes (2): moveBestSeller(), saveOrder()
 
 ### Community 639 - "Community 639"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): moveFeaturedItem(), saveOrder()
 
 ### Community 640 - "Community 640"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
-
-### Community 641 - "Community 641"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 641 - "Community 641"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
 ### Community 642 - "Community 642"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 643 - "Community 643"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 644 - "Community 644"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 644 - "Community 644"
+### Community 645 - "Community 645"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 645 - "Community 645"
+### Community 646 - "Community 646"
 Cohesion: 0.47
 Nodes (3): formatNextOpeningLabel(), formatStoreHoursTimeLabel(), formatStoreLocalDateLabel()
 
-### Community 646 - "Community 646"
+### Community 647 - "Community 647"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
-### Community 647 - "Community 647"
+### Community 648 - "Community 648"
 Cohesion: 0.47
 Nodes (3): baseInput(), buildRuntimeStatus(), emptySyncEvidence()
-
-### Community 648 - "Community 648"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 649 - "Community 649"
 Cohesion: 0.33
@@ -5891,115 +5891,115 @@ Nodes (0):
 
 ### Community 650 - "Community 650"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 651 - "Community 651"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 652 - "Community 652"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 653 - "Community 653"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 654 - "Community 654"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 654 - "Community 654"
+### Community 655 - "Community 655"
 Cohesion: 0.6
 Nodes (5): identity(), liveResult(), metrics(), quickAddIdentity(), skuMetrics()
 
-### Community 655 - "Community 655"
+### Community 656 - "Community 656"
 Cohesion: 0.6
 Nodes (5): addSkuMetrics(), sharedDemoFixtureSkuId(), toSharedDemoLiveReportsDay(), toSharedDemoLiveSkuStock(), zeroDayMetrics()
 
-### Community 656 - "Community 656"
+### Community 657 - "Community 657"
 Cohesion: 0.6
 Nodes (5): classifyAthenaViewSurface(), isSharedDemoSurfaceVisible(), normalizePathname(), resolveAthenaViewRoute(), routeTemplateMatches()
 
-### Community 657 - "Community 657"
+### Community 658 - "Community 658"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 658 - "Community 658"
+### Community 659 - "Community 659"
 Cohesion: 0.4
 Nodes (2): isValidRecipientEmail(), normalizeRecipientEmailInput()
 
-### Community 659 - "Community 659"
+### Community 660 - "Community 660"
 Cohesion: 0.53
 Nodes (4): formatPaymentMethods(), formatTraceMoney(), getLifecycleStatement(), getTransactionStatement()
 
-### Community 660 - "Community 660"
+### Community 661 - "Community 661"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 661 - "Community 661"
+### Community 662 - "Community 662"
 Cohesion: 0.6
 Nodes (5): deriveStoreFrontFromAdminHost(), getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
-
-### Community 662 - "Community 662"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 663 - "Community 663"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 664 - "Community 664"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 665 - "Community 665"
 Cohesion: 0.73
 Nodes (5): canAccessCashControlsSurface(), canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 665 - "Community 665"
+### Community 666 - "Community 666"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 666 - "Community 666"
+### Community 667 - "Community 667"
 Cohesion: 0.4
 Nodes (3): ProductArchiveBlockedError, productArchiveBlockFromResult(), readGroupCount()
 
-### Community 667 - "Community 667"
+### Community 668 - "Community 668"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 668 - "Community 668"
-Cohesion: 0.4
-Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 669 - "Community 669"
 Cohesion: 0.4
-Nodes (2): buildRecoveryCommandStore(), storeFactory()
+Nodes (2): deriveRegisterLifecycleAuthorityCandidates(), mappingCandidate()
 
 ### Community 670 - "Community 670"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): buildRecoveryCommandStore(), storeFactory()
 
 ### Community 671 - "Community 671"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 672 - "Community 672"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 673 - "Community 673"
 Cohesion: 0.4
 Nodes (2): encodeFocusKey(), encodeSheetReturn()
 
-### Community 673 - "Community 673"
+### Community 674 - "Community 674"
 Cohesion: 0.47
 Nodes (3): buildAdminSkuSearchOption(), compactJoin(), presentationText()
 
-### Community 674 - "Community 674"
+### Community 675 - "Community 675"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 675 - "Community 675"
+### Community 676 - "Community 676"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 676 - "Community 676"
-Cohesion: 0.33
-Nodes (1): MemoryCache
-
 ### Community 677 - "Community 677"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): MemoryCache
 
 ### Community 678 - "Community 678"
 Cohesion: 0.33
@@ -6014,96 +6014,96 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 681 - "Community 681"
-Cohesion: 0.47
-Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 682 - "Community 682"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.47
+Nodes (3): completePendingAuthSync(), navigationTargetForRedirect(), sleep()
 
 ### Community 683 - "Community 683"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 684 - "Community 684"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 685 - "Community 685"
 Cohesion: 0.6
 Nodes (5): useDailyCloseFixture(), useDailyOpeningFixture(), useDailyOperationsFixture(), usePosHubFixture(), useWorkspaceFixture()
 
-### Community 685 - "Community 685"
+### Community 686 - "Community 686"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 686 - "Community 686"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 687 - "Community 687"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 688 - "Community 688"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
 ### Community 689 - "Community 689"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 690 - "Community 690"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 691 - "Community 691"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 691 - "Community 691"
+### Community 692 - "Community 692"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 692 - "Community 692"
+### Community 693 - "Community 693"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 693 - "Community 693"
+### Community 694 - "Community 694"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 694 - "Community 694"
+### Community 695 - "Community 695"
 Cohesion: 0.6
 Nodes (5): counts(), formatScorecard(), main(), parseScorecardArgs(), seconds()
 
-### Community 695 - "Community 695"
+### Community 696 - "Community 696"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 696 - "Community 696"
+### Community 697 - "Community 697"
 Cohesion: 0.67
 Nodes (5): assertDocsLinks(), classifyLink(), collectDocsLinkFindings(), collectSolutionSlugs(), solutionsRoot()
 
-### Community 697 - "Community 697"
+### Community 698 - "Community 698"
 Cohesion: 0.73
 Nodes (5): asObject(), discoverDocumentationWaiverAttestation(), nonEmpty(), parseDocumentationWaiverAttestation(), verifyDocumentationWaiverAttestation()
 
-### Community 698 - "Community 698"
+### Community 699 - "Community 699"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 699 - "Community 699"
+### Community 700 - "Community 700"
 Cohesion: 0.53
 Nodes (4): errorMessage(), formatHumanReport(), runHarnessContractPreflight(), runHarnessContractPreflightCli()
 
-### Community 700 - "Community 700"
+### Community 701 - "Community 701"
 Cohesion: 0.4
 Nodes (2): evidence(), input()
 
-### Community 701 - "Community 701"
+### Community 702 - "Community 702"
 Cohesion: 0.47
 Nodes (4): commitFixtureRepo(), createFixtureRepo(), runFixtureCommand(), write()
 
-### Community 702 - "Community 702"
+### Community 703 - "Community 703"
 Cohesion: 0.47
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 703 - "Community 703"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 704 - "Community 704"
 Cohesion: 0.6
@@ -6386,36 +6386,36 @@ Cohesion: 0.7
 Nodes (4): computeSha256Digest(), rotr(), sha256Hex(), toBytes()
 
 ### Community 774 - "Community 774"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 775 - "Community 775"
 Cohesion: 0.5
 Nodes (2): getDiscountValue(), getOrderAmount()
 
-### Community 776 - "Community 776"
+### Community 775 - "Community 775"
 Cohesion: 0.5
 Nodes (2): revealedPrefix(), revealedProse()
+
+### Community 776 - "Community 776"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 777 - "Community 777"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 778 - "Community 778"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 779 - "Community 779"
 Cohesion: 0.5
 Nodes (2): cancel(), handleClick()
 
-### Community 780 - "Community 780"
+### Community 779 - "Community 779"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 781 - "Community 781"
+### Community 780 - "Community 780"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 781 - "Community 781"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 782 - "Community 782"
 Cohesion: 0.4
@@ -6426,12 +6426,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 784 - "Community 784"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 785 - "Community 785"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 785 - "Community 785"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 786 - "Community 786"
 Cohesion: 0.4
@@ -6470,124 +6470,124 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 795 - "Community 795"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 796 - "Community 796"
 Cohesion: 0.5
 Nodes (2): getSelectedAppActionBlocker(), sortAppActionBlockers()
 
-### Community 797 - "Community 797"
+### Community 796 - "Community 796"
 Cohesion: 0.5
 Nodes (2): getSelectedAppMessage(), sortAppMessages()
 
-### Community 798 - "Community 798"
+### Community 797 - "Community 797"
 Cohesion: 0.5
 Nodes (2): clearTrackedBeforeUnloadHandlers(), reloadBrowserForAppUpdate()
 
-### Community 799 - "Community 799"
+### Community 798 - "Community 798"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 800 - "Community 800"
+### Community 799 - "Community 799"
 Cohesion: 0.6
 Nodes (3): extractTraceId(), getSharedDemoDenial(), runCommand()
 
-### Community 801 - "Community 801"
+### Community 800 - "Community 800"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 802 - "Community 802"
+### Community 801 - "Community 801"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 803 - "Community 803"
+### Community 802 - "Community 802"
 Cohesion: 0.5
 Nodes (2): mapRegisterStateDto(), useConvexRegisterState()
 
-### Community 804 - "Community 804"
+### Community 803 - "Community 803"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 805 - "Community 805"
+### Community 804 - "Community 804"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 806 - "Community 806"
+### Community 805 - "Community 805"
 Cohesion: 0.8
 Nodes (4): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPagesOrFallback(), readScopedPosLocalEvents()
 
-### Community 807 - "Community 807"
+### Community 806 - "Community 806"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 808 - "Community 808"
+### Community 807 - "Community 807"
 Cohesion: 0.6
 Nodes (3): getRuntimeVisibleActiveRegisterSession(), refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
 
-### Community 809 - "Community 809"
+### Community 808 - "Community 808"
 Cohesion: 0.6
 Nodes (3): applySnapshot(), isRegisterLifecycleRepairClassification(), toObservation()
 
-### Community 810 - "Community 810"
+### Community 809 - "Community 809"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 811 - "Community 811"
+### Community 810 - "Community 810"
 Cohesion: 0.7
 Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+
+### Community 811 - "Community 811"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 812 - "Community 812"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 813 - "Community 813"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 814 - "Community 814"
 Cohesion: 0.5
 Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+
+### Community 814 - "Community 814"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 815 - "Community 815"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 816 - "Community 816"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 817 - "Community 817"
 Cohesion: 0.5
 Nodes (2): expenseCartItemSourceKey(), sessionItemRepresentsCartItem()
 
-### Community 818 - "Community 818"
+### Community 817 - "Community 817"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 819 - "Community 819"
+### Community 818 - "Community 818"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 820 - "Community 820"
+### Community 819 - "Community 819"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 821 - "Community 821"
+### Community 820 - "Community 820"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
-### Community 822 - "Community 822"
+### Community 821 - "Community 821"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 823 - "Community 823"
+### Community 822 - "Community 822"
 Cohesion: 0.6
 Nodes (3): toDisplayProduct(), toDisplaySku(), toFeaturedItem()
 
-### Community 824 - "Community 824"
+### Community 823 - "Community 823"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 824 - "Community 824"
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 825 - "Community 825"
 Cohesion: 0.7

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -198755,7 +198755,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_test_ts",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L416",
+      "source_location": "L446",
       "target": "policy_projection_check_test_capturecandidate",
       "weight": 1
     },
@@ -326539,7 +326539,7 @@
       "label": "captureCandidate()",
       "norm_label": "capturecandidate()",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L416"
+      "source_location": "L446"
     },
     {
       "community": 559,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -198755,7 +198755,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_test_ts",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L521",
+      "source_location": "L553",
       "target": "policy_projection_check_test_capturecandidate",
       "weight": 1
     },
@@ -326539,7 +326539,7 @@
       "label": "captureCandidate()",
       "norm_label": "capturecandidate()",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L521"
+      "source_location": "L553"
     },
     {
       "community": 559,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -198755,7 +198755,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_test_ts",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L446",
+      "source_location": "L506",
       "target": "policy_projection_check_test_capturecandidate",
       "weight": 1
     },
@@ -326539,7 +326539,7 @@
       "label": "captureCandidate()",
       "norm_label": "capturecandidate()",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L446"
+      "source_location": "L506"
     },
     {
       "community": 559,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -198755,7 +198755,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_test_ts",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L506",
+      "source_location": "L521",
       "target": "policy_projection_check_test_capturecandidate",
       "weight": 1
     },
@@ -326539,7 +326539,7 @@
       "label": "captureCandidate()",
       "norm_label": "capturecandidate()",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L506"
+      "source_location": "L521"
     },
     {
       "community": 559,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -168071,7 +168071,7 @@
       "relation": "calls",
       "source": "policy_projection_check_coveredbyprotectedtree",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L536",
+      "source_location": "L607",
       "target": "policy_projection_check_runpolicyprojectioncheck",
       "weight": 1
     },
@@ -168083,7 +168083,7 @@
       "relation": "calls",
       "source": "policy_projection_check_equalstringarrays",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L283",
+      "source_location": "L296",
       "target": "policy_projection_check_runpolicyprojectioncheck",
       "weight": 1
     },
@@ -168095,7 +168095,7 @@
       "relation": "calls",
       "source": "policy_projection_check_formatmechanicalselection",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L479",
+      "source_location": "L550",
       "target": "policy_projection_check_runpolicyprojectioncheck",
       "weight": 1
     },
@@ -168107,8 +168107,32 @@
       "relation": "calls",
       "source": "policy_projection_check_sha256",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L197",
+      "source_location": "L210",
       "target": "policy_projection_check_runpolicyprojectioncheck",
+      "weight": 1
+    },
+    {
+      "_src": "policy_projection_check_test_restamppolicydigests",
+      "_tgt": "policy_projection_check_test_readpolicyjson",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "policy_projection_check_test_readpolicyjson",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L199",
+      "target": "policy_projection_check_test_restamppolicydigests",
+      "weight": 1
+    },
+    {
+      "_src": "policy_projection_check_test_restamppolicydigests",
+      "_tgt": "policy_projection_check_test_writepolicyjson",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "policy_projection_check_test_writepolicyjson",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L202",
+      "target": "policy_projection_check_test_restamppolicydigests",
       "weight": 1
     },
     {
@@ -198731,7 +198755,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_test_ts",
       "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L266",
+      "source_location": "L416",
       "target": "policy_projection_check_test_capturecandidate",
       "weight": 1
     },
@@ -198773,6 +198797,18 @@
     },
     {
       "_src": "scripts_policy_projection_check_test_ts",
+      "_tgt": "policy_projection_check_test_restamppolicydigests",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "contains",
+      "source": "scripts_policy_projection_check_test_ts",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L192",
+      "target": "policy_projection_check_test_restamppolicydigests",
+      "weight": 1
+    },
+    {
+      "_src": "scripts_policy_projection_check_test_ts",
       "_tgt": "policy_projection_check_test_writepolicyjson",
       "confidence": "EXTRACTED",
       "confidence_score": 1,
@@ -198791,7 +198827,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_ts",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L100",
+      "source_location": "L101",
       "target": "policy_projection_check_coveredbyprotectedtree",
       "weight": 1
     },
@@ -198803,7 +198839,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_ts",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L93",
+      "source_location": "L94",
       "target": "policy_projection_check_equalstringarrays",
       "weight": 1
     },
@@ -198815,7 +198851,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_ts",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L81",
+      "source_location": "L82",
       "target": "policy_projection_check_formatmechanicalselection",
       "weight": 1
     },
@@ -198827,7 +198863,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_ts",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L106",
+      "source_location": "L107",
       "target": "policy_projection_check_runpolicyprojectioncheck",
       "weight": 1
     },
@@ -198839,7 +198875,7 @@
       "relation": "contains",
       "source": "scripts_policy_projection_check_ts",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L89",
+      "source_location": "L90",
       "target": "policy_projection_check_sha256",
       "weight": 1
     },
@@ -234285,182 +234321,182 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "importboundary_test_collectsources",
-      "label": "collectSources()",
-      "norm_label": "collectsources()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_finddisallowedimports",
-      "label": "findDisallowedImports()",
-      "norm_label": "finddisallowedimports()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findindirectcomponentmountviolations",
-      "label": "findIndirectComponentMountViolations()",
-      "norm_label": "findindirectcomponentmountviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findkernelimportviolations",
-      "label": "findKernelImportViolations()",
-      "norm_label": "findkernelimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findleafimportviolations",
-      "label": "findLeafImportViolations()",
-      "norm_label": "findleafimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findproductsurfaceimports",
-      "label": "findProductSurfaceImports()",
-      "norm_label": "findproductsurfaceimports()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findprofileimportviolations",
-      "label": "findProfileImportViolations()",
-      "norm_label": "findprofileimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findregistrationshimviolations",
-      "label": "findRegistrationShimViolations()",
-      "norm_label": "findregistrationshimviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L264"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findrootconvexconfigviolations",
-      "label": "findRootConvexConfigViolations()",
-      "norm_label": "findrootconvexconfigviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findruntimenativeidentifierviolations",
-      "label": "findRuntimeNativeIdentifierViolations()",
-      "norm_label": "findruntimenativeidentifierviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findruntimenativeimportviolations",
-      "label": "findRuntimeNativeImportViolations()",
-      "norm_label": "findruntimenativeimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findruntimenativeviolations",
-      "label": "findRuntimeNativeViolations()",
-      "norm_label": "findruntimenativeviolations()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_findsharedcontractviolations",
-      "label": "findSharedContractViolations()",
-      "norm_label": "findsharedcontractviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_fixture",
-      "label": "fixture()",
-      "norm_label": "fixture()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_importsof",
-      "label": "importsOf()",
-      "norm_label": "importsof()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_iscompositionroot",
-      "label": "isCompositionRoot()",
-      "norm_label": "iscompositionroot()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_iskernelmodule",
-      "label": "isKernelModule()",
-      "norm_label": "iskernelmodule()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "importboundary_test_isruntimenativespecifier",
-      "label": "isRuntimeNativeSpecifier()",
-      "norm_label": "isruntimenativespecifier()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_importboundary_test_ts",
-      "label": "importBoundary.test.ts",
-      "norm_label": "importboundary.test.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "id": "packages_athena_webapp_convex_agentharness_readports_ts",
+      "label": "readPorts.ts",
+      "norm_label": "readports.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
       "source_location": "L1"
     },
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_agent_importboundary_test_ts",
-      "label": "importBoundary.test.ts",
-      "norm_label": "importboundary.test.ts",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L1"
+      "id": "readports_agentreadportbindingerror",
+      "label": "AgentReadPortBindingError",
+      "norm_label": "agentreadportbindingerror",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_agentreadportbindingerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_computereadresulthash",
+      "label": "computeReadResultHash()",
+      "norm_label": "computereadresulthash()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L428"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_contractviolation",
+      "label": "contractViolation()",
+      "norm_label": "contractviolation()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_createagentreadportquerydefiner",
+      "label": "createAgentReadPortQueryDefiner()",
+      "norm_label": "createagentreadportquerydefiner()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L586"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_createagentreadportregistry",
+      "label": "createAgentReadPortRegistry()",
+      "norm_label": "createagentreadportregistry()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_cursorbindingdigest",
+      "label": "cursorBindingDigest()",
+      "norm_label": "cursorbindingdigest()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_dispatchagentreadport",
+      "label": "dispatchAgentReadPort()",
+      "norm_label": "dispatchagentreadport()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_filtervaluevalid",
+      "label": "filterValueValid()",
+      "norm_label": "filtervaluevalid()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L344"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_finishagentreadenvelope",
+      "label": "finishAgentReadEnvelope()",
+      "norm_label": "finishagentreadenvelope()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_fromhex",
+      "label": "fromHex()",
+      "norm_label": "fromhex()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L298"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_functionnameof",
+      "label": "functionNameOf()",
+      "norm_label": "functionnameof()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_invalidinvocation",
+      "label": "invalidInvocation()",
+      "norm_label": "invalidinvocation()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_mintagentcursor",
+      "label": "mintAgentCursor()",
+      "norm_label": "mintagentcursor()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L315"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_refusedresponse",
+      "label": "refusedResponse()",
+      "norm_label": "refusedresponse()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_resolveagentcursor",
+      "label": "resolveAgentCursor()",
+      "norm_label": "resolveagentcursor()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L320"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_resolveagentreadporthandler",
+      "label": "resolveAgentReadPortHandler()",
+      "norm_label": "resolveagentreadporthandler()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_tohex",
+      "label": "toHex()",
+      "norm_label": "tohex()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "readports_validateagentreadrequestargs",
+      "label": "validateAgentReadRequestArgs()",
+      "norm_label": "validateagentreadrequestargs()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L363"
     },
     {
       "community": 1140,
@@ -234735,182 +234771,182 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_readports_ts",
-      "label": "readPorts.ts",
-      "norm_label": "readports.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "id": "actions_buildproviderregistry",
+      "label": "buildProviderRegistry()",
+      "norm_label": "buildproviderregistry()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L455"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_createintelligencerun",
+      "label": "createIntelligenceRun()",
+      "norm_label": "createintelligencerun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L469"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_defaultfakeoutput",
+      "label": "defaultFakeOutput()",
+      "norm_label": "defaultfakeoutput()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L653"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_failedgenerationresult",
+      "label": "failedGenerationResult()",
+      "norm_label": "failedgenerationresult()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L646"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_failrunbesteffort",
+      "label": "failRunBestEffort()",
+      "norm_label": "failrunbesteffort()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L625"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_getbundlesnapshotfields",
+      "label": "getBundleSnapshotFields()",
+      "norm_label": "getbundlesnapshotfields()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L666"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_getstoreinsightssnapshotfallback",
+      "label": "getStoreInsightsSnapshotFallback()",
+      "norm_label": "getstoreinsightssnapshotfallback()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L679"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_isactivitytrend",
+      "label": "isActivityTrend()",
+      "norm_label": "isactivitytrend()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L706"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_isdevicedistribution",
+      "label": "isDeviceDistribution()",
+      "norm_label": "isdevicedistribution()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L691"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_isinsightgenerationinprogresserror",
+      "label": "isInsightGenerationInProgressError()",
+      "norm_label": "isinsightgenerationinprogresserror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L496"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_recordproviderfailure",
+      "label": "recordProviderFailure()",
+      "norm_label": "recordproviderfailure()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L589"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_recordproviderstarted",
+      "label": "recordProviderStarted()",
+      "norm_label": "recordproviderstarted()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L551"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_recordprovidersucceeded",
+      "label": "recordProviderSucceeded()",
+      "norm_label": "recordprovidersucceeded()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L572"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_resolveproviderid",
+      "label": "resolveProviderId()",
+      "norm_label": "resolveproviderid()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L447"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_resolveprovidermodel",
+      "label": "resolveProviderModel()",
+      "norm_label": "resolveprovidermodel()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L451"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_rungeneratestoreinsights",
+      "label": "runGenerateStoreInsights()",
+      "norm_label": "rungeneratestoreinsights()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_rungenerateuserinsights",
+      "label": "runGenerateUserInsights()",
+      "norm_label": "rungenerateuserinsights()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L309"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_runstructuredprovider",
+      "label": "runStructuredProvider()",
+      "norm_label": "runstructuredprovider()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L503"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "actions_topersistedintelligenceerror",
+      "label": "toPersistedIntelligenceError()",
+      "norm_label": "topersistedintelligenceerror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L614"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_ts",
+      "label": "actions.ts",
+      "norm_label": "actions.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_agentreadportbindingerror",
-      "label": "AgentReadPortBindingError",
-      "norm_label": "agentreadportbindingerror",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_agentreadportbindingerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_computereadresulthash",
-      "label": "computeReadResultHash()",
-      "norm_label": "computereadresulthash()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L428"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_contractviolation",
-      "label": "contractViolation()",
-      "norm_label": "contractviolation()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_createagentreadportquerydefiner",
-      "label": "createAgentReadPortQueryDefiner()",
-      "norm_label": "createagentreadportquerydefiner()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L586"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_createagentreadportregistry",
-      "label": "createAgentReadPortRegistry()",
-      "norm_label": "createagentreadportregistry()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_cursorbindingdigest",
-      "label": "cursorBindingDigest()",
-      "norm_label": "cursorbindingdigest()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_dispatchagentreadport",
-      "label": "dispatchAgentReadPort()",
-      "norm_label": "dispatchagentreadport()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_filtervaluevalid",
-      "label": "filterValueValid()",
-      "norm_label": "filtervaluevalid()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_finishagentreadenvelope",
-      "label": "finishAgentReadEnvelope()",
-      "norm_label": "finishagentreadenvelope()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_fromhex",
-      "label": "fromHex()",
-      "norm_label": "fromhex()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L298"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_functionnameof",
-      "label": "functionNameOf()",
-      "norm_label": "functionnameof()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_invalidinvocation",
-      "label": "invalidInvocation()",
-      "norm_label": "invalidinvocation()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L573"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_mintagentcursor",
-      "label": "mintAgentCursor()",
-      "norm_label": "mintagentcursor()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L315"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_refusedresponse",
-      "label": "refusedResponse()",
-      "norm_label": "refusedresponse()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_resolveagentcursor",
-      "label": "resolveAgentCursor()",
-      "norm_label": "resolveagentcursor()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L320"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_resolveagentreadporthandler",
-      "label": "resolveAgentReadPortHandler()",
-      "norm_label": "resolveagentreadporthandler()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_tohex",
-      "label": "toHex()",
-      "norm_label": "tohex()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L294"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "readports_validateagentreadrequestargs",
-      "label": "validateAgentReadRequestArgs()",
-      "norm_label": "validateagentreadrequestargs()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L363"
     },
     {
       "community": 1150,
@@ -235185,182 +235221,182 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "actions_buildproviderregistry",
-      "label": "buildProviderRegistry()",
-      "norm_label": "buildproviderregistry()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L455"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_createintelligencerun",
-      "label": "createIntelligenceRun()",
-      "norm_label": "createintelligencerun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L469"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_defaultfakeoutput",
-      "label": "defaultFakeOutput()",
-      "norm_label": "defaultfakeoutput()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L653"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_failedgenerationresult",
-      "label": "failedGenerationResult()",
-      "norm_label": "failedgenerationresult()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L646"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_failrunbesteffort",
-      "label": "failRunBestEffort()",
-      "norm_label": "failrunbesteffort()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L625"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_getbundlesnapshotfields",
-      "label": "getBundleSnapshotFields()",
-      "norm_label": "getbundlesnapshotfields()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L666"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_getstoreinsightssnapshotfallback",
-      "label": "getStoreInsightsSnapshotFallback()",
-      "norm_label": "getstoreinsightssnapshotfallback()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L679"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_isactivitytrend",
-      "label": "isActivityTrend()",
-      "norm_label": "isactivitytrend()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L706"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_isdevicedistribution",
-      "label": "isDeviceDistribution()",
-      "norm_label": "isdevicedistribution()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L691"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_isinsightgenerationinprogresserror",
-      "label": "isInsightGenerationInProgressError()",
-      "norm_label": "isinsightgenerationinprogresserror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L496"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_recordproviderfailure",
-      "label": "recordProviderFailure()",
-      "norm_label": "recordproviderfailure()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L589"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_recordproviderstarted",
-      "label": "recordProviderStarted()",
-      "norm_label": "recordproviderstarted()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L551"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_recordprovidersucceeded",
-      "label": "recordProviderSucceeded()",
-      "norm_label": "recordprovidersucceeded()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L572"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_resolveproviderid",
-      "label": "resolveProviderId()",
-      "norm_label": "resolveproviderid()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L447"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_resolveprovidermodel",
-      "label": "resolveProviderModel()",
-      "norm_label": "resolveprovidermodel()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L451"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_rungeneratestoreinsights",
-      "label": "runGenerateStoreInsights()",
-      "norm_label": "rungeneratestoreinsights()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_rungenerateuserinsights",
-      "label": "runGenerateUserInsights()",
-      "norm_label": "rungenerateuserinsights()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_runstructuredprovider",
-      "label": "runStructuredProvider()",
-      "norm_label": "runstructuredprovider()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L503"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "actions_topersistedintelligenceerror",
-      "label": "toPersistedIntelligenceError()",
-      "norm_label": "topersistedintelligenceerror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L614"
-    },
-    {
-      "community": 116,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_ts",
-      "label": "actions.ts",
-      "norm_label": "actions.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sync_registersessionsyncreview_ts",
+      "label": "registerSessionSyncReview.ts",
+      "norm_label": "registersessionsyncreview.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_arraydetail",
+      "label": "arrayDetail()",
+      "norm_label": "arraydetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L423"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_buildinventoryreviewdetail",
+      "label": "buildInventoryReviewDetail()",
+      "norm_label": "buildinventoryreviewdetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L431"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_buildregistersessionlocalsyncstatus",
+      "label": "buildRegisterSessionLocalSyncStatus()",
+      "norm_label": "buildregistersessionlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L768"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_buildsyncsalesummary",
+      "label": "buildSyncSaleSummary()",
+      "norm_label": "buildsyncsalesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L487"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_classifyregistersessionsyncreview",
+      "label": "classifyRegisterSessionSyncReview()",
+      "norm_label": "classifyregistersessionsyncreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_findprojectedregistersessionidforrepairablemissingmapping",
+      "label": "findProjectedRegisterSessionIdForRepairableMissingMapping()",
+      "norm_label": "findprojectedregistersessionidforrepairablemissingmapping()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_findtransactionidforsyncevent",
+      "label": "findTransactionIdForSyncEvent()",
+      "norm_label": "findtransactionidforsyncevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L536"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_getsyncconflictreconciliationtype",
+      "label": "getSyncConflictReconciliationType()",
+      "norm_label": "getsyncconflictreconciliationtype()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_hasinventoryreviewworkitemforprojectedsale",
+      "label": "hasInventoryReviewWorkItemForProjectedSale()",
+      "norm_label": "hasinventoryreviewworkitemforprojectedsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L313"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_isnonsalemissingregistersessionmappingconflict",
+      "label": "isNonSaleMissingRegisterSessionMappingConflict()",
+      "norm_label": "isnonsalemissingregistersessionmappingconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersession",
+      "label": "listOpenLocalSyncConflictsByRegisterSession()",
+      "norm_label": "listopenlocalsyncconflictsbyregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L1159"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersessionwithcompleteness",
+      "label": "listOpenLocalSyncConflictsByRegisterSessionWithCompleteness()",
+      "norm_label": "listopenlocalsyncconflictsbyregistersessionwithcompleteness()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L820"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_listtargetregistersessionsyncfacts",
+      "label": "listTargetRegisterSessionSyncFacts()",
+      "norm_label": "listtargetregistersessionsyncfacts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L641"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_numberdetail",
+      "label": "numberDetail()",
+      "norm_label": "numberdetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_recorddetail",
+      "label": "recordDetail()",
+      "norm_label": "recorddetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L417"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_stringdetail",
+      "label": "stringDetail()",
+      "norm_label": "stringdetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L298"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_summarizesaleitems",
+      "label": "summarizeSaleItems()",
+      "norm_label": "summarizesaleitems()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L456"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_syncconflicteventkey",
+      "label": "syncConflictEventKey()",
+      "norm_label": "syncconflicteventkey()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 116,
+      "file_type": "code",
+      "id": "registersessionsyncreview_uniquebyid",
+      "label": "uniqueById()",
+      "norm_label": "uniquebyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L632"
     },
     {
       "community": 1160,
@@ -235635,182 +235671,182 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_registersessionsyncreview_ts",
-      "label": "registerSessionSyncReview.ts",
-      "norm_label": "registersessionsyncreview.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationsweep_test_ts",
+      "label": "verificationSweep.test.ts",
+      "norm_label": "verificationsweep.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
       "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_arraydetail",
-      "label": "arrayDetail()",
-      "norm_label": "arraydetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L423"
+      "id": "verificationsweep_test_allowlist",
+      "label": "allowlist()",
+      "norm_label": "allowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L75"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_buildinventoryreviewdetail",
-      "label": "buildInventoryReviewDetail()",
-      "norm_label": "buildinventoryreviewdetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L431"
+      "id": "verificationsweep_test_expecteddedupekey",
+      "label": "expectedDedupeKey()",
+      "norm_label": "expecteddedupekey()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L228"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_buildregistersessionlocalsyncstatus",
-      "label": "buildRegisterSessionLocalSyncStatus()",
-      "norm_label": "buildregistersessionlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L768"
+      "id": "verificationsweep_test_insertexcludedfact",
+      "label": "insertExcludedFact()",
+      "norm_label": "insertexcludedfact()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L275"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_buildsyncsalesummary",
-      "label": "buildSyncSaleSummary()",
-      "norm_label": "buildsyncsalesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L487"
+      "id": "verificationsweep_test_insertreportday",
+      "label": "insertReportDay()",
+      "norm_label": "insertreportday()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L112"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_classifyregistersessionsyncreview",
-      "label": "classifyRegisterSessionSyncReview()",
-      "norm_label": "classifyregistersessionsyncreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L151"
+      "id": "verificationsweep_test_insertvoidfact",
+      "label": "insertVoidFact()",
+      "norm_label": "insertvoidfact()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L247"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_findprojectedregistersessionidforrepairablemissingmapping",
-      "label": "findProjectedRegisterSessionIdForRepairableMissingMapping()",
-      "norm_label": "findprojectedregistersessionidforrepairablemissingmapping()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L573"
+      "id": "verificationsweep_test_metrics",
+      "label": "metrics()",
+      "norm_label": "metrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1630"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_findtransactionidforsyncevent",
-      "label": "findTransactionIdForSyncEvent()",
-      "norm_label": "findtransactionidforsyncevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L536"
+      "id": "verificationsweep_test_missingdayresult",
+      "label": "missingDayResult()",
+      "norm_label": "missingdayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1664"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_getsyncconflictreconciliationtype",
-      "label": "getSyncConflictReconciliationType()",
-      "norm_label": "getsyncconflictreconciliationtype()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L128"
+      "id": "verificationsweep_test_notificationintentsfor",
+      "label": "notificationIntentsFor()",
+      "norm_label": "notificationintentsfor()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L211"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_hasinventoryreviewworkitemforprojectedsale",
-      "label": "hasInventoryReviewWorkItemForProjectedSale()",
-      "norm_label": "hasinventoryreviewworkitemforprojectedsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L313"
+      "id": "verificationsweep_test_operationaleventsfor",
+      "label": "operationalEventsFor()",
+      "norm_label": "operationaleventsfor()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L193"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_isnonsalemissingregistersessionmappingconflict",
-      "label": "isNonSaleMissingRegisterSessionMappingConflict()",
-      "norm_label": "isnonsalemissingregistersessionmappingconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L391"
+      "id": "verificationsweep_test_patchday",
+      "label": "patchDay()",
+      "norm_label": "patchday()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L156"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersession",
-      "label": "listOpenLocalSyncConflictsByRegisterSession()",
-      "norm_label": "listopenlocalsyncconflictsbyregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L1159"
+      "id": "verificationsweep_test_posture",
+      "label": "posture()",
+      "norm_label": "posture()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1644"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersessionwithcompleteness",
-      "label": "listOpenLocalSyncConflictsByRegisterSessionWithCompleteness()",
-      "norm_label": "listopenlocalsyncconflictsbyregistersessionwithcompleteness()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L820"
+      "id": "verificationsweep_test_runrow",
+      "label": "runRow()",
+      "norm_label": "runrow()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L174"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_listtargetregistersessionsyncfacts",
-      "label": "listTargetRegisterSessionSyncFacts()",
-      "norm_label": "listtargetregistersessionsyncfacts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L641"
+      "id": "verificationsweep_test_seedfleet",
+      "label": "seedFleet()",
+      "norm_label": "seedfleet()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1736"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_numberdetail",
-      "label": "numberDetail()",
-      "norm_label": "numberdetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L289"
+      "id": "verificationsweep_test_seedstorewithday",
+      "label": "seedStoreWithDay()",
+      "norm_label": "seedstorewithday()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L309"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_recorddetail",
-      "label": "recordDetail()",
-      "norm_label": "recorddetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L417"
+      "id": "verificationsweep_test_seedweekcurrent",
+      "label": "seedWeekCurrent()",
+      "norm_label": "seedweekcurrent()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L885"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_stringdetail",
-      "label": "stringDetail()",
-      "norm_label": "stringdetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L298"
+      "id": "verificationsweep_test_seedweeklystore",
+      "label": "seedWeeklyStore()",
+      "norm_label": "seedweeklystore()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L2172"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_summarizesaleitems",
-      "label": "summarizeSaleItems()",
-      "norm_label": "summarizesaleitems()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L456"
+      "id": "verificationsweep_test_sweepctx",
+      "label": "sweepCtx()",
+      "norm_label": "sweepctx()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L84"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_syncconflicteventkey",
-      "label": "syncConflictEventKey()",
-      "norm_label": "syncconflicteventkey()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L307"
+      "id": "verificationsweep_test_verifiedats",
+      "label": "verifiedAts()",
+      "norm_label": "verifiedats()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1400"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "registersessionsyncreview_uniquebyid",
-      "label": "uniqueById()",
-      "norm_label": "uniquebyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L632"
+      "id": "verificationsweep_test_windowsoverticks",
+      "label": "windowsOverTicks()",
+      "norm_label": "windowsoverticks()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1764"
     },
     {
       "community": 1170,
@@ -236085,182 +236121,182 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationsweep_test_ts",
-      "label": "verificationSweep.test.ts",
-      "norm_label": "verificationsweep.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
+      "label": "weekly.test.ts",
+      "norm_label": "weekly.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
       "source_location": "L1"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_allowlist",
-      "label": "allowlist()",
-      "norm_label": "allowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L75"
+      "id": "weekly_test_baselineof",
+      "label": "baselineOf()",
+      "norm_label": "baselineof()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L1009"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_expecteddedupekey",
-      "label": "expectedDedupeKey()",
-      "norm_label": "expecteddedupekey()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L228"
+      "id": "weekly_test_cashonlymix",
+      "label": "cashOnlyMix()",
+      "norm_label": "cashonlymix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L983"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_insertexcludedfact",
-      "label": "insertExcludedFact()",
-      "norm_label": "insertexcludedfact()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L275"
+      "id": "weekly_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L136"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_insertreportday",
-      "label": "insertReportDay()",
-      "norm_label": "insertreportday()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L112"
+      "id": "weekly_test_fact",
+      "label": "fact()",
+      "norm_label": "fact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L169"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_insertvoidfact",
-      "label": "insertVoidFact()",
-      "norm_label": "insertvoidfact()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L247"
+      "id": "weekly_test_insertcompletedclose",
+      "label": "insertCompletedClose()",
+      "norm_label": "insertcompletedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L502"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_metrics",
-      "label": "metrics()",
-      "norm_label": "metrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1630"
+      "id": "weekly_test_insertfact",
+      "label": "insertFact()",
+      "norm_label": "insertfact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L473"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_missingdayresult",
-      "label": "missingDayResult()",
-      "norm_label": "missingdayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1664"
+      "id": "weekly_test_insertfoldedcloseday",
+      "label": "insertFoldedCloseDay()",
+      "norm_label": "insertfoldedcloseday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L582"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_notificationintentsfor",
-      "label": "notificationIntentsFor()",
-      "norm_label": "notificationintentsfor()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L211"
+      "id": "weekly_test_inserthistoricalweekdays",
+      "label": "insertHistoricalWeekDays()",
+      "norm_label": "inserthistoricalweekdays()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L610"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_operationaleventsfor",
-      "label": "operationalEventsFor()",
-      "norm_label": "operationaleventsfor()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L193"
+      "id": "weekly_test_lanemix",
+      "label": "laneMix()",
+      "norm_label": "lanemix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L1349"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_patchday",
-      "label": "patchDay()",
-      "norm_label": "patchday()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L156"
+      "id": "weekly_test_linkclosetoday",
+      "label": "linkCloseToDay()",
+      "norm_label": "linkclosetoday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3650"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_posture",
-      "label": "posture()",
-      "norm_label": "posture()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1644"
+      "id": "weekly_test_mix",
+      "label": "mix()",
+      "norm_label": "mix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L287"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_runrow",
-      "label": "runRow()",
-      "norm_label": "runrow()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L174"
+      "id": "weekly_test_patchscheduleexceptions",
+      "label": "patchScheduleExceptions()",
+      "norm_label": "patchscheduleexceptions()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3629"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_seedfleet",
-      "label": "seedFleet()",
-      "norm_label": "seedfleet()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1736"
+      "id": "weekly_test_period",
+      "label": "period()",
+      "norm_label": "period()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L118"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_seedstorewithday",
-      "label": "seedStoreWithDay()",
-      "norm_label": "seedstorewithday()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L309"
+      "id": "weekly_test_readbaseline",
+      "label": "readBaseline()",
+      "norm_label": "readbaseline()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3140"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_seedweekcurrent",
-      "label": "seedWeekCurrent()",
-      "norm_label": "seedweekcurrent()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L885"
+      "id": "weekly_test_readweekmark",
+      "label": "readWeekMark()",
+      "norm_label": "readweekmark()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3131"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_seedweeklystore",
-      "label": "seedWeeklyStore()",
-      "norm_label": "seedweeklystore()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L2172"
+      "id": "weekly_test_receipt",
+      "label": "receipt()",
+      "norm_label": "receipt()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L916"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_sweepctx",
-      "label": "sweepCtx()",
-      "norm_label": "sweepctx()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L84"
+      "id": "weekly_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L434"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_verifiedats",
-      "label": "verifiedAts()",
-      "norm_label": "verifiedats()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1400"
+      "id": "weekly_test_seteverydaymix",
+      "label": "setEveryDayMix()",
+      "norm_label": "seteverydaymix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L1356"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "verificationsweep_test_windowsoverticks",
-      "label": "windowsOverTicks()",
-      "norm_label": "windowsoverticks()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1764"
+      "id": "weekly_test_withcloses",
+      "label": "withCloses()",
+      "norm_label": "withcloses()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L635"
     },
     {
       "community": 1180,
@@ -236535,182 +236571,182 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
-      "label": "weekly.test.ts",
-      "norm_label": "weekly.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "id": "packages_athena_webapp_convex_shareddemo_provision_ts",
+      "label": "provision.ts",
+      "norm_label": "provision.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
       "source_location": "L1"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_baselineof",
-      "label": "baselineOf()",
-      "norm_label": "baselineof()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L1009"
+      "id": "provision_buildshareddemocontinuitymigrationstatepatch",
+      "label": "buildSharedDemoContinuityMigrationStatePatch()",
+      "norm_label": "buildshareddemocontinuitymigrationstatepatch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L125"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_cashonlymix",
-      "label": "cashOnlyMix()",
-      "norm_label": "cashonlymix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L983"
+      "id": "provision_ensuredemocredentialwithctx",
+      "label": "ensureDemoCredentialWithCtx()",
+      "norm_label": "ensuredemocredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L481"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L136"
+      "id": "provision_ensuredemoroleassignmentwithctx",
+      "label": "ensureDemoRoleAssignmentWithCtx()",
+      "norm_label": "ensuredemoroleassignmentwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L441"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_fact",
-      "label": "fact()",
-      "norm_label": "fact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L169"
+      "id": "provision_ensuredemostaffaccesswithctx",
+      "label": "ensureDemoStaffAccessWithCtx()",
+      "norm_label": "ensuredemostaffaccesswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L518"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_insertcompletedclose",
-      "label": "insertCompletedClose()",
-      "norm_label": "insertcompletedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L502"
+      "id": "provision_ensureshareddemoregisterfoundationwithctx",
+      "label": "ensureSharedDemoRegisterFoundationWithCtx()",
+      "norm_label": "ensureshareddemoregisterfoundationwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L980"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_insertfact",
-      "label": "insertFact()",
-      "norm_label": "insertfact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L473"
+      "id": "provision_ensureshareddemoseededterminalwithctx",
+      "label": "ensureSharedDemoSeededTerminalWithCtx()",
+      "norm_label": "ensureshareddemoseededterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L864"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_insertfoldedcloseday",
-      "label": "insertFoldedCloseDay()",
-      "norm_label": "insertfoldedcloseday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L582"
+      "id": "provision_migrateshareddemostorywithctx",
+      "label": "migrateSharedDemoStoryWithCtx()",
+      "norm_label": "migrateshareddemostorywithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L714"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_inserthistoricalweekdays",
-      "label": "insertHistoricalWeekDays()",
-      "norm_label": "inserthistoricalweekdays()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L610"
+      "id": "provision_planshareddemomigration",
+      "label": "planSharedDemoMigration()",
+      "norm_label": "planshareddemomigration()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L91"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_lanemix",
-      "label": "laneMix()",
-      "norm_label": "lanemix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L1349"
+      "id": "provision_reconcileshareddemocatalogwithctx",
+      "label": "reconcileSharedDemoCatalogWithCtx()",
+      "norm_label": "reconcileshareddemocatalogwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L583"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_linkclosetoday",
-      "label": "linkCloseToDay()",
-      "norm_label": "linkclosetoday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3650"
+      "id": "provision_repairshareddemoseededterminalbindingwithctx",
+      "label": "repairSharedDemoSeededTerminalBindingWithCtx()",
+      "norm_label": "repairshareddemoseededterminalbindingwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L926"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_mix",
-      "label": "mix()",
-      "norm_label": "mix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L287"
+      "id": "provision_shareddemobootstrapseedmatches",
+      "label": "sharedDemoBootstrapSeedMatches()",
+      "norm_label": "shareddemobootstrapseedmatches()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L245"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_patchscheduleexceptions",
-      "label": "patchScheduleExceptions()",
-      "norm_label": "patchscheduleexceptions()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3629"
+      "id": "provision_shareddemocheckoutsessionmatchesorder",
+      "label": "sharedDemoCheckoutSessionMatchesOrder()",
+      "norm_label": "shareddemocheckoutsessionmatchesorder()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L420"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_period",
-      "label": "period()",
-      "norm_label": "period()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L118"
+      "id": "provision_shareddemomigrationskiptables",
+      "label": "sharedDemoMigrationSkipTables()",
+      "norm_label": "shareddemomigrationskiptables()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L84"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_readbaseline",
-      "label": "readBaseline()",
-      "norm_label": "readbaseline()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3140"
+      "id": "provision_shareddemopristinetablecountsmatch",
+      "label": "sharedDemoPristineTableCountsMatch()",
+      "norm_label": "shareddemopristinetablecountsmatch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L405"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_readweekmark",
-      "label": "readWeekMark()",
-      "norm_label": "readweekmark()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3131"
+      "id": "provision_shareddemoproductimages",
+      "label": "sharedDemoProductImages()",
+      "norm_label": "shareddemoproductimages()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L430"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_receipt",
-      "label": "receipt()",
-      "norm_label": "receipt()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L916"
+      "id": "provision_transformshareddemocatalogimagebaselinedocument",
+      "label": "transformSharedDemoCatalogImageBaselineDocument()",
+      "norm_label": "transformshareddemocatalogimagebaselinedocument()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L178"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L434"
+      "id": "provision_transformshareddemopickuporderbaselinedocument",
+      "label": "transformSharedDemoPickupOrderBaselineDocument()",
+      "norm_label": "transformshareddemopickuporderbaselinedocument()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L202"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_seteverydaymix",
-      "label": "setEveryDayMix()",
-      "norm_label": "seteverydaymix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L1356"
+      "id": "provision_transformshareddemostaffstorybaselinedocument",
+      "label": "transformSharedDemoStaffStoryBaselineDocument()",
+      "norm_label": "transformshareddemostaffstorybaselinedocument()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L132"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "weekly_test_withcloses",
-      "label": "withCloses()",
-      "norm_label": "withcloses()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L635"
+      "id": "provision_validateshareddemoseed",
+      "label": "validateSharedDemoSeed()",
+      "norm_label": "validateshareddemoseed()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L235"
     },
     {
       "community": 1190,
@@ -237426,182 +237462,182 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_provision_ts",
-      "label": "provision.ts",
-      "norm_label": "provision.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L1"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_buildshareddemocontinuitymigrationstatepatch",
-      "label": "buildSharedDemoContinuityMigrationStatePatch()",
-      "norm_label": "buildshareddemocontinuitymigrationstatepatch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L125"
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L103"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_ensuredemocredentialwithctx",
-      "label": "ensureDemoCredentialWithCtx()",
-      "norm_label": "ensuredemocredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L481"
+      "id": "replenishment_buildskucontinuitycontextbyid",
+      "label": "buildSkuContinuityContextById()",
+      "norm_label": "buildskucontinuitycontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L339"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_ensuredemoroleassignmentwithctx",
-      "label": "ensureDemoRoleAssignmentWithCtx()",
-      "norm_label": "ensuredemoroleassignmentwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L441"
+      "id": "replenishment_derivecontinuitystatus",
+      "label": "deriveContinuityStatus()",
+      "norm_label": "derivecontinuitystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L493"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_ensuredemostaffaccesswithctx",
-      "label": "ensureDemoStaffAccessWithCtx()",
-      "norm_label": "ensuredemostaffaccesswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L518"
+      "id": "replenishment_deriverecommendationstatus",
+      "label": "deriveRecommendationStatus()",
+      "norm_label": "deriverecommendationstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L482"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_ensureshareddemoregisterfoundationwithctx",
-      "label": "ensureSharedDemoRegisterFoundationWithCtx()",
-      "norm_label": "ensureshareddemoregisterfoundationwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L980"
+      "id": "replenishment_getcontinuitystatusrank",
+      "label": "getContinuityStatusRank()",
+      "norm_label": "getcontinuitystatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L78"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_ensureshareddemoseededterminalwithctx",
-      "label": "ensureSharedDemoSeededTerminalWithCtx()",
-      "norm_label": "ensureshareddemoseededterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L864"
+      "id": "replenishment_getplannedactionat",
+      "label": "getPlannedActionAt()",
+      "norm_label": "getplannedactionat()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L265"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_migrateshareddemostorywithctx",
-      "label": "migrateSharedDemoStoryWithCtx()",
-      "norm_label": "migrateshareddemostorywithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L714"
+      "id": "replenishment_getstartofcurrentday",
+      "label": "getStartOfCurrentDay()",
+      "norm_label": "getstartofcurrentday()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L277"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_planshareddemomigration",
-      "label": "planSharedDemoMigration()",
-      "norm_label": "planshareddemomigration()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L91"
+      "id": "replenishment_haslateinbound",
+      "label": "hasLateInbound()",
+      "norm_label": "haslateinbound()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L295"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_reconcileshareddemocatalogwithctx",
-      "label": "reconcileSharedDemoCatalogWithCtx()",
-      "norm_label": "reconcileshareddemocatalogwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L583"
+      "id": "replenishment_hasrelatedpurchaseordercontext",
+      "label": "hasRelatedPurchaseOrderContext()",
+      "norm_label": "hasrelatedpurchaseordercontext()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L473"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_repairshareddemoseededterminalbindingwithctx",
-      "label": "repairSharedDemoSeededTerminalBindingWithCtx()",
-      "norm_label": "repairshareddemoseededterminalbindingwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L926"
+      "id": "replenishment_hasstaleplannedaction",
+      "label": "hasStalePlannedAction()",
+      "norm_label": "hasstaleplannedaction()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L287"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_shareddemobootstrapseedmatches",
-      "label": "sharedDemoBootstrapSeedMatches()",
-      "norm_label": "shareddemobootstrapseedmatches()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L245"
+      "id": "replenishment_isinboundstatus",
+      "label": "isInboundStatus()",
+      "norm_label": "isinboundstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L259"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_shareddemocheckoutsessionmatchesorder",
-      "label": "sharedDemoCheckoutSessionMatchesOrder()",
-      "norm_label": "shareddemocheckoutsessionmatchesorder()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L420"
+      "id": "replenishment_isplannedstatus",
+      "label": "isPlannedStatus()",
+      "norm_label": "isplannedstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L253"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_shareddemomigrationskiptables",
-      "label": "sharedDemoMigrationSkipTables()",
-      "norm_label": "shareddemomigrationskiptables()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L84"
+      "id": "replenishment_listactivestorevendors",
+      "label": "listActiveStoreVendors()",
+      "norm_label": "listactivestorevendors()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L210"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_shareddemopristinetablecountsmatch",
-      "label": "sharedDemoPristineTableCountsMatch()",
-      "norm_label": "shareddemopristinetablecountsmatch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L405"
+      "id": "replenishment_listboundedreplenishmentrecommendationswithctx",
+      "label": "listBoundedReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listboundedreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L572"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_shareddemoproductimages",
-      "label": "sharedDemoProductImages()",
-      "norm_label": "shareddemoproductimages()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L430"
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L229"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_transformshareddemocatalogimagebaselinedocument",
-      "label": "transformSharedDemoCatalogImageBaselineDocument()",
-      "norm_label": "transformshareddemocatalogimagebaselinedocument()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L178"
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L550"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_transformshareddemopickuporderbaselinedocument",
-      "label": "transformSharedDemoPickupOrderBaselineDocument()",
-      "norm_label": "transformshareddemopickuporderbaselinedocument()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L202"
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L153"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_transformshareddemostaffstorybaselinedocument",
-      "label": "transformSharedDemoStaffStoryBaselineDocument()",
-      "norm_label": "transformshareddemostaffstorybaselinedocument()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L132"
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L183"
     },
     {
       "community": 120,
       "file_type": "code",
-      "id": "provision_validateshareddemoseed",
-      "label": "validateSharedDemoSeed()",
-      "norm_label": "validateshareddemoseed()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L235"
+      "id": "replenishment_sortpurchaseordercontexts",
+      "label": "sortPurchaseOrderContexts()",
+      "norm_label": "sortpurchaseordercontexts()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L306"
     },
     {
       "community": 1200,
@@ -237876,182 +237912,182 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "athenaagentpresentationadapter_composeathenathreadkey",
+      "label": "composeAthenaThreadKey()",
+      "norm_label": "composeathenathreadkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenacontext",
+      "label": "describeAthenaContext()",
+      "norm_label": "describeathenacontext()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenadenial",
+      "label": "describeAthenaDenial()",
+      "norm_label": "describeathenadenial()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L324"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenafailure",
+      "label": "describeAthenaFailure()",
+      "norm_label": "describeathenafailure()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L503"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenamilestone",
+      "label": "describeAthenaMilestone()",
+      "norm_label": "describeathenamilestone()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L532"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenaprovisionalcue",
+      "label": "describeAthenaProvisionalCue()",
+      "norm_label": "describeathenaprovisionalcue()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L548"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenaprovisionaltimelineempty",
+      "label": "describeAthenaProvisionalTimelineEmpty()",
+      "norm_label": "describeathenaprovisionaltimelineempty()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenashortenednotice",
+      "label": "describeAthenaShortenedNotice()",
+      "norm_label": "describeathenashortenednotice()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenatrailunavailable",
+      "label": "describeAthenaTrailUnavailable()",
+      "norm_label": "describeathenatrailunavailable()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L390"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenaunavailable",
+      "label": "describeAthenaUnavailable()",
+      "norm_label": "describeathenaunavailable()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L401"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeprovisionalwithdrawal",
+      "label": "describeProvisionalWithdrawal()",
+      "norm_label": "describeprovisionalwithdrawal()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L605"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_displayvalueforcontextkey",
+      "label": "displayValueForContextKey()",
+      "norm_label": "displayvalueforcontextkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_encodethreadkey",
+      "label": "encodeThreadKey()",
+      "norm_label": "encodethreadkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_hashtoken",
+      "label": "hashToken()",
+      "norm_label": "hashtoken()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_isthreadkeysafecharacter",
+      "label": "isThreadKeySafeCharacter()",
+      "norm_label": "isthreadkeysafecharacter()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_labelforcontextkey",
+      "label": "labelForContextKey()",
+      "norm_label": "labelforcontextkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_resolveathenasourcelink",
+      "label": "resolveAthenaSourceLink()",
+      "norm_label": "resolveathenasourcelink()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_snapshotathenacontext",
+      "label": "snapshotAthenaContext()",
+      "norm_label": "snapshotathenacontext()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_truncatetobytes",
+      "label": "truncateToBytes()",
+      "norm_label": "truncatetobytes()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 121,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_agent_athenaagentpresentationadapter_ts",
+      "label": "AthenaAgentPresentationAdapter.ts",
+      "norm_label": "athenaagentpresentationadapter.ts",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_buildskucontinuitycontextbyid",
-      "label": "buildSkuContinuityContextById()",
-      "norm_label": "buildskucontinuitycontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_derivecontinuitystatus",
-      "label": "deriveContinuityStatus()",
-      "norm_label": "derivecontinuitystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L493"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_deriverecommendationstatus",
-      "label": "deriveRecommendationStatus()",
-      "norm_label": "deriverecommendationstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L482"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_getcontinuitystatusrank",
-      "label": "getContinuityStatusRank()",
-      "norm_label": "getcontinuitystatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_getplannedactionat",
-      "label": "getPlannedActionAt()",
-      "norm_label": "getplannedactionat()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_getstartofcurrentday",
-      "label": "getStartOfCurrentDay()",
-      "norm_label": "getstartofcurrentday()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_haslateinbound",
-      "label": "hasLateInbound()",
-      "norm_label": "haslateinbound()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_hasrelatedpurchaseordercontext",
-      "label": "hasRelatedPurchaseOrderContext()",
-      "norm_label": "hasrelatedpurchaseordercontext()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_hasstaleplannedaction",
-      "label": "hasStalePlannedAction()",
-      "norm_label": "hasstaleplannedaction()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_isinboundstatus",
-      "label": "isInboundStatus()",
-      "norm_label": "isinboundstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_isplannedstatus",
-      "label": "isPlannedStatus()",
-      "norm_label": "isplannedstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_listactivestorevendors",
-      "label": "listActiveStoreVendors()",
-      "norm_label": "listactivestorevendors()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_listboundedreplenishmentrecommendationswithctx",
-      "label": "listBoundedReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listboundedreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L572"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L550"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 121,
-      "file_type": "code",
-      "id": "replenishment_sortpurchaseordercontexts",
-      "label": "sortPurchaseOrderContexts()",
-      "norm_label": "sortpurchaseordercontexts()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L306"
     },
     {
       "community": 1210,
@@ -238326,181 +238362,181 @@
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_composeathenathreadkey",
-      "label": "composeAthenaThreadKey()",
-      "norm_label": "composeathenathreadkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L85"
+      "id": "importboundary_test_collectsources",
+      "label": "collectSources()",
+      "norm_label": "collectsources()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L30"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenacontext",
-      "label": "describeAthenaContext()",
-      "norm_label": "describeathenacontext()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L126"
+      "id": "importboundary_test_finddisallowedimports",
+      "label": "findDisallowedImports()",
+      "norm_label": "finddisallowedimports()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L102"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenadenial",
-      "label": "describeAthenaDenial()",
-      "norm_label": "describeathenadenial()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L324"
+      "id": "importboundary_test_findindirectcomponentmountviolations",
+      "label": "findIndirectComponentMountViolations()",
+      "norm_label": "findindirectcomponentmountviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L273"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenafailure",
-      "label": "describeAthenaFailure()",
-      "norm_label": "describeathenafailure()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L503"
+      "id": "importboundary_test_findkernelimportviolations",
+      "label": "findKernelImportViolations()",
+      "norm_label": "findkernelimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L144"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenamilestone",
-      "label": "describeAthenaMilestone()",
-      "norm_label": "describeathenamilestone()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L532"
+      "id": "importboundary_test_findleafimportviolations",
+      "label": "findLeafImportViolations()",
+      "norm_label": "findleafimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L191"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenaprovisionalcue",
-      "label": "describeAthenaProvisionalCue()",
-      "norm_label": "describeathenaprovisionalcue()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L548"
+      "id": "importboundary_test_findproductsurfaceimports",
+      "label": "findProductSurfaceImports()",
+      "norm_label": "findproductsurfaceimports()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L116"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenaprovisionaltimelineempty",
-      "label": "describeAthenaProvisionalTimelineEmpty()",
-      "norm_label": "describeathenaprovisionaltimelineempty()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L553"
+      "id": "importboundary_test_findprofileimportviolations",
+      "label": "findProfileImportViolations()",
+      "norm_label": "findprofileimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L338"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenashortenednotice",
-      "label": "describeAthenaShortenedNotice()",
-      "norm_label": "describeathenashortenednotice()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L558"
+      "id": "importboundary_test_findregistrationshimviolations",
+      "label": "findRegistrationShimViolations()",
+      "norm_label": "findregistrationshimviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L264"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenatrailunavailable",
-      "label": "describeAthenaTrailUnavailable()",
-      "norm_label": "describeathenatrailunavailable()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L390"
+      "id": "importboundary_test_findrootconvexconfigviolations",
+      "label": "findRootConvexConfigViolations()",
+      "norm_label": "findrootconvexconfigviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L251"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenaunavailable",
-      "label": "describeAthenaUnavailable()",
-      "norm_label": "describeathenaunavailable()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L401"
+      "id": "importboundary_test_findruntimenativeidentifierviolations",
+      "label": "findRuntimeNativeIdentifierViolations()",
+      "norm_label": "findruntimenativeidentifierviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L286"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeprovisionalwithdrawal",
-      "label": "describeProvisionalWithdrawal()",
-      "norm_label": "describeprovisionalwithdrawal()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L605"
+      "id": "importboundary_test_findruntimenativeimportviolations",
+      "label": "findRuntimeNativeImportViolations()",
+      "norm_label": "findruntimenativeimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L237"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_displayvalueforcontextkey",
-      "label": "displayValueForContextKey()",
-      "norm_label": "displayvalueforcontextkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L119"
+      "id": "importboundary_test_findruntimenativeviolations",
+      "label": "findRuntimeNativeViolations()",
+      "norm_label": "findruntimenativeviolations()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L128"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_encodethreadkey",
-      "label": "encodeThreadKey()",
-      "norm_label": "encodethreadkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L64"
+      "id": "importboundary_test_findsharedcontractviolations",
+      "label": "findSharedContractViolations()",
+      "norm_label": "findsharedcontractviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L305"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_hashtoken",
-      "label": "hashToken()",
-      "norm_label": "hashtoken()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L50"
+      "id": "importboundary_test_fixture",
+      "label": "fixture()",
+      "norm_label": "fixture()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L358"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_isthreadkeysafecharacter",
-      "label": "isThreadKeySafeCharacter()",
-      "norm_label": "isthreadkeysafecharacter()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "id": "importboundary_test_importsof",
+      "label": "importsOf()",
+      "norm_label": "importsof()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
       "source_location": "L46"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_labelforcontextkey",
-      "label": "labelForContextKey()",
-      "norm_label": "labelforcontextkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L112"
+      "id": "importboundary_test_iscompositionroot",
+      "label": "isCompositionRoot()",
+      "norm_label": "iscompositionroot()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L126"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_resolveathenasourcelink",
-      "label": "resolveAthenaSourceLink()",
-      "norm_label": "resolveathenasourcelink()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L214"
+      "id": "importboundary_test_iskernelmodule",
+      "label": "isKernelModule()",
+      "norm_label": "iskernelmodule()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L130"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_snapshotathenacontext",
-      "label": "snapshotAthenaContext()",
-      "norm_label": "snapshotathenacontext()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L168"
+      "id": "importboundary_test_isruntimenativespecifier",
+      "label": "isRuntimeNativeSpecifier()",
+      "norm_label": "isruntimenativespecifier()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L233"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_truncatetobytes",
-      "label": "truncateToBytes()",
-      "norm_label": "truncatetobytes()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L154"
+      "id": "packages_athena_webapp_convex_agentharness_importboundary_test_ts",
+      "label": "importBoundary.test.ts",
+      "norm_label": "importboundary.test.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 122,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_agent_athenaagentpresentationadapter_ts",
-      "label": "AthenaAgentPresentationAdapter.ts",
-      "norm_label": "athenaagentpresentationadapter.ts",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "id": "packages_athena_webapp_src_components_agent_importboundary_test_ts",
+      "label": "importBoundary.test.ts",
+      "norm_label": "importboundary.test.ts",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
       "source_location": "L1"
     },
     {
@@ -310911,330 +310947,6 @@
     {
       "community": 401,
       "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
-      "label": "applyAcceptedControlResult()",
-      "norm_label": "applyacceptedcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L84"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applykeyevent",
-      "label": "applyKeyEvent()",
-      "norm_label": "applykeyevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L155"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applypointerevent",
-      "label": "applyPointerEvent()",
-      "norm_label": "applypointerevent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
-      "label": "applyRemoteAssistControlIntent()",
-      "norm_label": "applyremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L17"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
-      "label": "getRecentControlResult()",
-      "norm_label": "getrecentcontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L95"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
-      "label": "getRemoteAssistControlTarget()",
-      "norm_label": "getremoteassistcontroltarget()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L145"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
-      "label": "prepareRemoteAssistControlIntent()",
-      "norm_label": "prepareremoteassistcontrolintent()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "applyremoteassistcontrolintent_remembercontrolresult",
-      "label": "rememberControlResult()",
-      "norm_label": "remembercontrolresult()",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 401,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
-      "label": "applyRemoteAssistControlIntent.ts",
-      "norm_label": "applyremoteassistcontrolintent.ts",
-      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
-      "label": "posOfflineReadiness.ts",
-      "norm_label": "posofflinereadiness.ts",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildposofflinereadinesssummary",
-      "label": "buildPosOfflineReadinessSummary()",
-      "norm_label": "buildposofflinereadinesssummary()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L152"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_buildsignal",
-      "label": "buildSignal()",
-      "norm_label": "buildsignal()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L178"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_formatage",
-      "label": "formatAge()",
-      "norm_label": "formatage()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L290"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignaldescription",
-      "label": "getSignalDescription()",
-      "norm_label": "getsignaldescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L221"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsignalstatus",
-      "label": "getSignalStatus()",
-      "norm_label": "getsignalstatus()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L201"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarydescription",
-      "label": "getSummaryDescription()",
-      "norm_label": "getsummarydescription()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L262"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_getsummarytitle",
-      "label": "getSummaryTitle()",
-      "norm_label": "getsummarytitle()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L256"
-    },
-    {
-      "community": 402,
-      "file_type": "code",
-      "id": "posofflinereadiness_isreadylike",
-      "label": "isReadyLike()",
-      "norm_label": "isreadylike()",
-      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_colorrolecard",
-      "label": "ColorRoleCard()",
-      "norm_label": "colorrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L222"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_densitycard",
-      "label": "DensityCard()",
-      "norm_label": "densitycard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L283"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_detailviewrolecard",
-      "label": "DetailViewRoleCard()",
-      "norm_label": "detailviewrolecard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L363"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_hslvar",
-      "label": "hslVar()",
-      "norm_label": "hslvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L214"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_motioncard",
-      "label": "MotionCard()",
-      "norm_label": "motioncard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L342"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_spacetokenrow",
-      "label": "SpaceTokenRow()",
-      "norm_label": "spacetokenrow()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L265"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_textvar",
-      "label": "textVar()",
-      "norm_label": "textvar()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L218"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "foundations_content_typespecimencard",
-      "label": "TypeSpecimenCard()",
-      "norm_label": "typespecimencard()",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L246"
-    },
-    {
-      "community": 403,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
-      "label": "foundations-content.tsx",
-      "norm_label": "foundations-content.tsx",
-      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
-      "label": "versionChecker.ts",
-      "norm_label": "versionchecker.ts",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_buildidfromscripts",
-      "label": "buildIdFromScripts()",
-      "norm_label": "buildidfromscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L192"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_createversionchecker",
-      "label": "createVersionChecker()",
-      "norm_label": "createversionchecker()",
-      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
-      "source_location": "L16"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_getinitialdeploybuildid",
-      "label": "getInitialDeployBuildId()",
-      "norm_label": "getinitialdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L135"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_readdeploybuildid",
-      "label": "readDeployBuildId()",
-      "norm_label": "readdeploybuildid()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L141"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_readdocumentscriptsources",
-      "label": "readDocumentScriptSources()",
-      "norm_label": "readdocumentscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_readentryhtmlscripts",
-      "label": "readEntryHtmlScripts()",
-      "norm_label": "readentryhtmlscripts()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L151"
-    },
-    {
-      "community": 404,
-      "file_type": "code",
-      "id": "versionchecker_readscriptsources",
-      "label": "readScriptSources()",
-      "norm_label": "readscriptsources()",
-      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
-      "source_location": "L182"
-    },
-    {
-      "community": 405,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
       "norm_label": "productutils.ts",
@@ -311242,7 +310954,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_productutils_ts",
       "label": "productUtils.ts",
@@ -311251,7 +310963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_getpreferredsku",
       "label": "getPreferredSku()",
@@ -311260,7 +310972,7 @@
       "source_location": "L78"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_getproductname",
       "label": "getProductName()",
@@ -311269,7 +310981,7 @@
       "source_location": "L18"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_haslowstock",
       "label": "hasLowStock()",
@@ -311278,7 +310990,7 @@
       "source_location": "L52"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_issoldout",
       "label": "isSoldOut()",
@@ -311287,7 +310999,7 @@
       "source_location": "L45"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_sortproduct",
       "label": "sortProduct()",
@@ -311296,7 +311008,7 @@
       "source_location": "L82"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_sortskusbyavailabilitythenlength",
       "label": "sortSkusByAvailabilityThenLength()",
@@ -311305,13 +311017,337 @@
       "source_location": "L63"
     },
     {
-      "community": 405,
+      "community": 401,
       "file_type": "code",
       "id": "productutils_sortskusbylength",
       "label": "sortSkusByLength()",
       "norm_label": "sortskusbylength()",
       "source_file": "packages/storefront-webapp/src/lib/productUtils.ts",
       "source_location": "L59"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyacceptedcontrolresult",
+      "label": "applyAcceptedControlResult()",
+      "norm_label": "applyacceptedcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L84"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applykeyevent",
+      "label": "applyKeyEvent()",
+      "norm_label": "applykeyevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L155"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applypointerevent",
+      "label": "applyPointerEvent()",
+      "norm_label": "applypointerevent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_applyremoteassistcontrolintent",
+      "label": "applyRemoteAssistControlIntent()",
+      "norm_label": "applyremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L17"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getrecentcontrolresult",
+      "label": "getRecentControlResult()",
+      "norm_label": "getrecentcontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L95"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_getremoteassistcontroltarget",
+      "label": "getRemoteAssistControlTarget()",
+      "norm_label": "getremoteassistcontroltarget()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L145"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_prepareremoteassistcontrolintent",
+      "label": "prepareRemoteAssistControlIntent()",
+      "norm_label": "prepareremoteassistcontrolintent()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "applyremoteassistcontrolintent_remembercontrolresult",
+      "label": "rememberControlResult()",
+      "norm_label": "remembercontrolresult()",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L101"
+    },
+    {
+      "community": 402,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_remote_assist_runtime_applyremoteassistcontrolintent_ts",
+      "label": "applyRemoteAssistControlIntent.ts",
+      "norm_label": "applyremoteassistcontrolintent.ts",
+      "source_file": "packages/athena-webapp/src/lib/remote-assist/runtime/applyRemoteAssistControlIntent.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_offline_posofflinereadiness_ts",
+      "label": "posOfflineReadiness.ts",
+      "norm_label": "posofflinereadiness.ts",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildposofflinereadinesssummary",
+      "label": "buildPosOfflineReadinessSummary()",
+      "norm_label": "buildposofflinereadinesssummary()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L152"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_buildsignal",
+      "label": "buildSignal()",
+      "norm_label": "buildsignal()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L178"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_formatage",
+      "label": "formatAge()",
+      "norm_label": "formatage()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L290"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignaldescription",
+      "label": "getSignalDescription()",
+      "norm_label": "getsignaldescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L221"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsignalstatus",
+      "label": "getSignalStatus()",
+      "norm_label": "getsignalstatus()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L201"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarydescription",
+      "label": "getSummaryDescription()",
+      "norm_label": "getsummarydescription()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L262"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_getsummarytitle",
+      "label": "getSummaryTitle()",
+      "norm_label": "getsummarytitle()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L256"
+    },
+    {
+      "community": 403,
+      "file_type": "code",
+      "id": "posofflinereadiness_isreadylike",
+      "label": "isReadyLike()",
+      "norm_label": "isreadylike()",
+      "source_file": "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+      "source_location": "L286"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_colorrolecard",
+      "label": "ColorRoleCard()",
+      "norm_label": "colorrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L222"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_densitycard",
+      "label": "DensityCard()",
+      "norm_label": "densitycard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L283"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_detailviewrolecard",
+      "label": "DetailViewRoleCard()",
+      "norm_label": "detailviewrolecard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L363"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_hslvar",
+      "label": "hslVar()",
+      "norm_label": "hslvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L214"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_motioncard",
+      "label": "MotionCard()",
+      "norm_label": "motioncard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L342"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_spacetokenrow",
+      "label": "SpaceTokenRow()",
+      "norm_label": "spacetokenrow()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L265"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_textvar",
+      "label": "textVar()",
+      "norm_label": "textvar()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L218"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "foundations_content_typespecimencard",
+      "label": "TypeSpecimenCard()",
+      "norm_label": "typespecimencard()",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L246"
+    },
+    {
+      "community": 404,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_stories_foundations_foundations_content_tsx",
+      "label": "foundations-content.tsx",
+      "norm_label": "foundations-content.tsx",
+      "source_file": "packages/athena-webapp/src/stories/Foundations/foundations-content.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_utils_versionchecker_ts",
+      "label": "versionChecker.ts",
+      "norm_label": "versionchecker.ts",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_buildidfromscripts",
+      "label": "buildIdFromScripts()",
+      "norm_label": "buildidfromscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L192"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_createversionchecker",
+      "label": "createVersionChecker()",
+      "norm_label": "createversionchecker()",
+      "source_file": "packages/storefront-webapp/src/utils/versionChecker.ts",
+      "source_location": "L16"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_getinitialdeploybuildid",
+      "label": "getInitialDeployBuildId()",
+      "norm_label": "getinitialdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L135"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_readdeploybuildid",
+      "label": "readDeployBuildId()",
+      "norm_label": "readdeploybuildid()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L141"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_readdocumentscriptsources",
+      "label": "readDocumentScriptSources()",
+      "norm_label": "readdocumentscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_readentryhtmlscripts",
+      "label": "readEntryHtmlScripts()",
+      "norm_label": "readentryhtmlscripts()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 405,
+      "file_type": "code",
+      "id": "versionchecker_readscriptsources",
+      "label": "readScriptSources()",
+      "norm_label": "readscriptsources()",
+      "source_file": "packages/athena-webapp/src/utils/versionChecker.ts",
+      "source_location": "L182"
     },
     {
       "community": 406,
@@ -326499,64 +326535,64 @@
     {
       "community": 559,
       "file_type": "code",
-      "id": "portable_baseline_check_test_canresolvecaseinsensitivealias",
-      "label": "canResolveCaseInsensitiveAlias()",
-      "norm_label": "canresolvecaseinsensitivealias()",
-      "source_file": "scripts/portable-baseline-check.test.ts",
+      "id": "policy_projection_check_test_capturecandidate",
+      "label": "captureCandidate()",
+      "norm_label": "capturecandidate()",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L416"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "policy_projection_check_test_findingcodes",
+      "label": "findingCodes()",
+      "norm_label": "findingcodes()",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L44"
+    },
+    {
+      "community": 559,
+      "file_type": "code",
+      "id": "policy_projection_check_test_policydircopy",
+      "label": "policyDirCopy()",
+      "norm_label": "policydircopy()",
+      "source_file": "scripts/policy-projection-check.test.ts",
       "source_location": "L30"
     },
     {
       "community": 559,
       "file_type": "code",
-      "id": "portable_baseline_check_test_replaceclosure",
-      "label": "replaceClosure()",
-      "norm_label": "replaceclosure()",
-      "source_file": "scripts/portable-baseline-check.test.ts",
-      "source_location": "L923"
+      "id": "policy_projection_check_test_readpolicyjson",
+      "label": "readPolicyJson()",
+      "norm_label": "readpolicyjson()",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L36"
     },
     {
       "community": 559,
       "file_type": "code",
-      "id": "portable_baseline_check_test_replaceedge",
-      "label": "replaceEdge()",
-      "norm_label": "replaceedge()",
-      "source_file": "scripts/portable-baseline-check.test.ts",
-      "source_location": "L1437"
+      "id": "policy_projection_check_test_restamppolicydigests",
+      "label": "restampPolicyDigests()",
+      "norm_label": "restamppolicydigests()",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L192"
     },
     {
       "community": 559,
       "file_type": "code",
-      "id": "portable_baseline_check_test_replacerules",
-      "label": "replaceRules()",
-      "norm_label": "replacerules()",
-      "source_file": "scripts/portable-baseline-check.test.ts",
-      "source_location": "L1060"
+      "id": "policy_projection_check_test_writepolicyjson",
+      "label": "writePolicyJson()",
+      "norm_label": "writepolicyjson()",
+      "source_file": "scripts/policy-projection-check.test.ts",
+      "source_location": "L40"
     },
     {
       "community": 559,
       "file_type": "code",
-      "id": "portable_baseline_check_test_replacesources",
-      "label": "replaceSources()",
-      "norm_label": "replacesources()",
-      "source_file": "scripts/portable-baseline-check.test.ts",
-      "source_location": "L374"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "portable_baseline_check_test_replacetarget",
-      "label": "replaceTarget()",
-      "norm_label": "replacetarget()",
-      "source_file": "scripts/portable-baseline-check.test.ts",
-      "source_location": "L224"
-    },
-    {
-      "community": 559,
-      "file_type": "code",
-      "id": "scripts_portable_baseline_check_test_ts",
-      "label": "portable-baseline-check.test.ts",
-      "norm_label": "portable-baseline-check.test.ts",
-      "source_file": "scripts/portable-baseline-check.test.ts",
+      "id": "scripts_policy_projection_check_test_ts",
+      "label": "policy-projection-check.test.ts",
+      "norm_label": "policy-projection-check.test.ts",
+      "source_file": "scripts/policy-projection-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -326823,6 +326859,69 @@
     {
       "community": 560,
       "file_type": "code",
+      "id": "portable_baseline_check_test_canresolvecaseinsensitivealias",
+      "label": "canResolveCaseInsensitiveAlias()",
+      "norm_label": "canresolvecaseinsensitivealias()",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L30"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "portable_baseline_check_test_replaceclosure",
+      "label": "replaceClosure()",
+      "norm_label": "replaceclosure()",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L923"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "portable_baseline_check_test_replaceedge",
+      "label": "replaceEdge()",
+      "norm_label": "replaceedge()",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L1437"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "portable_baseline_check_test_replacerules",
+      "label": "replaceRules()",
+      "norm_label": "replacerules()",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L1060"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "portable_baseline_check_test_replacesources",
+      "label": "replaceSources()",
+      "norm_label": "replacesources()",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L374"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "portable_baseline_check_test_replacetarget",
+      "label": "replaceTarget()",
+      "norm_label": "replacetarget()",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L224"
+    },
+    {
+      "community": 560,
+      "file_type": "code",
+      "id": "scripts_portable_baseline_check_test_ts",
+      "label": "portable-baseline-check.test.ts",
+      "norm_label": "portable-baseline-check.test.ts",
+      "source_file": "scripts/portable-baseline-check.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 561,
+      "file_type": "code",
       "id": "pre_push_validation_proof_test_createfixtureroot",
       "label": "createFixtureRoot()",
       "norm_label": "createfixtureroot()",
@@ -326830,7 +326929,7 @@
       "source_location": "L21"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_createspawn",
       "label": "createSpawn()",
@@ -326839,7 +326938,7 @@
       "source_location": "L64"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_log",
       "label": "log()",
@@ -326848,7 +326947,7 @@
       "source_location": "L185"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_racingspawn",
       "label": "racingSpawn()",
@@ -326857,7 +326956,7 @@
       "source_location": "L284"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_warn",
       "label": "warn()",
@@ -326866,7 +326965,7 @@
       "source_location": "L279"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "pre_push_validation_proof_test_write",
       "label": "write()",
@@ -326875,7 +326974,7 @@
       "source_location": "L15"
     },
     {
-      "community": 560,
+      "community": 561,
       "file_type": "code",
       "id": "scripts_pre_push_validation_proof_test_ts",
       "label": "pre-push-validation-proof.test.ts",
@@ -326884,7 +326983,7 @@
       "source_location": "L1"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "convexagent_contract_test_kernelfor",
       "label": "kernelFor()",
@@ -326893,7 +326992,7 @@
       "source_location": "L50"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "convexagent_contract_test_openstreamturn",
       "label": "openStreamTurn()",
@@ -326902,7 +327001,7 @@
       "source_location": "L79"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "convexagent_contract_test_openterminalturn",
       "label": "openTerminalTurn()",
@@ -326911,7 +327010,7 @@
       "source_location": "L565"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "convexagent_contract_test_streamusage",
       "label": "streamUsage()",
@@ -326920,7 +327019,7 @@
       "source_location": "L71"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "convexagent_contract_test_terminalkernel",
       "label": "terminalKernel()",
@@ -326929,7 +327028,7 @@
       "source_location": "L536"
     },
     {
-      "community": 561,
+      "community": 562,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_agentruntime_convexagent_contract_test_ts",
       "label": "convexAgent.contract.test.ts",
@@ -326938,7 +327037,7 @@
       "source_location": "L1"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "convexagentpersistence_test_installed",
       "label": "installed()",
@@ -326947,7 +327046,7 @@
       "source_location": "L283"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "convexagentpersistence_test_kernel",
       "label": "kernel()",
@@ -326956,7 +327055,7 @@
       "source_location": "L42"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "convexagentpersistence_test_openturn",
       "label": "openTurn()",
@@ -326965,7 +327064,7 @@
       "source_location": "L64"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "convexagentpersistence_test_storedmessages",
       "label": "storedMessages()",
@@ -326974,7 +327073,7 @@
       "source_location": "L112"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "convexagentpersistence_test_threads0",
       "label": "threads0()",
@@ -326983,7 +327082,7 @@
       "source_location": "L300"
     },
     {
-      "community": 562,
+      "community": 563,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_agentruntime_convexagentpersistence_test_ts",
       "label": "convexAgentPersistence.test.ts",
@@ -326992,7 +327091,7 @@
       "source_location": "L1"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "budgets_attemptcallidempotencykey",
       "label": "attemptCallIdempotencyKey()",
@@ -327001,7 +327100,7 @@
       "source_location": "L134"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "budgets_clamprunlimitstoevidenceceiling",
       "label": "clampRunLimitsToEvidenceCeiling()",
@@ -327010,7 +327109,7 @@
       "source_location": "L91"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "budgets_deriveexecutionceilings",
       "label": "deriveExecutionCeilings()",
@@ -327019,7 +327118,7 @@
       "source_location": "L109"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "budgets_describesettlementpolicy",
       "label": "describeSettlementPolicy()",
@@ -327028,7 +327127,7 @@
       "source_location": "L66"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "budgets_settlementoutcomeforprogramend",
       "label": "settlementOutcomeForProgramEnd()",
@@ -327037,7 +327136,7 @@
       "source_location": "L81"
     },
     {
-      "community": 563,
+      "community": 564,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_budgets_ts",
       "label": "budgets.ts",
@@ -327046,7 +327145,7 @@
       "source_location": "L1"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "completionoutbox_test_completionrequest",
       "label": "completionRequest()",
@@ -327055,7 +327154,7 @@
       "source_location": "L89"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "completionoutbox_test_provisionalrow",
       "label": "provisionalRow()",
@@ -327064,7 +327163,7 @@
       "source_location": "L259"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "completionoutbox_test_reservedcostunits",
       "label": "reservedCostUnits()",
@@ -327073,7 +327172,7 @@
       "source_location": "L77"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "completionoutbox_test_reserveturnspend",
       "label": "reserveTurnSpend()",
@@ -327082,7 +327181,7 @@
       "source_location": "L69"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "completionoutbox_test_seedreleasedrun",
       "label": "seedReleasedRun()",
@@ -327091,7 +327190,7 @@
       "source_location": "L46"
     },
     {
-      "community": 564,
+      "community": 565,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_completionoutbox_test_ts",
       "label": "completionOutbox.test.ts",
@@ -327100,7 +327199,7 @@
       "source_location": "L1"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "dailyoperations_ports_test_beginattempt",
       "label": "beginAttempt()",
@@ -327109,7 +327208,7 @@
       "source_location": "L61"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "dailyoperations_ports_test_describe",
       "label": "describe()",
@@ -327118,7 +327217,7 @@
       "source_location": "L667"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "dailyoperations_ports_test_expectenvelope",
       "label": "expectEnvelope()",
@@ -327127,7 +327226,7 @@
       "source_location": "L135"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "dailyoperations_ports_test_mixsource",
       "label": "mixSource()",
@@ -327136,7 +327235,7 @@
       "source_location": "L550"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "dailyoperations_ports_test_read",
       "label": "read()",
@@ -327145,7 +327244,7 @@
       "source_location": "L86"
     },
     {
-      "community": 565,
+      "community": 566,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_evals_dailyoperations_ports_test_ts",
       "label": "dailyOperations.ports.test.ts",
@@ -327154,7 +327253,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_evals_syntheticsecondsurface_test_ts",
       "label": "syntheticSecondSurface.test.ts",
@@ -327163,7 +327262,7 @@
       "source_location": "L1"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "syntheticsecondsurface_test_executor",
       "label": "executor()",
@@ -327172,7 +327271,7 @@
       "source_location": "L62"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "syntheticsecondsurface_test_executorctx",
       "label": "executorCtx()",
@@ -327181,7 +327280,7 @@
       "source_location": "L55"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "syntheticsecondsurface_test_foreign_program",
       "label": "FOREIGN_PROGRAM()",
@@ -327190,7 +327289,7 @@
       "source_location": "L96"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "syntheticsecondsurface_test_runtime",
       "label": "runtime()",
@@ -327199,7 +327298,7 @@
       "source_location": "L53"
     },
     {
-      "community": 566,
+      "community": 567,
       "file_type": "code",
       "id": "syntheticsecondsurface_test_seedrun",
       "label": "seedRun()",
@@ -327208,7 +327307,7 @@
       "source_location": "L105"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "grants_test_authorized",
       "label": "authorized()",
@@ -327217,7 +327316,7 @@
       "source_location": "L60"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "grants_test_materializefor",
       "label": "materializeFor()",
@@ -327226,7 +327325,7 @@
       "source_location": "L48"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "grants_test_reauth",
       "label": "reauth()",
@@ -327235,7 +327334,7 @@
       "source_location": "L263"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "grants_test_refused",
       "label": "refused()",
@@ -327244,7 +327343,7 @@
       "source_location": "L67"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "grants_test_seedrunninggrant",
       "label": "seedRunningGrant()",
@@ -327253,7 +327352,7 @@
       "source_location": "L223"
     },
     {
-      "community": 567,
+      "community": 568,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_grants_test_ts",
       "label": "grants.test.ts",
@@ -327262,7 +327361,7 @@
       "source_location": "L1"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "modelregistry_agentmodelregistryerror",
       "label": "AgentModelRegistryError",
@@ -327271,7 +327370,7 @@
       "source_location": "L58"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "modelregistry_agentmodelregistryerror_constructor",
       "label": ".constructor()",
@@ -327280,7 +327379,7 @@
       "source_location": "L60"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "modelregistry_createathenamodelresolver",
       "label": "createAthenaModelResolver()",
@@ -327289,7 +327388,7 @@
       "source_location": "L72"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "modelregistry_isproviderconfigured",
       "label": "isProviderConfigured()",
@@ -327298,7 +327397,7 @@
       "source_location": "L39"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "modelregistry_ratecardfor",
       "label": "rateCardFor()",
@@ -327307,66 +327406,12 @@
       "source_location": "L34"
     },
     {
-      "community": 568,
+      "community": 569,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_modelregistry_ts",
       "label": "modelRegistry.ts",
       "norm_label": "modelregistry.ts",
       "source_file": "packages/athena-webapp/convex/agentHarness/modelRegistry.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "outputceiling_fitencodedcalloutput",
-      "label": "fitEncodedCallOutput()",
-      "norm_label": "fitencodedcalloutput()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "outputceiling_measureencodedbytes",
-      "label": "measureEncodedBytes()",
-      "norm_label": "measureencodedbytes()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "outputceiling_measureutf8bytes",
-      "label": "measureUtf8Bytes()",
-      "norm_label": "measureutf8bytes()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
-      "source_location": "L33"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "outputceiling_readcollection",
-      "label": "readCollection()",
-      "norm_label": "readcollection()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
-      "source_location": "L52"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "outputceiling_withcollection",
-      "label": "withCollection()",
-      "norm_label": "withcollection()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 569,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_programruntime_outputceiling_ts",
-      "label": "outputCeiling.ts",
-      "norm_label": "outputceiling.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
       "source_location": "L1"
     },
     {
@@ -327633,6 +327678,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "outputceiling_fitencodedcalloutput",
+      "label": "fitEncodedCallOutput()",
+      "norm_label": "fitencodedcalloutput()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "outputceiling_measureencodedbytes",
+      "label": "measureEncodedBytes()",
+      "norm_label": "measureencodedbytes()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "outputceiling_measureutf8bytes",
+      "label": "measureUtf8Bytes()",
+      "norm_label": "measureutf8bytes()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
+      "source_location": "L33"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "outputceiling_readcollection",
+      "label": "readCollection()",
+      "norm_label": "readcollection()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "outputceiling_withcollection",
+      "label": "withCollection()",
+      "norm_label": "withcollection()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_agentharness_programruntime_outputceiling_ts",
+      "label": "outputCeiling.ts",
+      "norm_label": "outputceiling.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/programRuntime/outputCeiling.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_provisionalnarrative_ts",
       "label": "provisionalNarrative.ts",
       "norm_label": "provisionalnarrative.ts",
@@ -327640,7 +327739,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "provisionalnarrative_deleteexpiredprovisionalnarrativeswithctx",
       "label": "deleteExpiredProvisionalNarrativesWithCtx()",
@@ -327649,7 +327748,7 @@
       "source_location": "L120"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "provisionalnarrative_deleteprovisionalnarrativebybindingwithctx",
       "label": "deleteProvisionalNarrativeByBindingWithCtx()",
@@ -327658,7 +327757,7 @@
       "source_location": "L106"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "provisionalnarrative_fitprovisionalnarrative",
       "label": "fitProvisionalNarrative()",
@@ -327667,7 +327766,7 @@
       "source_location": "L49"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "provisionalnarrative_loadprovisionalnarrativebybindingwithctx",
       "label": "loadProvisionalNarrativeByBindingWithCtx()",
@@ -327676,7 +327775,7 @@
       "source_location": "L63"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "provisionalnarrative_upsertprovisionalnarrativewithctx",
       "label": "upsertProvisionalNarrativeWithCtx()",
@@ -327685,7 +327784,7 @@
       "source_location": "L74"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_agentharness_runtimehost_ts",
       "label": "runtimeHost.ts",
@@ -327694,7 +327793,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "runtimehost_collapseeventkinds",
       "label": "collapseEventKinds()",
@@ -327703,7 +327802,7 @@
       "source_location": "L211"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "runtimehost_createturnhost",
       "label": "createTurnHost()",
@@ -327712,7 +327811,7 @@
       "source_location": "L229"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "runtimehost_productionhost",
       "label": "productionHost()",
@@ -327721,7 +327820,7 @@
       "source_location": "L1005"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "runtimehost_settlementof",
       "label": "settlementOf()",
@@ -327730,7 +327829,7 @@
       "source_location": "L960"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "runtimehost_sleep",
       "label": "sleep()",
@@ -327739,7 +327838,7 @@
       "source_location": "L225"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_automation_scheduledrunledger_ts",
       "label": "scheduledRunLedger.ts",
@@ -327748,7 +327847,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "scheduledrunledger_besteffortrecordscheduledrunevidence",
       "label": "bestEffortRecordScheduledRunEvidence()",
@@ -327757,7 +327856,7 @@
       "source_location": "L165"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "scheduledrunledger_buildscheduledrunkey",
       "label": "buildScheduledRunKey()",
@@ -327766,7 +327865,7 @@
       "source_location": "L78"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "scheduledrunledger_derivescheduledrunoutcome",
       "label": "deriveScheduledRunOutcome()",
@@ -327775,7 +327874,7 @@
       "source_location": "L95"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "scheduledrunledger_recordscheduledrunevidencewithctx",
       "label": "recordScheduledRunEvidenceWithCtx()",
@@ -327784,7 +327883,7 @@
       "source_location": "L108"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "scheduledrunledger_resolvescheduledwindow",
       "label": "resolveScheduledWindow()",
@@ -327793,7 +327892,7 @@
       "source_location": "L64"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "index_valkeyclient",
       "label": "ValkeyClient",
@@ -327802,7 +327901,7 @@
       "source_location": "L4"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "index_valkeyclient_constructor",
       "label": ".constructor()",
@@ -327811,7 +327910,7 @@
       "source_location": "L11"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "index_valkeyclient_get",
       "label": ".get()",
@@ -327820,7 +327919,7 @@
       "source_location": "L20"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "index_valkeyclient_invalidate",
       "label": ".invalidate()",
@@ -327829,7 +327928,7 @@
       "source_location": "L75"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "index_valkeyclient_set",
       "label": ".set()",
@@ -327838,7 +327937,7 @@
       "source_location": "L48"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cache_index_ts",
       "label": "index.ts",
@@ -327847,7 +327946,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_cashcontrols_agentcapabilities_registersports_ts",
       "label": "registersPorts.ts",
@@ -327856,7 +327955,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "registersports_closeoutversionof",
       "label": "closeoutVersionOf()",
@@ -327865,7 +327964,7 @@
       "source_location": "L121"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "registersports_projectsession",
       "label": "projectSession()",
@@ -327874,7 +327973,7 @@
       "source_location": "L127"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "registersports_readregistersessionshandler",
       "label": "readRegisterSessionsHandler()",
@@ -327883,7 +327982,7 @@
       "source_location": "L180"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "registersports_readsessionsfordate",
       "label": "readSessionsForDate()",
@@ -327892,7 +327991,7 @@
       "source_location": "L64"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "registersports_terminallabelsfor",
       "label": "terminalLabelsFor()",
@@ -327901,7 +328000,7 @@
       "source_location": "L167"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "contextevents_appendcontexteventwithctx",
       "label": "appendContextEventWithCtx()",
@@ -327910,7 +328009,7 @@
       "source_location": "L65"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "contextevents_buildcontexteventsemanticenvelopehash",
       "label": "buildContextEventSemanticEnvelopeHash()",
@@ -327919,7 +328018,7 @@
       "source_location": "L33"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "contextevents_isallowedglobalcontextevent",
       "label": "isAllowedGlobalContextEvent()",
@@ -327928,7 +328027,7 @@
       "source_location": "L204"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "contextevents_iscontexteventwritequotaexceeded",
       "label": "isContextEventWriteQuotaExceeded()",
@@ -327937,7 +328036,7 @@
       "source_location": "L19"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "contextevents_selectcontexteventappendquotadecision",
       "label": "selectContextEventAppendQuotaDecision()",
@@ -327946,7 +328045,7 @@
       "source_location": "L23"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_contexttracking_contextevents_ts",
       "label": "contextEvents.ts",
@@ -327955,7 +328054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
       "label": "public.test.ts",
@@ -327964,7 +328063,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_public_test_ts",
       "label": "public.test.ts",
@@ -327973,7 +328072,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "public_test_admittedctx",
       "label": "admittedCtx()",
@@ -327982,7 +328081,7 @@
       "source_location": "L60"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "public_test_buildclient",
       "label": "buildClient()",
@@ -327991,7 +328090,7 @@
       "source_location": "L353"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "public_test_buildsession",
       "label": "buildSession()",
@@ -328000,7 +328099,7 @@
       "source_location": "L378"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "public_test_gethandler",
       "label": "getHandler()",
@@ -328009,7 +328108,7 @@
       "source_location": "L45"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_tsx",
       "label": "RegisterCloseoutVarianceAlert.tsx",
@@ -328018,7 +328117,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealert",
       "label": "RegisterCloseoutVarianceAlert()",
@@ -328027,7 +328126,7 @@
       "source_location": "L60"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealertemailpreview",
       "label": "RegisterCloseoutVarianceAlertEmailPreview()",
@@ -328036,7 +328135,7 @@
       "source_location": "L186"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "registercloseoutvariancealert_sectionheading",
       "label": "SectionHeading()",
@@ -328045,7 +328144,7 @@
       "source_location": "L194"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "registercloseoutvariancealert_statusbadge",
       "label": "StatusBadge()",
@@ -328054,7 +328153,7 @@
       "source_location": "L204"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "registercloseoutvariancealert_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
@@ -328063,7 +328162,7 @@
       "source_location": "L232"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_ts",
       "label": "walkthroughRequests.ts",
@@ -328072,7 +328171,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "walkthroughrequests_canonical",
       "label": "canonical()",
@@ -328081,7 +328180,7 @@
       "source_location": "L26"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "walkthroughrequests_evaluatewalkthroughingress",
       "label": "evaluateWalkthroughIngress()",
@@ -328090,7 +328189,7 @@
       "source_location": "L18"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "walkthroughrequests_isvalidbody",
       "label": "isValidBody()",
@@ -328099,7 +328198,7 @@
       "source_location": "L28"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "walkthroughrequests_sha256",
       "label": "sha256()",
@@ -328108,67 +328207,13 @@
       "source_location": "L27"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "walkthroughrequests_text",
       "label": "text()",
       "norm_label": "text()",
       "source_file": "packages/athena-webapp/convex/http/domains/core/routes/walkthroughRequests.ts",
       "source_location": "L25"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
-      "label": "security.ts",
-      "norm_label": "security.ts",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "security_buildcanonicalcheckoutproducts",
-      "label": "buildCanonicalCheckoutProducts()",
-      "norm_label": "buildcanonicalcheckoutproducts()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "security_hasvalidpositivequantity",
-      "label": "hasValidPositiveQuantity()",
-      "norm_label": "hasvalidpositivequantity()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L27"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "security_isamounttampered",
-      "label": "isAmountTampered()",
-      "norm_label": "isamounttampered()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "security_isauthorizedresourceowner",
-      "label": "isAuthorizedResourceOwner()",
-      "norm_label": "isauthorizedresourceowner()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L31"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "security_isduplicatechargesuccess",
-      "label": "isDuplicateChargeSuccess()",
-      "norm_label": "isduplicatechargesuccess()",
-      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
-      "source_location": "L76"
     },
     {
       "community": 58,
@@ -328434,6 +328479,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
+      "label": "security.ts",
+      "norm_label": "security.ts",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "security_buildcanonicalcheckoutproducts",
+      "label": "buildCanonicalCheckoutProducts()",
+      "norm_label": "buildcanonicalcheckoutproducts()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "security_hasvalidpositivequantity",
+      "label": "hasValidPositiveQuantity()",
+      "norm_label": "hasvalidpositivequantity()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L27"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "security_isamounttampered",
+      "label": "isAmountTampered()",
+      "norm_label": "isamounttampered()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "security_isauthorizedresourceowner",
+      "label": "isAuthorizedResourceOwner()",
+      "norm_label": "isauthorizedresourceowner()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L31"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "security_isduplicatechargesuccess",
+      "label": "isDuplicateChargeSuccess()",
+      "norm_label": "isduplicatechargesuccess()",
+      "source_file": "packages/athena-webapp/convex/http/domains/customerChannel/routes/security.ts",
+      "source_location": "L76"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "catalogimport_test_buildtrustedconversionargs",
       "label": "buildTrustedConversionArgs()",
       "norm_label": "buildtrustedconversionargs()",
@@ -328441,7 +328540,7 @@
       "source_location": "L397"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "catalogimport_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -328450,7 +328549,7 @@
       "source_location": "L144"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "catalogimport_test_gethandler",
       "label": "getHandler()",
@@ -328459,7 +328558,7 @@
       "source_location": "L140"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "catalogimport_test_readtrustedconversionbinding",
       "label": "readTrustedConversionBinding()",
@@ -328468,7 +328567,7 @@
       "source_location": "L383"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "catalogimport_test_seedtrustedconversiondata",
       "label": "seedTrustedConversionData()",
@@ -328477,7 +328576,7 @@
       "source_location": "L289"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogimport_test_ts",
       "label": "catalogImport.test.ts",
@@ -328486,7 +328585,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "expensesessions_expensesessionerror",
       "label": "expenseSessionError()",
@@ -328495,7 +328594,7 @@
       "source_location": "L72"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -328504,7 +328603,7 @@
       "source_location": "L139"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "expensesessions_mapexpensesessionvalidationerror",
       "label": "mapExpenseSessionValidationError()",
@@ -328513,7 +328612,7 @@
       "source_location": "L120"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "expensesessions_recordexpensesessionlifecycletrace",
       "label": "recordExpenseSessionLifecycleTrace()",
@@ -328522,7 +328621,7 @@
       "source_location": "L164"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
       "label": "userErrorFromExpenseSessionCommandFailure()",
@@ -328531,7 +328630,7 @@
       "source_location": "L86"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -328540,7 +328639,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "featureditem_countfeaturedtargets",
       "label": "countFeaturedTargets()",
@@ -328549,7 +328648,7 @@
       "source_location": "L61"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "featureditem_getnextfeatureditemrank",
       "label": "getNextFeaturedItemRank()",
@@ -328558,7 +328657,7 @@
       "source_location": "L121"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "featureditem_listfeatureditemswithctx",
       "label": "listFeaturedItemsWithCtx()",
@@ -328567,7 +328666,7 @@
       "source_location": "L241"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "featureditem_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -328576,7 +328675,7 @@
       "source_location": "L41"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "featureditem_validatefeaturedplacement",
       "label": "validateFeaturedPlacement()",
@@ -328585,7 +328684,7 @@
       "source_location": "L70"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -328594,7 +328693,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "corrections_test_asadmitted",
       "label": "asAdmitted()",
@@ -328603,7 +328702,7 @@
       "source_location": "L48"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "corrections_test_correctionargs",
       "label": "correctionArgs()",
@@ -328612,7 +328711,7 @@
       "source_location": "L144"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "corrections_test_countcorrections",
       "label": "countCorrections()",
@@ -328621,7 +328720,7 @@
       "source_location": "L157"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "corrections_test_gethandler",
       "label": "getHandler()",
@@ -328630,7 +328729,7 @@
       "source_location": "L40"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "corrections_test_seedfixture",
       "label": "seedFixture()",
@@ -328639,7 +328738,7 @@
       "source_location": "L66"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_corrections_test_ts",
       "label": "corrections.test.ts",
@@ -328648,7 +328747,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createctx",
       "label": "createCtx()",
@@ -328657,7 +328756,7 @@
       "source_location": "L20"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -328666,7 +328765,7 @@
       "source_location": "L58"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishbackfill",
       "label": "finishBackfill()",
@@ -328675,7 +328774,7 @@
       "source_location": "L96"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishverification",
       "label": "finishVerification()",
@@ -328684,7 +328783,7 @@
       "source_location": "L116"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_observedatfield",
       "label": "observedAtField()",
@@ -328693,7 +328792,7 @@
       "source_location": "L264"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_test_ts",
       "label": "backfillReportFactObservedAt.test.ts",
@@ -328702,7 +328801,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "backfillstorecurrencycase_backfillstorecurrencycasewithctx",
       "label": "backfillStoreCurrencyCaseWithCtx()",
@@ -328711,7 +328810,7 @@
       "source_location": "L70"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "backfillstorecurrencycase_boundedlimit",
       "label": "boundedLimit()",
@@ -328720,7 +328819,7 @@
       "source_location": "L43"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "backfillstorecurrencycase_needsnormalization",
       "label": "needsNormalization()",
@@ -328729,7 +328828,7 @@
       "source_location": "L66"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "backfillstorecurrencycase_storepage",
       "label": "storePage()",
@@ -328738,7 +328837,7 @@
       "source_location": "L50"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "backfillstorecurrencycase_verifystorecurrencycasewithctx",
       "label": "verifyStoreCurrencyCaseWithCtx()",
@@ -328747,7 +328846,7 @@
       "source_location": "L133"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_ts",
       "label": "backfillStoreCurrencyCase.ts",
@@ -328756,7 +328855,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_notifications_registry_ts",
       "label": "registry.ts",
@@ -328765,7 +328864,7 @@
       "source_location": "L1"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "registry_findnotificationkind",
       "label": "findNotificationKind()",
@@ -328774,7 +328873,7 @@
       "source_location": "L421"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "registry_getnotificationkind",
       "label": "getNotificationKind()",
@@ -328783,7 +328882,7 @@
       "source_location": "L431"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "registry_isstaledailyclosepayload",
       "label": "isStaleDailyClosePayload()",
@@ -328792,7 +328891,7 @@
       "source_location": "L88"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "registry_listnotificationkinds",
       "label": "listNotificationKinds()",
@@ -328801,7 +328900,7 @@
       "source_location": "L439"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "registry_requirestaledailyclosepayload",
       "label": "requireStaleDailyClosePayload()",
@@ -328810,7 +328909,7 @@
       "source_location": "L102"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "definitions_costoverlaystorewriteoperation",
       "label": "costOverlayStoreWriteOperation()",
@@ -328819,7 +328918,7 @@
       "source_location": "L619"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "definitions_cyclecountdraftstorewriteoperation",
       "label": "cycleCountDraftStoreWriteOperation()",
@@ -328828,7 +328927,7 @@
       "source_location": "L405"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "definitions_inventoryimportreviewpayloadwriteoperation",
       "label": "inventoryImportReviewPayloadWriteOperation()",
@@ -328837,7 +328936,7 @@
       "source_location": "L589"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "definitions_notificationsubscriptionrowwriteoperation",
       "label": "notificationSubscriptionRowWriteOperation()",
@@ -328846,7 +328945,7 @@
       "source_location": "L695"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "definitions_validateoperationdefinition",
       "label": "validateOperationDefinition()",
@@ -328855,7 +328954,7 @@
       "source_location": "L834"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
       "label": "definitions.ts",
@@ -328864,7 +328963,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "inventorycatalog_definitions_idarg",
       "label": "idArg()",
@@ -328873,7 +328972,7 @@
       "source_location": "L30"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "inventorycatalog_definitions_inventoryimportstorewrite",
       "label": "inventoryImportStoreWrite()",
@@ -328882,7 +328981,7 @@
       "source_location": "L170"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "inventorycatalog_definitions_rankedrowsstorescope",
       "label": "rankedRowsStoreScope()",
@@ -328891,7 +328990,7 @@
       "source_location": "L78"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "inventorycatalog_definitions_rowstorescope",
       "label": "rowStoreScope()",
@@ -328900,7 +328999,7 @@
       "source_location": "L39"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "inventorycatalog_definitions_rowstoretarget",
       "label": "rowStoreTarget()",
@@ -328909,66 +329008,12 @@
       "source_location": "L54"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_domains_inventorycatalog_definitions_ts",
       "label": "inventoryCatalog_definitions.ts",
       "norm_label": "inventorycatalog_definitions.ts",
       "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryCatalog_definitions.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "inventoryidentity_definitions_expensewriteoperation",
-      "label": "expenseWriteOperation()",
-      "norm_label": "expensewriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
-      "source_location": "L66"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "inventoryidentity_definitions_possessionwriteoperation",
-      "label": "posSessionWriteOperation()",
-      "norm_label": "possessionwriteoperation()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
-      "source_location": "L91"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "inventoryidentity_definitions_resolveexpensesessionstore",
-      "label": "resolveExpenseSessionStore()",
-      "norm_label": "resolveexpensesessionstore()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
-      "source_location": "L35"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "inventoryidentity_definitions_resolvepossessionstore",
-      "label": "resolvePosSessionStore()",
-      "norm_label": "resolvepossessionstore()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "inventoryidentity_definitions_storeprovideraction",
-      "label": "storeProviderAction()",
-      "norm_label": "storeprovideraction()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
-      "source_location": "L594"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_domains_inventoryidentity_definitions_ts",
-      "label": "inventoryIdentity_definitions.ts",
-      "norm_label": "inventoryidentity_definitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
       "source_location": "L1"
     },
     {
@@ -329235,6 +329280,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "inventoryidentity_definitions_expensewriteoperation",
+      "label": "expenseWriteOperation()",
+      "norm_label": "expensewriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
+      "source_location": "L66"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "inventoryidentity_definitions_possessionwriteoperation",
+      "label": "posSessionWriteOperation()",
+      "norm_label": "possessionwriteoperation()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
+      "source_location": "L91"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "inventoryidentity_definitions_resolveexpensesessionstore",
+      "label": "resolveExpenseSessionStore()",
+      "norm_label": "resolveexpensesessionstore()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
+      "source_location": "L35"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "inventoryidentity_definitions_resolvepossessionstore",
+      "label": "resolvePosSessionStore()",
+      "norm_label": "resolvepossessionstore()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "inventoryidentity_definitions_storeprovideraction",
+      "label": "storeProviderAction()",
+      "norm_label": "storeprovideraction()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
+      "source_location": "L594"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operationadmission_domains_inventoryidentity_definitions_ts",
+      "label": "inventoryIdentity_definitions.ts",
+      "norm_label": "inventoryidentity_definitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/inventoryIdentity_definitions.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_domains_storefrontcustomer_readdefinitions_ts",
       "label": "storefrontCustomer_readDefinitions.ts",
       "norm_label": "storefrontcustomer_readdefinitions.ts",
@@ -329242,7 +329341,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_customerbehaviorread",
       "label": "customerBehaviorRead()",
@@ -329251,7 +329350,7 @@
       "source_location": "L161"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_resolvestorefromrow",
       "label": "resolveStoreFromRow()",
@@ -329260,7 +329359,7 @@
       "source_location": "L36"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_resolvestorefromstorefrontactor",
       "label": "resolveStoreFromStorefrontActor()",
@@ -329269,7 +329368,7 @@
       "source_location": "L55"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_storefrontaccountread",
       "label": "storefrontAccountRead()",
@@ -329278,7 +329377,7 @@
       "source_location": "L269"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_storefrontread",
       "label": "storefrontRead()",
@@ -329287,7 +329386,7 @@
       "source_location": "L73"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_resourceguards_ts",
       "label": "resourceGuards.ts",
@@ -329296,7 +329395,7 @@
       "source_location": "L1"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "resourceguards_evaluateoperationtargetguards",
       "label": "evaluateOperationTargetGuards()",
@@ -329305,7 +329404,7 @@
       "source_location": "L72"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "resourceguards_readidarg",
       "label": "readIdArg()",
@@ -329314,7 +329413,7 @@
       "source_location": "L10"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "resourceguards_resolveoperationtargetexternalrefs",
       "label": "resolveOperationTargetExternalRefs()",
@@ -329323,7 +329422,7 @@
       "source_location": "L47"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "resourceguards_resolveoperationtargetids",
       "label": "resolveOperationTargetIds()",
@@ -329332,7 +329431,7 @@
       "source_location": "L19"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "resourceguards_validateoperationtarget",
       "label": "validateOperationTarget()",
@@ -329341,7 +329440,7 @@
       "source_location": "L102"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_agentcapabilities_workports_ts",
       "label": "workPorts.ts",
@@ -329350,7 +329449,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "workports_approvalproofof",
       "label": "approvalProofOf()",
@@ -329359,7 +329458,7 @@
       "source_location": "L131"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "workports_approvalstateversion",
       "label": "approvalStateVersion()",
@@ -329368,7 +329467,7 @@
       "source_location": "L127"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "workports_listapprovalshandler",
       "label": "listApprovalsHandler()",
@@ -329377,7 +329476,7 @@
       "source_location": "L143"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "workports_listattentionhandler",
       "label": "listAttentionHandler()",
@@ -329386,7 +329485,7 @@
       "source_location": "L49"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "workports_windowfallbackwarning",
       "label": "windowFallbackWarning()",
@@ -329395,7 +329494,7 @@
       "source_location": "L40"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -329404,7 +329503,7 @@
       "source_location": "L152"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -329413,7 +329512,7 @@
       "source_location": "L110"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "approvalproofs_getvalidapprovalproof",
       "label": "getValidApprovalProof()",
@@ -329422,7 +329521,7 @@
       "source_location": "L49"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -329431,7 +329530,7 @@
       "source_location": "L103"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "approvalproofs_validateapprovalproofwithctx",
       "label": "validateApprovalProofWithCtx()",
@@ -329440,7 +329539,7 @@
       "source_location": "L88"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -329449,7 +329548,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "approval_builddailycloseapprovalsubject",
       "label": "buildDailyCloseApprovalSubject()",
@@ -329458,7 +329557,7 @@
       "source_location": "L15"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalrequirement",
       "label": "buildDailyCloseCarryForwardApprovalRequirement()",
@@ -329467,7 +329566,7 @@
       "source_location": "L101"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalsubject",
       "label": "buildDailyCloseCarryForwardApprovalSubject()",
@@ -329476,7 +329575,7 @@
       "source_location": "L88"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "approval_builddailyclosecompletionapprovalrequirement",
       "label": "buildDailyCloseCompletionApprovalRequirement()",
@@ -329485,7 +329584,7 @@
       "source_location": "L26"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "approval_builddailyclosereopenapprovalrequirement",
       "label": "buildDailyCloseReopenApprovalRequirement()",
@@ -329494,7 +329593,7 @@
       "source_location": "L54"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_ts",
       "label": "approval.ts",
@@ -329503,7 +329602,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "eventbuilders_buildonlineorderoperationaleventmessage",
       "label": "buildOnlineOrderOperationalEventMessage()",
@@ -329512,7 +329611,7 @@
       "source_location": "L68"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -329521,7 +329620,7 @@
       "source_location": "L1"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
       "label": "buildStockAdjustmentOperationalEventMessage()",
@@ -329530,7 +329629,7 @@
       "source_location": "L93"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "eventbuilders_formatonlineorderlabel",
       "label": "formatOnlineOrderLabel()",
@@ -329539,7 +329638,7 @@
       "source_location": "L112"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "eventbuilders_formatstockadjustmentsubjectdetail",
       "label": "formatStockAdjustmentSubjectDetail()",
@@ -329548,7 +329647,7 @@
       "source_location": "L106"
     },
     {
-      "community": 595,
+      "community": 596,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
@@ -329557,7 +329656,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
       "label": "serviceIntake.test.ts",
@@ -329566,7 +329665,7 @@
       "source_location": "L1"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "serviceintake_test_buildcreateserviceintakeargs",
       "label": "buildCreateServiceIntakeArgs()",
@@ -329575,7 +329674,7 @@
       "source_location": "L40"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "serviceintake_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -329584,7 +329683,7 @@
       "source_location": "L54"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "serviceintake_test_createserviceintakebehaviorctx",
       "label": "createServiceIntakeBehaviorCtx()",
@@ -329593,7 +329692,7 @@
       "source_location": "L98"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "serviceintake_test_gethandler",
       "label": "getHandler()",
@@ -329602,7 +329701,7 @@
       "source_location": "L36"
     },
     {
-      "community": 596,
+      "community": 597,
       "file_type": "code",
       "id": "serviceintake_test_getsource",
       "label": "getSource()",
@@ -329611,7 +329710,7 @@
       "source_location": "L32"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_weeklymanagerreportemail_test_ts",
       "label": "weeklyManagerReportEmail.test.ts",
@@ -329620,7 +329719,7 @@
       "source_location": "L1"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_buildpayload",
       "label": "buildPayload()",
@@ -329629,7 +329728,7 @@
       "source_location": "L128"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_countedcashsection",
       "label": "countedCashSection()",
@@ -329638,7 +329737,7 @@
       "source_location": "L234"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_evidencecoverage",
       "label": "evidenceCoverage()",
@@ -329647,7 +329746,7 @@
       "source_location": "L61"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_lineageday",
       "label": "lineageDay()",
@@ -329656,7 +329755,7 @@
       "source_location": "L117"
     },
     {
-      "community": 597,
+      "community": 598,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_makecloseevidence",
       "label": "makeCloseEvidence()",
@@ -329665,7 +329764,7 @@
       "source_location": "L69"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "completetransaction_test_createvoidctx",
       "label": "createVoidCtx()",
@@ -329674,7 +329773,7 @@
       "source_location": "L219"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -329683,7 +329782,7 @@
       "source_location": "L197"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "completetransaction_test_expectnovoidbusinesssideeffects",
       "label": "expectNoVoidBusinessSideEffects()",
@@ -329692,7 +329791,7 @@
       "source_location": "L211"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "completetransaction_test_seeddirect",
       "label": "seedDirect()",
@@ -329701,7 +329800,7 @@
       "source_location": "L4983"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "completetransaction_test_seeddirecthappypath",
       "label": "seedDirectHappyPath()",
@@ -329710,67 +329809,13 @@
       "source_location": "L4826"
     },
     {
-      "community": 598,
+      "community": 599,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
       "norm_label": "completetransaction.test.ts",
       "source_file": "packages/athena-webapp/convex/pos/application/completeTransaction.test.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_queries_registerlifecycleauthority_test_ts",
-      "label": "registerLifecycleAuthority.test.ts",
-      "norm_label": "registerlifecycleauthority.test.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_test_createrepository",
-      "label": "createRepository()",
-      "norm_label": "createrepository()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
-      "source_location": "L675"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_test_mapping",
-      "label": "mapping()",
-      "norm_label": "mapping()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
-      "source_location": "L741"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_test_mappingauthority",
-      "label": "mappingAuthority()",
-      "norm_label": "mappingauthority()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
-      "source_location": "L708"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_test_registersession",
-      "label": "registerSession()",
-      "norm_label": "registersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
-      "source_location": "L760"
-    },
-    {
-      "community": 599,
-      "file_type": "code",
-      "id": "registerlifecycleauthority_test_terminal",
-      "label": "terminal()",
-      "norm_label": "terminal()",
-      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
-      "source_location": "L726"
     },
     {
       "community": 6,
@@ -330711,6 +330756,60 @@
     {
       "community": 600,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_pos_application_queries_registerlifecycleauthority_test_ts",
+      "label": "registerLifecycleAuthority.test.ts",
+      "norm_label": "registerlifecycleauthority.test.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_test_createrepository",
+      "label": "createRepository()",
+      "norm_label": "createrepository()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
+      "source_location": "L675"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_test_mapping",
+      "label": "mapping()",
+      "norm_label": "mapping()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
+      "source_location": "L741"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_test_mappingauthority",
+      "label": "mappingAuthority()",
+      "norm_label": "mappingauthority()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
+      "source_location": "L708"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_test_registersession",
+      "label": "registerSession()",
+      "norm_label": "registersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
+      "source_location": "L760"
+    },
+    {
+      "community": 600,
+      "file_type": "code",
+      "id": "registerlifecycleauthority_test_terminal",
+      "label": "terminal()",
+      "norm_label": "terminal()",
+      "source_file": "packages/athena-webapp/convex/pos/application/queries/registerLifecycleAuthority.test.ts",
+      "source_location": "L726"
+    },
+    {
+      "community": 601,
+      "file_type": "code",
       "id": "localsyncrepository_areconflictdetailsequivalent",
       "label": "areConflictDetailsEquivalent()",
       "norm_label": "areconflictdetailsequivalent()",
@@ -330718,7 +330817,7 @@
       "source_location": "L67"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "localsyncrepository_createconvexlocalsyncrepository",
       "label": "createConvexLocalSyncRepository()",
@@ -330727,7 +330826,7 @@
       "source_location": "L157"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "localsyncrepository_omitundefined",
       "label": "omitUndefined()",
@@ -330736,7 +330835,7 @@
       "source_location": "L61"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "localsyncrepository_reportfactsfromlocalsyncingressargs",
       "label": "reportFactsFromLocalSyncIngressArgs()",
@@ -330745,7 +330844,7 @@
       "source_location": "L112"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "localsyncrepository_trimoptional",
       "label": "trimOptional()",
@@ -330754,7 +330853,7 @@
       "source_location": "L97"
     },
     {
-      "community": 600,
+      "community": 601,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_ts",
       "label": "localSyncRepository.ts",
@@ -330763,7 +330862,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -330772,7 +330871,7 @@
       "source_location": "L1"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -330781,7 +330880,7 @@
       "source_location": "L108"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -330790,7 +330889,7 @@
       "source_location": "L34"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -330799,7 +330898,7 @@
       "source_location": "L24"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -330808,7 +330907,7 @@
       "source_location": "L528"
     },
     {
-      "community": 601,
+      "community": 602,
       "file_type": "code",
       "id": "telemetry_test_v2event",
       "label": "v2Event()",
@@ -330817,7 +330916,7 @@
       "source_location": "L120"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_remoteassist_transportinternal_test_ts",
       "label": "transportInternal.test.ts",
@@ -330826,7 +330925,7 @@
       "source_location": "L1"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "transportinternal_test_buildclient",
       "label": "buildClient()",
@@ -330835,7 +330934,7 @@
       "source_location": "L342"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "transportinternal_test_buildruntimectx",
       "label": "buildRuntimeCtx()",
@@ -330844,7 +330943,7 @@
       "source_location": "L318"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "transportinternal_test_buildsession",
       "label": "buildSession()",
@@ -330853,7 +330952,7 @@
       "source_location": "L352"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "transportinternal_test_buildterminal",
       "label": "buildTerminal()",
@@ -330862,7 +330961,7 @@
       "source_location": "L365"
     },
     {
-      "community": 602,
+      "community": 603,
       "file_type": "code",
       "id": "transportinternal_test_gethandler",
       "label": "getHandler()",
@@ -330871,7 +330970,7 @@
       "source_location": "L34"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "foldday_comparefacts",
       "label": "compareFacts()",
@@ -330880,7 +330979,7 @@
       "source_location": "L95"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "foldday_foldday",
       "label": "foldDay()",
@@ -330889,7 +330988,7 @@
       "source_location": "L126"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "foldday_revenuecontribution",
       "label": "revenueContribution()",
@@ -330898,7 +330997,7 @@
       "source_location": "L108"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "foldday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -330907,7 +331006,7 @@
       "source_location": "L51"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "foldday_zeroskuaccumulator",
       "label": "zeroSkuAccumulator()",
@@ -330916,7 +331015,7 @@
       "source_location": "L77"
     },
     {
-      "community": 603,
+      "community": 604,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_foldday_ts",
       "label": "foldDay.ts",
@@ -330925,7 +331024,7 @@
       "source_location": "L1"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "operatingday_configuredtimezone",
       "label": "configuredTimezone()",
@@ -330934,7 +331033,7 @@
       "source_location": "L52"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "operatingday_isvalidtimezone",
       "label": "isValidTimezone()",
@@ -330943,7 +331042,7 @@
       "source_location": "L27"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "operatingday_localdatelabel",
       "label": "localDateLabel()",
@@ -330952,7 +331051,7 @@
       "source_location": "L38"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "operatingday_resolveoperatingdate",
       "label": "resolveOperatingDate()",
@@ -330961,7 +331060,7 @@
       "source_location": "L98"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "operatingday_resolvestoretimezone",
       "label": "resolveStoreTimezone()",
@@ -330970,7 +331069,7 @@
       "source_location": "L68"
     },
     {
-      "community": 604,
+      "community": 605,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_operatingday_ts",
       "label": "operatingDay.ts",
@@ -330979,7 +331078,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_pipelineclosebackfill_ts",
       "label": "pipelineCloseBackfill.ts",
@@ -330988,7 +331087,7 @@
       "source_location": "L1"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "pipelineclosebackfill_backfillclosepage",
       "label": "backfillClosePage()",
@@ -330997,7 +331096,7 @@
       "source_location": "L50"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "pipelineclosebackfill_backfillcloseweeklypagewithctx",
       "label": "backfillCloseWeeklyPageWithCtx()",
@@ -331006,7 +331105,7 @@
       "source_location": "L149"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "pipelineclosebackfill_backfilldaypage",
       "label": "backfillDayPage()",
@@ -331015,7 +331114,7 @@
       "source_location": "L117"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "pipelineclosebackfill_ensurework",
       "label": "ensureWork()",
@@ -331024,7 +331123,7 @@
       "source_location": "L27"
     },
     {
-      "community": 605,
+      "community": 606,
       "file_type": "code",
       "id": "pipelineclosebackfill_verifyclosecoveragepagewithctx",
       "label": "verifyCloseCoveragePageWithCtx()",
@@ -331033,7 +331132,7 @@
       "source_location": "L199"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_pipelineevidence_ts",
       "label": "pipelineEvidence.ts",
@@ -331042,7 +331141,7 @@
       "source_location": "L1"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "pipelineevidence_boundedcount",
       "label": "boundedCount()",
@@ -331051,7 +331150,7 @@
       "source_location": "L61"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "pipelineevidence_ledgeroutcome",
       "label": "ledgerOutcome()",
@@ -331060,7 +331159,7 @@
       "source_location": "L67"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "pipelineevidence_recordpipelinebacklogwithctx",
       "label": "recordPipelineBacklogWithCtx()",
@@ -331069,7 +331168,7 @@
       "source_location": "L100"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "pipelineevidence_recordpipelineevidencewithctx",
       "label": "recordPipelineEvidenceWithCtx()",
@@ -331078,7 +331177,7 @@
       "source_location": "L107"
     },
     {
-      "community": 606,
+      "community": 607,
       "file_type": "code",
       "id": "pipelineevidence_recordpipelineoutcomewithctx",
       "label": "recordPipelineOutcomeWithCtx()",
@@ -331087,7 +331186,7 @@
       "source_location": "L88"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_pipelineisolation_test_ts",
       "label": "pipelineIsolation.test.ts",
@@ -331096,7 +331195,7 @@
       "source_location": "L1"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "pipelineisolation_test_claimday",
       "label": "claimDay()",
@@ -331105,7 +331204,7 @@
       "source_location": "L99"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "pipelineisolation_test_dispatch",
       "label": "dispatch()",
@@ -331114,7 +331213,7 @@
       "source_location": "L205"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "pipelineisolation_test_readstoreprojection",
       "label": "readStoreProjection()",
@@ -331123,7 +331222,7 @@
       "source_location": "L111"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "pipelineisolation_test_seedfacts",
       "label": "seedFacts()",
@@ -331132,7 +331231,7 @@
       "source_location": "L71"
     },
     {
-      "community": 607,
+      "community": 608,
       "file_type": "code",
       "id": "pipelineisolation_test_seedstore",
       "label": "seedStore()",
@@ -331141,7 +331240,7 @@
       "source_location": "L43"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_pipelinemigration_ts",
       "label": "pipelineMigration.ts",
@@ -331150,7 +331249,7 @@
       "source_location": "L1"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "pipelinemigration_activatepipelinewithctx",
       "label": "activatePipelineWithCtx()",
@@ -331159,7 +331258,7 @@
       "source_location": "L386"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "pipelinemigration_canonicalpage",
       "label": "canonicalPage()",
@@ -331168,7 +331267,7 @@
       "source_location": "L89"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "pipelinemigration_daycoveragepage",
       "label": "dayCoveragePage()",
@@ -331177,7 +331276,7 @@
       "source_location": "L114"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "pipelinemigration_outstandingbasis",
       "label": "outstandingBasis()",
@@ -331186,67 +331285,13 @@
       "source_location": "L44"
     },
     {
-      "community": 608,
+      "community": 609,
       "file_type": "code",
       "id": "pipelinemigration_steppipelinemigrationwithctx",
       "label": "stepPipelineMigrationWithCtx()",
       "norm_label": "steppipelinemigrationwithctx()",
       "source_file": "packages/athena-webapp/convex/reports/pipelineMigration.ts",
       "source_location": "L137"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_pipelinereadcostoptimized_test_ts",
-      "label": "pipelineReadCostOptimized.test.ts",
-      "norm_label": "pipelinereadcostoptimized.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "pipelinereadcostoptimized_test_allow",
-      "label": "allow()",
-      "norm_label": "allow()",
-      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "pipelinereadcostoptimized_test_configure",
-      "label": "configure()",
-      "norm_label": "configure()",
-      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
-      "source_location": "L362"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "pipelinereadcostoptimized_test_measuredpipeline",
-      "label": "measuredPipeline()",
-      "norm_label": "measuredpipeline()",
-      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "pipelinereadcostoptimized_test_sum",
-      "label": "sum()",
-      "norm_label": "sum()",
-      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 609,
-      "file_type": "code",
-      "id": "pipelinereadcostoptimized_test_weeklyfixture",
-      "label": "weeklyFixture()",
-      "norm_label": "weeklyfixture()",
-      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
-      "source_location": "L215"
     },
     {
       "community": 61,
@@ -331503,6 +331548,60 @@
     {
       "community": 610,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_pipelinereadcostoptimized_test_ts",
+      "label": "pipelineReadCostOptimized.test.ts",
+      "norm_label": "pipelinereadcostoptimized.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "pipelinereadcostoptimized_test_allow",
+      "label": "allow()",
+      "norm_label": "allow()",
+      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
+      "source_location": "L358"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "pipelinereadcostoptimized_test_configure",
+      "label": "configure()",
+      "norm_label": "configure()",
+      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
+      "source_location": "L362"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "pipelinereadcostoptimized_test_measuredpipeline",
+      "label": "measuredPipeline()",
+      "norm_label": "measuredpipeline()",
+      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
+      "source_location": "L125"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "pipelinereadcostoptimized_test_sum",
+      "label": "sum()",
+      "norm_label": "sum()",
+      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
+      "source_location": "L65"
+    },
+    {
+      "community": 610,
+      "file_type": "code",
+      "id": "pipelinereadcostoptimized_test_weeklyfixture",
+      "label": "weeklyFixture()",
+      "norm_label": "weeklyfixture()",
+      "source_file": "packages/athena-webapp/convex/reports/pipelineReadCostOptimized.test.ts",
+      "source_location": "L215"
+    },
+    {
+      "community": 611,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_reportsadmission_test_ts",
       "label": "reportsAdmission.test.ts",
       "norm_label": "reportsadmission.test.ts",
@@ -331510,7 +331609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "reportsadmission_test_as",
       "label": "as()",
@@ -331519,7 +331618,7 @@
       "source_location": "L286"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "reportsadmission_test_assertpending",
       "label": "assertPending()",
@@ -331528,7 +331627,7 @@
       "source_location": "L479"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "reportsadmission_test_seedrecoveryperiods",
       "label": "seedRecoveryPeriods()",
@@ -331537,7 +331636,7 @@
       "source_location": "L300"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "reportsadmission_test_seedrecoveryweekly",
       "label": "seedRecoveryWeekly()",
@@ -331546,7 +331645,7 @@
       "source_location": "L354"
     },
     {
-      "community": 610,
+      "community": 611,
       "file_type": "code",
       "id": "reportsadmission_test_seedworld",
       "label": "seedWorld()",
@@ -331555,7 +331654,7 @@
       "source_location": "L226"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_reseed_test_ts",
       "label": "reseed.test.ts",
@@ -331564,7 +331663,7 @@
       "source_location": "L1"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "reseed_test_at",
       "label": "at()",
@@ -331573,7 +331672,7 @@
       "source_location": "L48"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "reseed_test_factsignature",
       "label": "factSignature()",
@@ -331582,7 +331681,7 @@
       "source_location": "L116"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "reseed_test_resumereseed",
       "label": "resumeReseed()",
@@ -331591,7 +331690,7 @@
       "source_location": "L99"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "reseed_test_runreseed",
       "label": "runReseed()",
@@ -331600,7 +331699,7 @@
       "source_location": "L75"
     },
     {
-      "community": 611,
+      "community": 612,
       "file_type": "code",
       "id": "reseed_test_seedfullday",
       "label": "seedFullDay()",
@@ -331609,7 +331708,7 @@
       "source_location": "L140"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_rolluppipeline_test_ts",
       "label": "rollupPipeline.test.ts",
@@ -331618,7 +331717,7 @@
       "source_location": "L1"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "rolluppipeline_test_capture",
       "label": "capture()",
@@ -331627,7 +331726,7 @@
       "source_location": "L63"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "rolluppipeline_test_drain",
       "label": "drain()",
@@ -331636,7 +331735,7 @@
       "source_location": "L78"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "rolluppipeline_test_measures",
       "label": "measures()",
@@ -331645,7 +331744,7 @@
       "source_location": "L21"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "rolluppipeline_test_output",
       "label": "output()",
@@ -331654,7 +331753,7 @@
       "source_location": "L96"
     },
     {
-      "community": 612,
+      "community": 613,
       "file_type": "code",
       "id": "rolluppipeline_test_setup",
       "label": "setup()",
@@ -331663,7 +331762,7 @@
       "source_location": "L33"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_weeklyinventory_ts",
       "label": "weeklyInventory.ts",
@@ -331672,7 +331771,7 @@
       "source_location": "L1"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "weeklyinventory_classifyweeklyinventorygroup",
       "label": "classifyWeeklyInventoryGroup()",
@@ -331681,7 +331780,7 @@
       "source_location": "L56"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "weeklyinventory_issyncedsaleinventoryreviewgroup",
       "label": "isSyncedSaleInventoryReviewGroup()",
@@ -331690,7 +331789,7 @@
       "source_location": "L101"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "weeklyinventory_projectfrozenweeklyinventoryattention",
       "label": "projectFrozenWeeklyInventoryAttention()",
@@ -331699,7 +331798,7 @@
       "source_location": "L144"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "weeklyinventory_projectliveweeklyinventoryattention",
       "label": "projectLiveWeeklyInventoryAttention()",
@@ -331708,7 +331807,7 @@
       "source_location": "L110"
     },
     {
-      "community": 613,
+      "community": 614,
       "file_type": "code",
       "id": "weeklyinventory_summarizeweeklyinventoryattention",
       "label": "summarizeWeeklyInventoryAttention()",
@@ -331717,7 +331816,7 @@
       "source_location": "L82"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "catalogappointments_test_createappointmentmutationctx",
       "label": "createAppointmentMutationCtx()",
@@ -331726,7 +331825,7 @@
       "source_location": "L1016"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "catalogappointments_test_gethandler",
       "label": "getHandler()",
@@ -331735,7 +331834,7 @@
       "source_location": "L47"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "catalogappointments_test_invoke",
       "label": "invoke()",
@@ -331744,7 +331843,7 @@
       "source_location": "L936"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "catalogappointments_test_serviceopsingresscases",
       "label": "serviceOpsIngressCases()",
@@ -331753,7 +331852,7 @@
       "source_location": "L963"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "catalogappointments_test_serviceopsreadingresscases",
       "label": "serviceOpsReadIngressCases()",
@@ -331762,7 +331861,7 @@
       "source_location": "L1009"
     },
     {
-      "community": 614,
+      "community": 615,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_serviceops_catalogappointments_test_ts",
       "label": "catalogAppointments.test.ts",
@@ -331771,7 +331870,7 @@
       "source_location": "L1"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "orderemailservice_buildorderstatusmessage",
       "label": "buildOrderStatusMessage()",
@@ -331780,7 +331879,7 @@
       "source_location": "L56"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "orderemailservice_buildpickupdetails",
       "label": "buildPickupDetails()",
@@ -331789,7 +331888,7 @@
       "source_location": "L84"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "orderemailservice_sendpaymentverificationemails",
       "label": "sendPaymentVerificationEmails()",
@@ -331798,7 +331897,7 @@
       "source_location": "L232"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "orderemailservice_sendpodorderemails",
       "label": "sendPODOrderEmails()",
@@ -331807,7 +331906,7 @@
       "source_location": "L107"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "orderemailservice_shouldsendtoadmins",
       "label": "shouldSendToAdmins()",
@@ -331816,7 +331915,7 @@
       "source_location": "L49"
     },
     {
-      "community": 615,
+      "community": 616,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_services_orderemailservice_ts",
       "label": "orderEmailService.ts",
@@ -331825,7 +331924,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_shareddemo_scheduledrestore_ts",
       "label": "scheduledRestore.ts",
@@ -331834,7 +331933,7 @@
       "source_location": "L1"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "scheduledrestore_continuerestorewithctx",
       "label": "continueRestoreWithCtx()",
@@ -331843,7 +331942,7 @@
       "source_location": "L23"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "scheduledrestore_provisionforscheduledworkwithctx",
       "label": "provisionForScheduledWorkWithCtx()",
@@ -331852,7 +331951,7 @@
       "source_location": "L80"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "scheduledrestore_rundailyrestorewithctx",
       "label": "runDailyRestoreWithCtx()",
@@ -331861,7 +331960,7 @@
       "source_location": "L121"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "scheduledrestore_runhourlyprovisionhealwithctx",
       "label": "runHourlyProvisionHealWithCtx()",
@@ -331870,7 +331969,7 @@
       "source_location": "L112"
     },
     {
-      "community": 616,
+      "community": 617,
       "file_type": "code",
       "id": "scheduledrestore_shareddemorestoreenabled",
       "label": "sharedDemoRestoreEnabled()",
@@ -331879,7 +331978,7 @@
       "source_location": "L7"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "adjustments_test_createapprovaldecisionmutationctx",
       "label": "createApprovalDecisionMutationCtx()",
@@ -331888,7 +331987,7 @@
       "source_location": "L305"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "adjustments_test_createinventorysnapshotqueryctx",
       "label": "createInventorySnapshotQueryCtx()",
@@ -331897,7 +331996,7 @@
       "source_location": "L57"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "adjustments_test_createsubmissionmutationctx",
       "label": "createSubmissionMutationCtx()",
@@ -331906,7 +332005,7 @@
       "source_location": "L519"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "adjustments_test_gethandler",
       "label": "getHandler()",
@@ -331915,7 +332014,7 @@
       "source_location": "L53"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "adjustments_test_getsource",
       "label": "getSource()",
@@ -331924,7 +332023,7 @@
       "source_location": "L49"
     },
     {
-      "community": 617,
+      "community": 618,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_adjustments_test_ts",
       "label": "adjustments.test.ts",
@@ -331933,7 +332032,7 @@
       "source_location": "L1"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "inventoryports_listreplenishmenthandler",
       "label": "listReplenishmentHandler()",
@@ -331942,7 +332041,7 @@
       "source_location": "L198"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "inventoryports_projectposition",
       "label": "projectPosition()",
@@ -331951,7 +332050,7 @@
       "source_location": "L70"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "inventoryports_readpositionshandler",
       "label": "readPositionsHandler()",
@@ -331960,7 +332059,7 @@
       "source_location": "L93"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "inventoryports_stockstateof",
       "label": "stockStateOf()",
@@ -331969,7 +332068,7 @@
       "source_location": "L58"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "inventoryports_variantlabelof",
       "label": "variantLabelOf()",
@@ -331978,67 +332077,13 @@
       "source_location": "L63"
     },
     {
-      "community": 618,
+      "community": 619,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_stockops_agentcapabilities_inventoryports_ts",
       "label": "inventoryPorts.ts",
       "norm_label": "inventoryports.ts",
       "source_file": "packages/athena-webapp/convex/stockOps/agentCapabilities/inventoryPorts.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
-      "label": "vendors.ts",
-      "norm_label": "vendors.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "vendors_createvendorcommandwithctx",
-      "label": "createVendorCommandWithCtx()",
-      "norm_label": "createvendorcommandwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L127"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "vendors_createvendorwithctx",
-      "label": "createVendorWithCtx()",
-      "norm_label": "createvendorwithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L83"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "vendors_mapcreatevendorerror",
-      "label": "mapCreateVendorError()",
-      "norm_label": "mapcreatevendorerror()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "vendors_normalizevendorlookupkey",
-      "label": "normalizeVendorLookupKey()",
-      "norm_label": "normalizevendorlookupkey()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 619,
-      "file_type": "code",
-      "id": "vendors_trimoptional",
-      "label": "trimOptional()",
-      "norm_label": "trimoptional()",
-      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
-      "source_location": "L41"
     },
     {
       "community": 62,
@@ -332286,6 +332331,60 @@
     {
       "community": 620,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_stockops_vendors_ts",
+      "label": "vendors.ts",
+      "norm_label": "vendors.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "vendors_createvendorcommandwithctx",
+      "label": "createVendorCommandWithCtx()",
+      "norm_label": "createvendorcommandwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L127"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "vendors_createvendorwithctx",
+      "label": "createVendorWithCtx()",
+      "norm_label": "createvendorwithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L83"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "vendors_mapcreatevendorerror",
+      "label": "mapCreateVendorError()",
+      "norm_label": "mapcreatevendorerror()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "vendors_normalizevendorlookupkey",
+      "label": "normalizeVendorLookupKey()",
+      "norm_label": "normalizevendorlookupkey()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 620,
+      "file_type": "code",
+      "id": "vendors_trimoptional",
+      "label": "trimOptional()",
+      "norm_label": "trimoptional()",
+      "source_file": "packages/athena-webapp/convex/stockOps/vendors.ts",
+      "source_location": "L41"
+    },
+    {
+      "community": 621,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_helpers_returnexchangeoperations_ts",
       "label": "returnExchangeOperations.ts",
       "norm_label": "returnexchangeoperations.ts",
@@ -332293,7 +332392,7 @@
       "source_location": "L1"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreportedreturns",
       "label": "buildOnlineOrderReportedReturns()",
@@ -332302,7 +332401,7 @@
       "source_location": "L73"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "returnexchangeoperations_buildonlineorderreturnexchangeplan",
       "label": "buildOnlineOrderReturnExchangePlan()",
@@ -332311,7 +332410,7 @@
       "source_location": "L137"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "returnexchangeoperations_getapprovalreason",
       "label": "getApprovalReason()",
@@ -332320,7 +332419,7 @@
       "source_location": "L112"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "returnexchangeoperations_getkind",
       "label": "getKind()",
@@ -332329,7 +332428,7 @@
       "source_location": "L96"
     },
     {
-      "community": 620,
+      "community": 621,
       "file_type": "code",
       "id": "returnexchangeoperations_getlinerefundamount",
       "label": "getLineRefundAmount()",
@@ -332338,7 +332437,7 @@
       "source_location": "L92"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "onlineorder_test_createunauthorizednormalorderctx",
       "label": "createUnauthorizedNormalOrderCtx()",
@@ -332347,7 +332446,7 @@
       "source_location": "L203"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "onlineorder_test_gethandler",
       "label": "getHandler()",
@@ -332356,7 +332455,7 @@
       "source_location": "L199"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "onlineorder_test_getsource",
       "label": "getSource()",
@@ -332365,7 +332464,7 @@
       "source_location": "L195"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "onlineorder_test_readstorefrontfacts",
       "label": "readStorefrontFacts()",
@@ -332374,7 +332473,7 @@
       "source_location": "L189"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "onlineorder_test_seedfulfillableorder",
       "label": "seedFulfillableOrder()",
@@ -332383,7 +332482,7 @@
       "source_location": "L29"
     },
     {
-      "community": 621,
+      "community": 622,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storefront_onlineorder_test_ts",
       "label": "onlineOrder.test.ts",
@@ -332392,7 +332491,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_storetime_storetimeauthority_ts",
       "label": "storeTimeAuthority.ts",
@@ -332401,7 +332500,7 @@
       "source_location": "L1"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "storetimeauthority_assertstoretimezoneversioncanbeinserted",
       "label": "assertStoreTimezoneVersionCanBeInserted()",
@@ -332410,7 +332509,7 @@
       "source_location": "L50"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "storetimeauthority_includesoccurrence",
       "label": "includesOccurrence()",
@@ -332419,7 +332518,7 @@
       "source_location": "L18"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "storetimeauthority_intervalsoverlap",
       "label": "intervalsOverlap()",
@@ -332428,7 +332527,7 @@
       "source_location": "L41"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "storetimeauthority_localdate",
       "label": "localDate()",
@@ -332437,7 +332536,7 @@
       "source_location": "L28"
     },
     {
-      "community": 622,
+      "community": 623,
       "file_type": "code",
       "id": "storetimeauthority_resolvestoretimeauthority",
       "label": "resolveStoreTimeAuthority()",
@@ -332446,7 +332545,7 @@
       "source_location": "L84"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_workflowtraces_adapters_purchaseorder_ts",
       "label": "purchaseOrder.ts",
@@ -332455,7 +332554,7 @@
       "source_location": "L1"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseorderreceivinglookup",
       "label": "buildPurchaseOrderReceivingLookup()",
@@ -332464,7 +332563,7 @@
       "source_location": "L162"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "purchaseorder_buildpurchaseordertraceseed",
       "label": "buildPurchaseOrderTraceSeed()",
@@ -332473,7 +332572,7 @@
       "source_location": "L82"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "purchaseorder_compactdetails",
       "label": "compactDetails()",
@@ -332482,7 +332581,7 @@
       "source_location": "L74"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "purchaseorder_formatpurchaseorderlabel",
       "label": "formatPurchaseOrderLabel()",
@@ -332491,7 +332590,7 @@
       "source_location": "L45"
     },
     {
-      "community": 623,
+      "community": 624,
       "file_type": "code",
       "id": "purchaseorder_normalizelookup",
       "label": "normalizeLookup()",
@@ -332500,7 +332599,7 @@
       "source_location": "L53"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_find_block_end",
       "label": "find_block_end()",
@@ -332509,7 +332608,7 @@
       "source_location": "L123"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_list_convex_files",
       "label": "list_convex_files()",
@@ -332518,7 +332617,7 @@
       "source_location": "L187"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_main",
       "label": "main()",
@@ -332527,7 +332626,7 @@
       "source_location": "L207"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_scan_file",
       "label": "scan_file()",
@@ -332536,7 +332635,7 @@
       "source_location": "L137"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "convexpaginationantipatterncheck_strip_code",
       "label": "strip_code()",
@@ -332545,7 +332644,7 @@
       "source_location": "L9"
     },
     {
-      "community": 624,
+      "community": 625,
       "file_type": "code",
       "id": "packages_athena_webapp_scripts_convexpaginationantipatterncheck_py",
       "label": "convexPaginationAntiPatternCheck.py",
@@ -332554,7 +332653,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_agentharness_profile_ts",
       "label": "profile.ts",
@@ -332563,7 +332662,7 @@
       "source_location": "L1"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "profile_assertprofileselection",
       "label": "assertProfileSelection()",
@@ -332572,7 +332671,7 @@
       "source_location": "L466"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "profile_composethreadkey",
       "label": "composeThreadKey()",
@@ -332581,7 +332680,7 @@
       "source_location": "L122"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "profile_defineagentprofile",
       "label": "defineAgentProfile()",
@@ -332590,7 +332689,7 @@
       "source_location": "L446"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "profile_definepresentationadapter",
       "label": "definePresentationAdapter()",
@@ -332599,7 +332698,7 @@
       "source_location": "L133"
     },
     {
-      "community": 625,
+      "community": 626,
       "file_type": "code",
       "id": "profile_validateprofiledefinition",
       "label": "validateProfileDefinition()",
@@ -332608,7 +332707,7 @@
       "source_location": "L233"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_agentharness_readport_ts",
       "label": "readPort.ts",
@@ -332617,7 +332716,7 @@
       "source_location": "L1"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "readport_defineagentreadport",
       "label": "defineAgentReadPort()",
@@ -332626,7 +332725,7 @@
       "source_location": "L68"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "readport_isinternalfunctionpath",
       "label": "isInternalFunctionPath()",
@@ -332635,7 +332734,7 @@
       "source_location": "L76"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "readport_sameset",
       "label": "sameSet()",
@@ -332644,7 +332743,7 @@
       "source_location": "L140"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "readport_validatereadportdefinition",
       "label": "validateReadPortDefinition()",
@@ -332653,7 +332752,7 @@
       "source_location": "L85"
     },
     {
-      "community": 626,
+      "community": 627,
       "file_type": "code",
       "id": "readport_validatereadportindex",
       "label": "validateReadPortIndex()",
@@ -332662,7 +332761,7 @@
       "source_location": "L159"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "commandresult_approvalrequired",
       "label": "approvalRequired()",
@@ -332671,7 +332770,7 @@
       "source_location": "L62"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "commandresult_isapprovalrequiredresult",
       "label": "isApprovalRequiredResult()",
@@ -332680,7 +332779,7 @@
       "source_location": "L77"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "commandresult_isusererrorresult",
       "label": "isUserErrorResult()",
@@ -332689,7 +332788,7 @@
       "source_location": "L71"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "commandresult_ok",
       "label": "ok()",
@@ -332698,7 +332797,7 @@
       "source_location": "L48"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "commandresult_usererror",
       "label": "userError()",
@@ -332707,7 +332806,7 @@
       "source_location": "L55"
     },
     {
-      "community": 627,
+      "community": 628,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_commandresult_ts",
       "label": "commandResult.ts",
@@ -332716,7 +332815,7 @@
       "source_location": "L1"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "homepageranking_comparehomepagerankeditems",
       "label": "compareHomepageRankedItems()",
@@ -332725,7 +332824,7 @@
       "source_location": "L22"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "homepageranking_gethomepagesortrank",
       "label": "getHomepageSortRank()",
@@ -332734,7 +332833,7 @@
       "source_location": "L9"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "homepageranking_getnexthomepagerank",
       "label": "getNextHomepageRank()",
@@ -332743,7 +332842,7 @@
       "source_location": "L40"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "homepageranking_getpresentedhomepagerank",
       "label": "getPresentedHomepageRank()",
@@ -332752,7 +332851,7 @@
       "source_location": "L15"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "homepageranking_sorthomepagerankeditems",
       "label": "sortHomepageRankedItems()",
@@ -332761,67 +332860,13 @@
       "source_location": "L36"
     },
     {
-      "community": 628,
+      "community": 629,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_homepageranking_ts",
       "label": "homepageRanking.ts",
       "norm_label": "homepageranking.ts",
       "source_file": "packages/athena-webapp/shared/homepageRanking.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
-      "label": "registerSessionStatus.ts",
-      "norm_label": "registersessionstatus.ts",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "registersessionstatus_includesregistersessionstatus",
-      "label": "includesRegisterSessionStatus()",
-      "norm_label": "includesregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
-      "label": "isCashControlVisibleRegisterSessionStatus()",
-      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L62"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "registersessionstatus_isposusableregistersessionstatus",
-      "label": "isPosUsableRegisterSessionStatus()",
-      "norm_label": "isposusableregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
-      "label": "isRegisterSessionConflictBlockingStatus()",
-      "norm_label": "isregistersessionconflictblockingstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 629,
-      "file_type": "code",
-      "id": "registersessionstatus_isregistersessionstatus",
-      "label": "isRegisterSessionStatus()",
-      "norm_label": "isregistersessionstatus()",
-      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
-      "source_location": "L29"
     },
     {
       "community": 63,
@@ -333069,6 +333114,60 @@
     {
       "community": 630,
       "file_type": "code",
+      "id": "packages_athena_webapp_shared_registersessionstatus_ts",
+      "label": "registerSessionStatus.ts",
+      "norm_label": "registersessionstatus.ts",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "registersessionstatus_includesregistersessionstatus",
+      "label": "includesRegisterSessionStatus()",
+      "norm_label": "includesregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "registersessionstatus_iscashcontrolvisibleregistersessionstatus",
+      "label": "isCashControlVisibleRegisterSessionStatus()",
+      "norm_label": "iscashcontrolvisibleregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "registersessionstatus_isposusableregistersessionstatus",
+      "label": "isPosUsableRegisterSessionStatus()",
+      "norm_label": "isposusableregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionconflictblockingstatus",
+      "label": "isRegisterSessionConflictBlockingStatus()",
+      "norm_label": "isregistersessionconflictblockingstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L55"
+    },
+    {
+      "community": 630,
+      "file_type": "code",
+      "id": "registersessionstatus_isregistersessionstatus",
+      "label": "isRegisterSessionStatus()",
+      "norm_label": "isregistersessionstatus()",
+      "source_file": "packages/athena-webapp/shared/registerSessionStatus.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 631,
+      "file_type": "code",
       "id": "packages_athena_webapp_shared_workflowtrace_ts",
       "label": "workflowTrace.ts",
       "norm_label": "workflowtrace.ts",
@@ -333076,7 +333175,7 @@
       "source_location": "L1"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "workflowtrace_assertobjectkeysareminimized",
       "label": "assertObjectKeysAreMinimized()",
@@ -333085,7 +333184,7 @@
       "source_location": "L44"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "workflowtrace_assertworkflowtracedetailsareminimized",
       "label": "assertWorkflowTraceDetailsAreMinimized()",
@@ -333094,7 +333193,7 @@
       "source_location": "L67"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "workflowtrace_createworkflowtraceid",
       "label": "createWorkflowTraceId()",
@@ -333103,7 +333202,7 @@
       "source_location": "L93"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtraceeventkey",
       "label": "normalizeWorkflowTraceEventKey()",
@@ -333112,7 +333211,7 @@
       "source_location": "L83"
     },
     {
-      "community": 630,
+      "community": 631,
       "file_type": "code",
       "id": "workflowtrace_normalizeworkflowtracelookupvalue",
       "label": "normalizeWorkflowTraceLookupValue()",
@@ -333121,7 +333220,7 @@
       "source_location": "L73"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_productcategorization_tsx",
       "label": "ProductCategorization.tsx",
@@ -333130,7 +333229,7 @@
       "source_location": "L1"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "productcategorization_getproductname",
       "label": "getProductName()",
@@ -333139,7 +333238,7 @@
       "source_location": "L327"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "productcategorization_handleclose",
       "label": "handleClose()",
@@ -333148,7 +333247,7 @@
       "source_location": "L234"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "productcategorization_handleproductposvisibility",
       "label": "handleProductPosVisibility()",
@@ -333157,7 +333256,7 @@
       "source_location": "L284"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "productcategorization_handleproductvisibility",
       "label": "handleProductVisibility()",
@@ -333166,7 +333265,7 @@
       "source_location": "L274"
     },
     {
-      "community": 631,
+      "community": 632,
       "file_type": "code",
       "id": "productcategorization_setinitialselectedoption",
       "label": "setInitialSelectedOption()",
@@ -333175,7 +333274,7 @@
       "source_location": "L261"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "data_table_toolbar_datatabletoolbar",
       "label": "DataTableToolbar()",
@@ -333184,7 +333283,7 @@
       "source_location": "L23"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_add_product_copy_images_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -333193,7 +333292,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -333202,7 +333301,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -333211,7 +333310,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -333220,7 +333319,7 @@
       "source_location": "L1"
     },
     {
-      "community": 632,
+      "community": 633,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_table_data_table_toolbar_tsx",
       "label": "data-table-toolbar.tsx",
@@ -333229,7 +333328,7 @@
       "source_location": "L1"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "athenaagentsafetext_test_expectnoactiveelements",
       "label": "expectNoActiveElements()",
@@ -333238,7 +333337,7 @@
       "source_location": "L62"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "athenaagentsafetext_test_expectnonetworkrequest",
       "label": "expectNoNetworkRequest()",
@@ -333247,7 +333346,7 @@
       "source_location": "L55"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "athenaagentsafetext_test_spyimage",
       "label": "SpyImage",
@@ -333256,7 +333355,7 @@
       "source_location": "L32"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "athenaagentsafetext_test_spyimage_constructor",
       "label": ".constructor()",
@@ -333265,7 +333364,7 @@
       "source_location": "L33"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "athenaagentsafetext_test_words",
       "label": "words()",
@@ -333274,7 +333373,7 @@
       "source_location": "L334"
     },
     {
-      "community": 633,
+      "community": 634,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_agent_athenaagentsafetext_test_tsx",
       "label": "AthenaAgentSafeText.test.tsx",
@@ -333283,7 +333382,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_analytics_analytics_data_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -333292,7 +333391,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_base_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -333301,7 +333400,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_selectable_products_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -333310,7 +333409,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_user_bags_user_bags_table_selectable_data_provider_tsx",
       "label": "selectable-data-provider.tsx",
@@ -333319,7 +333418,7 @@
       "source_location": "L1"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "selectable_data_provider_selectedproductsprovider",
       "label": "SelectedProductsProvider()",
@@ -333328,7 +333427,7 @@
       "source_location": "L16"
     },
     {
-      "community": 634,
+      "community": 635,
       "file_type": "code",
       "id": "selectable_data_provider_useselectedproducts",
       "label": "useSelectedProducts()",
@@ -333337,7 +333436,7 @@
       "source_location": "L37"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "flipnumber_defaultformatvalue",
       "label": "defaultFormatValue()",
@@ -333346,7 +333445,7 @@
       "source_location": "L20"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "flipnumber_flipnumber",
       "label": "FlipNumber()",
@@ -333355,7 +333454,7 @@
       "source_location": "L202"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "flipnumber_fliptext",
       "label": "FlipText()",
@@ -333364,7 +333463,7 @@
       "source_location": "L47"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "flipnumber_renderflipglyphs",
       "label": "renderFlipGlyphs()",
@@ -333373,7 +333472,7 @@
       "source_location": "L24"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "flipnumber_renderfliptext",
       "label": "renderFlipText()",
@@ -333382,7 +333481,7 @@
       "source_location": "L37"
     },
     {
-      "community": 635,
+      "community": 636,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_common_flipnumber_tsx",
       "label": "FlipNumber.tsx",
@@ -333391,7 +333490,7 @@
       "source_location": "L1"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "bannermessageeditor_getcountdownstatus",
       "label": "getCountdownStatus()",
@@ -333400,7 +333499,7 @@
       "source_location": "L130"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "bannermessageeditor_handleactivetoggle",
       "label": "handleActiveToggle()",
@@ -333409,7 +333508,7 @@
       "source_location": "L90"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "bannermessageeditor_handleclear",
       "label": "handleClear()",
@@ -333418,7 +333517,7 @@
       "source_location": "L65"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "bannermessageeditor_handlecountdownchange",
       "label": "handleCountdownChange()",
@@ -333427,7 +333526,7 @@
       "source_location": "L120"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "bannermessageeditor_handlesave",
       "label": "handleSave()",
@@ -333436,7 +333535,7 @@
       "source_location": "L45"
     },
     {
-      "community": 636,
+      "community": 637,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bannermessageeditor_tsx",
       "label": "BannerMessageEditor.tsx",
@@ -333445,7 +333544,7 @@
       "source_location": "L1"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "bestsellers_bestsellers",
       "label": "bestSellers()",
@@ -333454,7 +333553,7 @@
       "source_location": "L157"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "bestsellers_handleremovebestseller",
       "label": "handleRemoveBestSeller()",
@@ -333463,7 +333562,7 @@
       "source_location": "L66"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "bestsellers_movebestseller",
       "label": "moveBestSeller()",
@@ -333472,7 +333571,7 @@
       "source_location": "L126"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "bestsellers_ondragend",
       "label": "onDragEnd()",
@@ -333481,7 +333580,7 @@
       "source_location": "L76"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "bestsellers_saveorder",
       "label": "saveOrder()",
@@ -333490,7 +333589,7 @@
       "source_location": "L104"
     },
     {
-      "community": 637,
+      "community": 638,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_bestsellers_tsx",
       "label": "BestSellers.tsx",
@@ -333499,7 +333598,7 @@
       "source_location": "L1"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "featuredsection_formatstoredcurrencyamount",
       "label": "formatStoredCurrencyAmount()",
@@ -333508,7 +333607,7 @@
       "source_location": "L215"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "featuredsection_handlehighlighteditem",
       "label": "handleHighlightedItem()",
@@ -333517,7 +333616,7 @@
       "source_location": "L66"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "featuredsection_movefeatureditem",
       "label": "moveFeaturedItem()",
@@ -333526,7 +333625,7 @@
       "source_location": "L128"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "featuredsection_ondragend",
       "label": "onDragEnd()",
@@ -333535,7 +333634,7 @@
       "source_location": "L78"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "featuredsection_saveorder",
       "label": "saveOrder()",
@@ -333544,67 +333643,13 @@
       "source_location": "L106"
     },
     {
-      "community": 638,
+      "community": 639,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_featuredsection_tsx",
       "label": "FeaturedSection.tsx",
       "norm_label": "featuredsection.tsx",
       "source_file": "packages/athena-webapp/src/components/homepage/FeaturedSection.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_landing_story_scenechrome_tsx",
-      "label": "SceneChrome.tsx",
-      "norm_label": "scenechrome.tsx",
-      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "scenechrome_appshellexhibit",
-      "label": "AppShellExhibit()",
-      "norm_label": "appshellexhibit()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
-      "source_location": "L131"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "scenechrome_automationbeat",
-      "label": "AutomationBeat()",
-      "norm_label": "automationbeat()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
-      "source_location": "L272"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "scenechrome_possyncbadge",
-      "label": "PosSyncBadge()",
-      "norm_label": "possyncbadge()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
-      "source_location": "L248"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "scenechrome_workspaceexhibit",
-      "label": "WorkspaceExhibit()",
-      "norm_label": "workspaceexhibit()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
-      "source_location": "L80"
-    },
-    {
-      "community": 639,
-      "file_type": "code",
-      "id": "scenechrome_workspaceframe",
-      "label": "WorkspaceFrame()",
-      "norm_label": "workspaceframe()",
-      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
-      "source_location": "L39"
     },
     {
       "community": 64,
@@ -333852,6 +333897,60 @@
     {
       "community": 640,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_landing_story_scenechrome_tsx",
+      "label": "SceneChrome.tsx",
+      "norm_label": "scenechrome.tsx",
+      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "scenechrome_appshellexhibit",
+      "label": "AppShellExhibit()",
+      "norm_label": "appshellexhibit()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
+      "source_location": "L131"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "scenechrome_automationbeat",
+      "label": "AutomationBeat()",
+      "norm_label": "automationbeat()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
+      "source_location": "L272"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "scenechrome_possyncbadge",
+      "label": "PosSyncBadge()",
+      "norm_label": "possyncbadge()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
+      "source_location": "L248"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "scenechrome_workspaceexhibit",
+      "label": "WorkspaceExhibit()",
+      "norm_label": "workspaceexhibit()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
+      "source_location": "L80"
+    },
+    {
+      "community": 640,
+      "file_type": "code",
+      "id": "scenechrome_workspaceframe",
+      "label": "WorkspaceFrame()",
+      "norm_label": "workspaceframe()",
+      "source_file": "packages/athena-webapp/src/components/landing/story/SceneChrome.tsx",
+      "source_location": "L39"
+    },
+    {
+      "community": 641,
+      "file_type": "code",
       "id": "dailyclosehistoryview_test_historyrecord",
       "label": "historyRecord()",
       "norm_label": "historyrecord()",
@@ -333859,7 +333958,7 @@
       "source_location": "L190"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockprotectedstate",
       "label": "mockProtectedState()",
@@ -333868,7 +333967,7 @@
       "source_location": "L241"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_mockqueries",
       "label": "mockQueries()",
@@ -333877,7 +333976,7 @@
       "source_location": "L255"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_snapshot",
       "label": "snapshot()",
@@ -333886,7 +333985,7 @@
       "source_location": "L104"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "dailyclosehistoryview_test_storedreportsnapshot",
       "label": "storedReportSnapshot()",
@@ -333895,7 +333994,7 @@
       "source_location": "L171"
     },
     {
-      "community": 640,
+      "community": 641,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyclosehistoryview_test_tsx",
       "label": "DailyCloseHistoryView.test.tsx",
@@ -333904,7 +334003,7 @@
       "source_location": "L1"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "dailyopeningview_test_async",
       "label": "async()",
@@ -333913,7 +334012,7 @@
       "source_location": "L124"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "dailyopeningview_test_disconnect",
       "label": "disconnect()",
@@ -333922,7 +334021,7 @@
       "source_location": "L359"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "dailyopeningview_test_formatexpectedtimestamp",
       "label": "formatExpectedTimestamp()",
@@ -333931,7 +334030,7 @@
       "source_location": "L258"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "dailyopeningview_test_observe",
       "label": "observe()",
@@ -333940,7 +334039,7 @@
       "source_location": "L360"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "dailyopeningview_test_unobserve",
       "label": "unobserve()",
@@ -333949,7 +334048,7 @@
       "source_location": "L361"
     },
     {
-      "community": 641,
+      "community": 642,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_dailyopeningview_test_tsx",
       "label": "DailyOpeningView.test.tsx",
@@ -333958,7 +334057,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_skuactivityuntrustedsales_tsx",
       "label": "SkuActivityUntrustedSales.tsx",
@@ -333967,7 +334066,7 @@
       "source_location": "L1"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_cn",
       "label": "cn()",
@@ -333976,7 +334075,7 @@
       "source_location": "L207"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_formatcountlabel",
       "label": "formatCountLabel()",
@@ -333985,7 +334084,7 @@
       "source_location": "L139"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_handlesourcepagechange",
       "label": "handleSourcePageChange()",
@@ -333994,7 +334093,7 @@
       "source_location": "L932"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_sourcematchesevidencequery",
       "label": "sourceMatchesEvidenceQuery()",
@@ -334003,7 +334102,7 @@
       "source_location": "L147"
     },
     {
-      "community": 642,
+      "community": 643,
       "file_type": "code",
       "id": "skuactivityuntrustedsales_usedetailstickyposition",
       "label": "useDetailStickyPosition()",
@@ -334012,7 +334111,7 @@
       "source_location": "L83"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_operations_useapprovedcommand_tsx",
       "label": "useApprovedCommand.tsx",
@@ -334021,7 +334120,7 @@
       "source_location": "L1"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useapprovedcommand_buildapprovalretryargs",
       "label": "buildApprovalRetryArgs()",
@@ -334030,7 +334129,7 @@
       "source_location": "L90"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useapprovedcommand_getasyncapprovalrequestid",
       "label": "getAsyncApprovalRequestId()",
@@ -334039,7 +334138,7 @@
       "source_location": "L78"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useapprovedcommand_hasasyncapprovalrequest",
       "label": "hasAsyncApprovalRequest()",
@@ -334048,7 +334147,7 @@
       "source_location": "L72"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useapprovedcommand_hasinlinemanagerproof",
       "label": "hasInlineManagerProof()",
@@ -334057,7 +334156,7 @@
       "source_location": "L66"
     },
     {
-      "community": 643,
+      "community": 644,
       "file_type": "code",
       "id": "useapprovedcommand_useapprovedcommand",
       "label": "useApprovedCommand()",
@@ -334066,7 +334165,7 @@
       "source_location": "L102"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_paymentsaddedlist_test_tsx",
       "label": "PaymentsAddedList.test.tsx",
@@ -334075,7 +334174,7 @@
       "source_location": "L1"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "paymentsaddedlist_test_deferred",
       "label": "deferred()",
@@ -334084,7 +334183,7 @@
       "source_location": "L46"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummaryamount",
       "label": "getSummaryAmount()",
@@ -334093,7 +334192,7 @@
       "source_location": "L28"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarylabel",
       "label": "getSummaryLabel()",
@@ -334102,7 +334201,7 @@
       "source_location": "L19"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "paymentsaddedlist_test_getsummarypanel",
       "label": "getSummaryPanel()",
@@ -334111,7 +334210,7 @@
       "source_location": "L41"
     },
     {
-      "community": 644,
+      "community": 645,
       "file_type": "code",
       "id": "paymentsaddedlist_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -334120,7 +334219,7 @@
       "source_location": "L15"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_pointofsaleview_tsx",
       "label": "PointOfSaleView.tsx",
@@ -334129,7 +334228,7 @@
       "source_location": "L1"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "pointofsaleview_formatnextopeninglabel",
       "label": "formatNextOpeningLabel()",
@@ -334138,7 +334237,7 @@
       "source_location": "L132"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "pointofsaleview_formatstorehourstimelabel",
       "label": "formatStoreHoursTimeLabel()",
@@ -334147,7 +334246,7 @@
       "source_location": "L101"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatelabel",
       "label": "formatStoreLocalDateLabel()",
@@ -334156,7 +334255,7 @@
       "source_location": "L117"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "pointofsaleview_formatstorelocaldatetime",
       "label": "formatStoreLocalDateTime()",
@@ -334165,7 +334264,7 @@
       "source_location": "L80"
     },
     {
-      "community": 645,
+      "community": 646,
       "file_type": "code",
       "id": "pointofsaleview_useminutenow",
       "label": "useMinuteNow()",
@@ -334174,7 +334273,7 @@
       "source_location": "L145"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_register_posregisteropeningguard_tsx",
       "label": "POSRegisterOpeningGuard.tsx",
@@ -334183,7 +334282,7 @@
       "source_location": "L1"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdate",
       "label": "getLocalOperatingDate()",
@@ -334192,7 +334291,7 @@
       "source_location": "L65"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posregisteropeningguard_getlocaloperatingdaterange",
       "label": "getLocalOperatingDateRange()",
@@ -334201,7 +334300,7 @@
       "source_location": "L73"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posregisteropeningguard_if",
       "label": "if()",
@@ -334210,7 +334309,7 @@
       "source_location": "L689"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posregisteropeningguard_isbrowseroffline",
       "label": "isBrowserOffline()",
@@ -334219,7 +334318,7 @@
       "source_location": "L92"
     },
     {
-      "community": 646,
+      "community": 647,
       "file_type": "code",
       "id": "posregisteropeningguard_posregisteropeningguard",
       "label": "POSRegisterOpeningGuard()",
@@ -334228,7 +334327,7 @@
       "source_location": "L96"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_terminals_terminalhealthserverpolicyparity_test_ts",
       "label": "terminalHealthServerPolicyParity.test.ts",
@@ -334237,7 +334336,7 @@
       "source_location": "L1"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "terminalhealthserverpolicyparity_test_baseinput",
       "label": "baseInput()",
@@ -334246,7 +334345,7 @@
       "source_location": "L249"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "terminalhealthserverpolicyparity_test_buildruntimestatus",
       "label": "buildRuntimeStatus()",
@@ -334255,7 +334354,7 @@
       "source_location": "L297"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "terminalhealthserverpolicyparity_test_buildsummary",
       "label": "buildSummary()",
@@ -334264,7 +334363,7 @@
       "source_location": "L229"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "terminalhealthserverpolicyparity_test_emptysyncevidence",
       "label": "emptySyncEvidence()",
@@ -334273,7 +334372,7 @@
       "source_location": "L277"
     },
     {
-      "community": 647,
+      "community": 648,
       "file_type": "code",
       "id": "terminalhealthserverpolicyparity_test_renderable",
       "label": "renderable()",
@@ -334282,7 +334381,7 @@
       "source_location": "L211"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_transactions_transactionview_test_tsx",
       "label": "TransactionView.test.tsx",
@@ -334291,7 +334390,7 @@
       "source_location": "L1"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "transactionview_test_async",
       "label": "async()",
@@ -334300,7 +334399,7 @@
       "source_location": "L199"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "transactionview_test_deferred",
       "label": "deferred()",
@@ -334309,7 +334408,7 @@
       "source_location": "L15"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "transactionview_test_mocktransactionmutations",
       "label": "mockTransactionMutations()",
@@ -334318,7 +334417,7 @@
       "source_location": "L554"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "transactionview_test_paymentapprovalrequirement",
       "label": "paymentApprovalRequirement()",
@@ -334327,67 +334426,13 @@
       "source_location": "L473"
     },
     {
-      "community": 648,
+      "community": 649,
       "file_type": "code",
       "id": "transactionview_test_voidapprovalrequirement",
       "label": "voidApprovalRequirement()",
       "norm_label": "voidapprovalrequirement()",
       "source_file": "packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx",
       "source_location": "L506"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
-      "label": "ProcurementView.test.tsx",
-      "norm_label": "procurementview.test.tsx",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "procurementview_test_choosedraftvendor",
-      "label": "chooseDraftVendor()",
-      "norm_label": "choosedraftvendor()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L367"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "procurementview_test_chooseprocurementmode",
-      "label": "chooseProcurementMode()",
-      "norm_label": "chooseprocurementmode()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L357"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "procurementview_test_installmutationmocks",
-      "label": "installMutationMocks()",
-      "norm_label": "installmutationmocks()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L323"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "procurementview_test_makeproductskusearchresult",
-      "label": "makeProductSkuSearchResult()",
-      "norm_label": "makeproductskusearchresult()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L294"
-    },
-    {
-      "community": 649,
-      "file_type": "code",
-      "id": "procurementview_test_makerecommendation",
-      "label": "makeRecommendation()",
-      "norm_label": "makerecommendation()",
-      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
-      "source_location": "L285"
     },
     {
       "community": 65,
@@ -334626,6 +334671,60 @@
     {
       "community": 650,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_procurement_procurementview_test_tsx",
+      "label": "ProcurementView.test.tsx",
+      "norm_label": "procurementview.test.tsx",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "procurementview_test_choosedraftvendor",
+      "label": "chooseDraftVendor()",
+      "norm_label": "choosedraftvendor()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L367"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "procurementview_test_chooseprocurementmode",
+      "label": "chooseProcurementMode()",
+      "norm_label": "chooseprocurementmode()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L357"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "procurementview_test_installmutationmocks",
+      "label": "installMutationMocks()",
+      "norm_label": "installmutationmocks()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L323"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "procurementview_test_makeproductskusearchresult",
+      "label": "makeProductSkuSearchResult()",
+      "norm_label": "makeproductskusearchresult()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L294"
+    },
+    {
+      "community": 650,
+      "file_type": "code",
+      "id": "procurementview_test_makerecommendation",
+      "label": "makeRecommendation()",
+      "norm_label": "makerecommendation()",
+      "source_file": "packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx",
+      "source_location": "L285"
+    },
+    {
+      "community": 651,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_components_product_quickaddproductdialog_test_tsx",
       "label": "QuickAddProductDialog.test.tsx",
       "norm_label": "quickaddproductdialog.test.tsx",
@@ -334633,7 +334732,7 @@
       "source_location": "L1"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "quickaddproductdialog_test_renderquickadddialog",
       "label": "renderQuickAddDialog()",
@@ -334642,7 +334741,7 @@
       "source_location": "L26"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub",
       "label": "ResizeObserverStub",
@@ -334651,7 +334750,7 @@
       "source_location": "L8"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub_disconnect",
       "label": ".disconnect()",
@@ -334660,7 +334759,7 @@
       "source_location": "L11"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub_observe",
       "label": ".observe()",
@@ -334669,7 +334768,7 @@
       "source_location": "L9"
     },
     {
-      "community": 650,
+      "community": 651,
       "file_type": "code",
       "id": "quickaddproductdialog_test_resizeobserverstub_unobserve",
       "label": ".unobserve()",
@@ -334678,7 +334777,7 @@
       "source_location": "L10"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_weeklyreportpresentation_ts",
       "label": "weeklyReportPresentation.ts",
@@ -334687,7 +334786,7 @@
       "source_location": "L1"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyamendmentlabel",
       "label": "weeklyAmendmentLabel()",
@@ -334696,7 +334795,7 @@
       "source_location": "L74"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklylifecyclelabel",
       "label": "weeklyLifecycleLabel()",
@@ -334705,7 +334804,7 @@
       "source_location": "L16"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklytotalswithheld",
       "label": "weeklyTotalsWithheld()",
@@ -334714,7 +334813,7 @@
       "source_location": "L50"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyupdatedat",
       "label": "weeklyUpdatedAt()",
@@ -334723,7 +334822,7 @@
       "source_location": "L3"
     },
     {
-      "community": 651,
+      "community": 652,
       "file_type": "code",
       "id": "weeklyreportpresentation_weeklyvaluelabelprefix",
       "label": "weeklyValueLabelPrefix()",
@@ -334732,7 +334831,7 @@
       "source_location": "L63"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reviews_reviewsview_tsx",
       "label": "ReviewsView.tsx",
@@ -334741,7 +334840,7 @@
       "source_location": "L1"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "reviewsview_handleapprove",
       "label": "handleApprove()",
@@ -334750,7 +334849,7 @@
       "source_location": "L44"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "reviewsview_handlepublish",
       "label": "handlePublish()",
@@ -334759,7 +334858,7 @@
       "source_location": "L80"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "reviewsview_handlereject",
       "label": "handleReject()",
@@ -334768,7 +334867,7 @@
       "source_location": "L62"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "reviewsview_handleunpublish",
       "label": "handleUnpublish()",
@@ -334777,7 +334876,7 @@
       "source_location": "L98"
     },
     {
-      "community": 652,
+      "community": 653,
       "file_type": "code",
       "id": "reviewsview_header",
       "label": "Header()",
@@ -334786,7 +334885,7 @@
       "source_location": "L15"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_services_servicecatalogform_ts",
       "label": "serviceCatalogForm.ts",
@@ -334795,7 +334894,7 @@
       "source_location": "L1"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "servicecatalogform_formatservicecatalogname",
       "label": "formatServiceCatalogName()",
@@ -334804,7 +334903,7 @@
       "source_location": "L92"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "servicecatalogform_itemtoservicecatalogformstate",
       "label": "itemToServiceCatalogFormState()",
@@ -334813,7 +334912,7 @@
       "source_location": "L154"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogcreateform",
       "label": "parseServiceCatalogCreateForm()",
@@ -334822,7 +334921,7 @@
       "source_location": "L178"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "servicecatalogform_parseservicecatalogupdateform",
       "label": "parseServiceCatalogUpdateForm()",
@@ -334831,7 +334930,7 @@
       "source_location": "L203"
     },
     {
-      "community": 653,
+      "community": 654,
       "file_type": "code",
       "id": "servicecatalogform_validateservicecatalogform",
       "label": "validateServiceCatalogForm()",
@@ -334840,7 +334939,7 @@
       "source_location": "L102"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_test_ts",
       "label": "sharedDemoLiveReportsDay.test.ts",
@@ -334849,7 +334948,7 @@
       "source_location": "L1"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_identity",
       "label": "identity()",
@@ -334858,7 +334957,7 @@
       "source_location": "L21"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_liveresult",
       "label": "liveResult()",
@@ -334867,7 +334966,7 @@
       "source_location": "L77"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_metrics",
       "label": "metrics()",
@@ -334876,7 +334975,7 @@
       "source_location": "L48"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_quickaddidentity",
       "label": "quickAddIdentity()",
@@ -334885,7 +334984,7 @@
       "source_location": "L36"
     },
     {
-      "community": 654,
+      "community": 655,
       "file_type": "code",
       "id": "shareddemolivereportsday_test_skumetrics",
       "label": "skuMetrics()",
@@ -334894,7 +334993,7 @@
       "source_location": "L64"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemolivereportsday_ts",
       "label": "sharedDemoLiveReportsDay.ts",
@@ -334903,7 +335002,7 @@
       "source_location": "L1"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "shareddemolivereportsday_addskumetrics",
       "label": "addSkuMetrics()",
@@ -334912,7 +335011,7 @@
       "source_location": "L142"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "shareddemolivereportsday_shareddemofixtureskuid",
       "label": "sharedDemoFixtureSkuId()",
@@ -334921,7 +335020,7 @@
       "source_location": "L117"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "shareddemolivereportsday_toshareddemolivereportsday",
       "label": "toSharedDemoLiveReportsDay()",
@@ -334930,7 +335029,7 @@
       "source_location": "L169"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "shareddemolivereportsday_toshareddemoliveskustock",
       "label": "toSharedDemoLiveSkuStock()",
@@ -334939,7 +335038,7 @@
       "source_location": "L240"
     },
     {
-      "community": 655,
+      "community": 656,
       "file_type": "code",
       "id": "shareddemolivereportsday_zerodaymetrics",
       "label": "zeroDayMetrics()",
@@ -334948,7 +335047,7 @@
       "source_location": "L127"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_shared_demo_shareddemosurfacecatalog_ts",
       "label": "sharedDemoSurfaceCatalog.ts",
@@ -334957,7 +335056,7 @@
       "source_location": "L1"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_classifyathenaviewsurface",
       "label": "classifyAthenaViewSurface()",
@@ -334966,7 +335065,7 @@
       "source_location": "L396"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_isshareddemosurfacevisible",
       "label": "isSharedDemoSurfaceVisible()",
@@ -334975,7 +335074,7 @@
       "source_location": "L402"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_normalizepathname",
       "label": "normalizePathname()",
@@ -334984,7 +335083,7 @@
       "source_location": "L333"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_resolveathenaviewroute",
       "label": "resolveAthenaViewRoute()",
@@ -334993,7 +335092,7 @@
       "source_location": "L365"
     },
     {
-      "community": 656,
+      "community": 657,
       "file_type": "code",
       "id": "shareddemosurfacecatalog_routetemplatematches",
       "label": "routeTemplateMatches()",
@@ -335002,7 +335101,7 @@
       "source_location": "L341"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "feesview_formatdeliveryfeeinput",
       "label": "formatDeliveryFeeInput()",
@@ -335011,7 +335110,7 @@
       "source_location": "L31"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "feesview_handletoggleallfees",
       "label": "handleToggleAllFees()",
@@ -335020,7 +335119,7 @@
       "source_location": "L162"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "feesview_handleupdatefees",
       "label": "handleUpdateFees()",
@@ -335029,7 +335128,7 @@
       "source_location": "L88"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "feesview_parsedeliveryfeeinputs",
       "label": "parseDeliveryFeeInputs()",
@@ -335038,7 +335137,7 @@
       "source_location": "L45"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "feesview_parseoptionaldeliveryfeeinput",
       "label": "parseOptionalDeliveryFeeInput()",
@@ -335047,7 +335146,7 @@
       "source_location": "L35"
     },
     {
-      "community": 657,
+      "community": 658,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_components_feesview_tsx",
       "label": "FeesView.tsx",
@@ -335056,7 +335155,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_configuration_hooks_usenotificationsubscriptions_ts",
       "label": "useNotificationSubscriptions.ts",
@@ -335065,7 +335164,7 @@
       "source_location": "L1"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "usenotificationsubscriptions_derivecategorystate",
       "label": "deriveCategoryState()",
@@ -335074,7 +335173,7 @@
       "source_location": "L108"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "usenotificationsubscriptions_isvalidrecipientemail",
       "label": "isValidRecipientEmail()",
@@ -335083,7 +335182,7 @@
       "source_location": "L99"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "usenotificationsubscriptions_normalizerecipientemailinput",
       "label": "normalizeRecipientEmailInput()",
@@ -335092,7 +335191,7 @@
       "source_location": "L95"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "usenotificationsubscriptions_sortrecipientcandidates",
       "label": "sortRecipientCandidates()",
@@ -335101,67 +335200,13 @@
       "source_location": "L122"
     },
     {
-      "community": 658,
+      "community": 659,
       "file_type": "code",
       "id": "usenotificationsubscriptions_usenotificationsubscriptions",
       "label": "useNotificationSubscriptions()",
       "norm_label": "usenotificationsubscriptions()",
       "source_file": "packages/athena-webapp/src/components/store-configuration/hooks/useNotificationSubscriptions.ts",
       "source_location": "L133"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
-      "label": "WorkflowTraceView.tsx",
-      "norm_label": "workflowtraceview.tsx",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "workflowtraceview_formatpaymentmethods",
-      "label": "formatPaymentMethods()",
-      "norm_label": "formatpaymentmethods()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L138"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "workflowtraceview_formattracelabel",
-      "label": "formatTraceLabel()",
-      "norm_label": "formattracelabel()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L202"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "workflowtraceview_formattracemoney",
-      "label": "formatTraceMoney()",
-      "norm_label": "formattracemoney()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "workflowtraceview_getlifecyclestatement",
-      "label": "getLifecycleStatement()",
-      "norm_label": "getlifecyclestatement()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L63"
-    },
-    {
-      "community": 659,
-      "file_type": "code",
-      "id": "workflowtraceview_gettransactionstatement",
-      "label": "getTransactionStatement()",
-      "norm_label": "gettransactionstatement()",
-      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
-      "source_location": "L147"
     },
     {
       "community": 66,
@@ -335400,6 +335445,60 @@
     {
       "community": 660,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_components_traces_workflowtraceview_tsx",
+      "label": "WorkflowTraceView.tsx",
+      "norm_label": "workflowtraceview.tsx",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "workflowtraceview_formatpaymentmethods",
+      "label": "formatPaymentMethods()",
+      "norm_label": "formatpaymentmethods()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L138"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "workflowtraceview_formattracelabel",
+      "label": "formatTraceLabel()",
+      "norm_label": "formattracelabel()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L202"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "workflowtraceview_formattracemoney",
+      "label": "formatTraceMoney()",
+      "norm_label": "formattracemoney()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "workflowtraceview_getlifecyclestatement",
+      "label": "getLifecycleStatement()",
+      "norm_label": "getlifecyclestatement()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L63"
+    },
+    {
+      "community": 660,
+      "file_type": "code",
+      "id": "workflowtraceview_gettransactionstatement",
+      "label": "getTransactionStatement()",
+      "norm_label": "gettransactionstatement()",
+      "source_file": "packages/athena-webapp/src/components/traces/WorkflowTraceView.tsx",
+      "source_location": "L147"
+    },
+    {
+      "community": 661,
+      "file_type": "code",
       "id": "image_uploader_ondragend",
       "label": "onDragEnd()",
       "norm_label": "ondragend()",
@@ -335407,7 +335506,7 @@
       "source_location": "L101"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "image_uploader_ondrop",
       "label": "onDrop()",
@@ -335416,7 +335515,7 @@
       "source_location": "L20"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "image_uploader_removeimage",
       "label": "removeImage()",
@@ -335425,7 +335524,7 @@
       "source_location": "L31"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "image_uploader_unmarkfordeletion",
       "label": "unmarkForDeletion()",
@@ -335434,7 +335533,7 @@
       "source_location": "L46"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -335443,7 +335542,7 @@
       "source_location": "L1"
     },
     {
-      "community": 660,
+      "community": 661,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_ui_image_uploader_tsx",
       "label": "image-uploader.tsx",
@@ -335452,7 +335551,7 @@
       "source_location": "L1"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "config_derivestorefrontfromadminhost",
       "label": "deriveStoreFrontFromAdminHost()",
@@ -335461,7 +335560,7 @@
       "source_location": "L29"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "config_getruntimeorigin",
       "label": "getRuntimeOrigin()",
@@ -335470,7 +335569,7 @@
       "source_location": "L12"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "config_islocalhost",
       "label": "isLocalHost()",
@@ -335479,7 +335578,7 @@
       "source_location": "L20"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "config_resolvestorefronturl",
       "label": "resolveStoreFrontUrl()",
@@ -335488,7 +335587,7 @@
       "source_location": "L51"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "config_trimtrailingslash",
       "label": "trimTrailingSlash()",
@@ -335497,7 +335596,7 @@
       "source_location": "L8"
     },
     {
-      "community": 661,
+      "community": 662,
       "file_type": "code",
       "id": "packages_athena_webapp_src_config_ts",
       "label": "config.ts",
@@ -335506,7 +335605,7 @@
       "source_location": "L1"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "managerelevationcontext_getstaffdisplayname",
       "label": "getStaffDisplayName()",
@@ -335515,7 +335614,7 @@
       "source_location": "L64"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "managerelevationcontext_managerelevationprovider",
       "label": "ManagerElevationProvider()",
@@ -335524,7 +335623,7 @@
       "source_location": "L87"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "managerelevationcontext_tostaffauthenticationresult",
       "label": "toStaffAuthenticationResult()",
@@ -335533,7 +335632,7 @@
       "source_location": "L74"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "managerelevationcontext_usemanagerelevation",
       "label": "useManagerElevation()",
@@ -335542,7 +335641,7 @@
       "source_location": "L242"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "managerelevationcontext_useoptionalmanagerelevation",
       "label": "useOptionalManagerElevation()",
@@ -335551,7 +335650,7 @@
       "source_location": "L251"
     },
     {
-      "community": 662,
+      "community": 663,
       "file_type": "code",
       "id": "packages_athena_webapp_src_contexts_managerelevationcontext_tsx",
       "label": "ManagerElevationContext.tsx",
@@ -335560,7 +335659,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpensesessions_ts",
       "label": "useExpenseSessions.ts",
@@ -335569,7 +335668,7 @@
       "source_location": "L1"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "useexpensesessions_useexpenseactivesession",
       "label": "useExpenseActiveSession()",
@@ -335578,7 +335677,7 @@
       "source_location": "L42"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesession",
       "label": "useExpenseSession()",
@@ -335587,7 +335686,7 @@
       "source_location": "L32"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessioncreate",
       "label": "useExpenseSessionCreate()",
@@ -335596,7 +335695,7 @@
       "source_location": "L62"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "useexpensesessions_useexpensesessionupdate",
       "label": "useExpenseSessionUpdate()",
@@ -335605,7 +335704,7 @@
       "source_location": "L101"
     },
     {
-      "community": 663,
+      "community": 664,
       "file_type": "code",
       "id": "useexpensesessions_useexpensestoresessions",
       "label": "useExpenseStoreSessions()",
@@ -335614,7 +335713,7 @@
       "source_location": "L10"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "capabilities_canaccesscashcontrolssurface",
       "label": "canAccessCashControlsSurface()",
@@ -335623,7 +335722,7 @@
       "source_location": "L54"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "capabilities_canaccessfulladminsurface",
       "label": "canAccessFullAdminSurface()",
@@ -335632,7 +335731,7 @@
       "source_location": "L41"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "capabilities_canaccessstoredaysurface",
       "label": "canAccessStoreDaySurface()",
@@ -335641,7 +335740,7 @@
       "source_location": "L47"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "capabilities_canviewfinancialdetails",
       "label": "canViewFinancialDetails()",
@@ -335650,7 +335749,7 @@
       "source_location": "L61"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "capabilities_getsurfaceaccess",
       "label": "getSurfaceAccess()",
@@ -335659,7 +335758,7 @@
       "source_location": "L68"
     },
     {
-      "community": 664,
+      "community": 665,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_access_capabilities_ts",
       "label": "capabilities.ts",
@@ -335668,7 +335767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "behaviorutils_calculateengagementmetrics",
       "label": "calculateEngagementMetrics()",
@@ -335677,7 +335776,7 @@
       "source_location": "L173"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "behaviorutils_calculateriskindicators",
       "label": "calculateRiskIndicators()",
@@ -335686,7 +335785,7 @@
       "source_location": "L71"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "behaviorutils_getactivitypriority",
       "label": "getActivityPriority()",
@@ -335695,7 +335794,7 @@
       "source_location": "L251"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "behaviorutils_getcustomerjourneystage",
       "label": "getCustomerJourneyStage()",
@@ -335704,7 +335803,7 @@
       "source_location": "L36"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "behaviorutils_getjourneystageinfo",
       "label": "getJourneyStageInfo()",
@@ -335713,7 +335812,7 @@
       "source_location": "L277"
     },
     {
-      "community": 665,
+      "community": 666,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_behaviorutils_ts",
       "label": "behaviorUtils.ts",
@@ -335722,7 +335821,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_errors_productarchivefailure_ts",
       "label": "productArchiveFailure.ts",
@@ -335731,7 +335830,7 @@
       "source_location": "L1"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "productarchivefailure_productarchiveblockederror",
       "label": "ProductArchiveBlockedError",
@@ -335740,7 +335839,7 @@
       "source_location": "L17"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "productarchivefailure_productarchiveblockederror_constructor",
       "label": ".constructor()",
@@ -335749,7 +335848,7 @@
       "source_location": "L21"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "productarchivefailure_productarchiveblockfromresult",
       "label": "productArchiveBlockFromResult()",
@@ -335758,7 +335857,7 @@
       "source_location": "L36"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "productarchivefailure_readgroupcount",
       "label": "readGroupCount()",
@@ -335767,7 +335866,7 @@
       "source_location": "L30"
     },
     {
-      "community": 666,
+      "community": 667,
       "file_type": "code",
       "id": "productarchivefailure_resolveproductarchivefailuretoast",
       "label": "resolveProductArchiveFailureToast()",
@@ -335776,7 +335875,7 @@
       "source_location": "L56"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_application_results_ts",
       "label": "results.ts",
@@ -335785,7 +335884,7 @@
       "source_location": "L1"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "results_isposusecasesuccess",
       "label": "isPosUseCaseSuccess()",
@@ -335794,7 +335893,7 @@
       "source_location": "L141"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "results_mapcommandoutcome",
       "label": "mapCommandOutcome()",
@@ -335803,7 +335902,7 @@
       "source_location": "L73"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "results_mapcommandresult",
       "label": "mapCommandResult()",
@@ -335812,7 +335911,7 @@
       "source_location": "L90"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "results_maplegacymutationresult",
       "label": "mapLegacyMutationResult()",
@@ -335821,7 +335920,7 @@
       "source_location": "L56"
     },
     {
-      "community": 667,
+      "community": 668,
       "file_type": "code",
       "id": "results_mapthrownerror",
       "label": "mapThrownError()",
@@ -335830,7 +335929,7 @@
       "source_location": "L107"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerlifecycleauthoritycandidates_ts",
       "label": "registerLifecycleAuthorityCandidates.ts",
@@ -335839,7 +335938,7 @@
       "source_location": "L1"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_deriveregisterlifecycleauthoritycandidates",
       "label": "deriveRegisterLifecycleAuthorityCandidates()",
@@ -335848,7 +335947,7 @@
       "source_location": "L45"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_isboundedidentifier",
       "label": "isBoundedIdentifier()",
@@ -335857,7 +335956,7 @@
       "source_location": "L220"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_iseligibleregistermapping",
       "label": "isEligibleRegisterMapping()",
@@ -335866,7 +335965,7 @@
       "source_location": "L167"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_legacymappingmatchesactivesession",
       "label": "legacyMappingMatchesActiveSession()",
@@ -335875,67 +335974,13 @@
       "source_location": "L182"
     },
     {
-      "community": 668,
+      "community": 669,
       "file_type": "code",
       "id": "registerlifecycleauthoritycandidates_mappingcandidate",
       "label": "mappingCandidate()",
       "norm_label": "mappingcandidate()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/registerLifecycleAuthorityCandidates.ts",
       "source_location": "L194"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
-      "label": "usePosLocalSyncRuntime.test.ts",
-      "norm_label": "useposlocalsyncruntime.test.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "useposlocalsyncruntime_test_buildlocalevent",
-      "label": "buildLocalEvent()",
-      "norm_label": "buildlocalevent()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
-      "source_location": "L7490"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "useposlocalsyncruntime_test_buildrecoverycommand",
-      "label": "buildRecoveryCommand()",
-      "norm_label": "buildrecoverycommand()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
-      "source_location": "L7513"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
-      "label": "buildRecoveryCommandStore()",
-      "norm_label": "buildrecoverycommandstore()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
-      "source_location": "L7532"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "useposlocalsyncruntime_test_deferred",
-      "label": "deferred()",
-      "norm_label": "deferred()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
-      "source_location": "L108"
-    },
-    {
-      "community": 669,
-      "file_type": "code",
-      "id": "useposlocalsyncruntime_test_storefactory",
-      "label": "storeFactory()",
-      "norm_label": "storefactory()",
-      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
-      "source_location": "L352"
     },
     {
       "community": 67,
@@ -336174,6 +336219,60 @@
     {
       "community": 670,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useposlocalsyncruntime_test_ts",
+      "label": "usePosLocalSyncRuntime.test.ts",
+      "norm_label": "useposlocalsyncruntime.test.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "useposlocalsyncruntime_test_buildlocalevent",
+      "label": "buildLocalEvent()",
+      "norm_label": "buildlocalevent()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
+      "source_location": "L7490"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "useposlocalsyncruntime_test_buildrecoverycommand",
+      "label": "buildRecoveryCommand()",
+      "norm_label": "buildrecoverycommand()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
+      "source_location": "L7513"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "useposlocalsyncruntime_test_buildrecoverycommandstore",
+      "label": "buildRecoveryCommandStore()",
+      "norm_label": "buildrecoverycommandstore()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
+      "source_location": "L7532"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "useposlocalsyncruntime_test_deferred",
+      "label": "deferred()",
+      "norm_label": "deferred()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
+      "source_location": "L108"
+    },
+    {
+      "community": 670,
+      "file_type": "code",
+      "id": "useposlocalsyncruntime_test_storefactory",
+      "label": "storeFactory()",
+      "norm_label": "storefactory()",
+      "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts",
+      "source_location": "L352"
+    },
+    {
+      "community": 671,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_presentation_register_selectors_ts",
       "label": "selectors.ts",
       "norm_label": "selectors.ts",
@@ -336181,7 +336280,7 @@
       "source_location": "L1"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "selectors_buildregisterheaderstate",
       "label": "buildRegisterHeaderState()",
@@ -336190,7 +336289,7 @@
       "source_location": "L28"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "selectors_buildregisterinfostate",
       "label": "buildRegisterInfoState()",
@@ -336199,7 +336298,7 @@
       "source_location": "L37"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "selectors_getcashierdisplayname",
       "label": "getCashierDisplayName()",
@@ -336208,7 +336307,7 @@
       "source_location": "L12"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "selectors_getregistercustomerinfo",
       "label": "getRegisterCustomerInfo()",
@@ -336217,7 +336316,7 @@
       "source_location": "L6"
     },
     {
-      "community": 670,
+      "community": 671,
       "file_type": "code",
       "id": "selectors_isregistersessionactive",
       "label": "isRegisterSessionActive()",
@@ -336226,7 +336325,7 @@
       "source_location": "L49"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_toastservice_ts",
       "label": "toastService.ts",
@@ -336235,7 +336334,7 @@
       "source_location": "L1"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "toastservice_handleposoperation",
       "label": "handlePOSOperation()",
@@ -336244,7 +336343,7 @@
       "source_location": "L171"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "toastservice_showinventoryerror",
       "label": "showInventoryError()",
@@ -336253,7 +336352,7 @@
       "source_location": "L313"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "toastservice_shownoactivesessionerror",
       "label": "showNoActiveSessionError()",
@@ -336262,7 +336361,7 @@
       "source_location": "L330"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "toastservice_showsessionexpirederror",
       "label": "showSessionExpiredError()",
@@ -336271,7 +336370,7 @@
       "source_location": "L323"
     },
     {
-      "community": 671,
+      "community": 672,
       "file_type": "code",
       "id": "toastservice_showvalidationerror",
       "label": "showValidationError()",
@@ -336280,7 +336379,7 @@
       "source_location": "L304"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_sheetreturn_ts",
       "label": "sheetReturn.ts",
@@ -336289,7 +336388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "sheetreturn_decodesheetreturn",
       "label": "decodeSheetReturn()",
@@ -336298,7 +336397,7 @@
       "source_location": "L85"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "sheetreturn_encodefocuskey",
       "label": "encodeFocusKey()",
@@ -336307,7 +336406,7 @@
       "source_location": "L74"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "sheetreturn_encodesheetreturn",
       "label": "encodeSheetReturn()",
@@ -336316,7 +336415,7 @@
       "source_location": "L55"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "sheetreturn_sheetreturnfocusselector",
       "label": "sheetReturnFocusSelector()",
@@ -336325,7 +336424,7 @@
       "source_location": "L126"
     },
     {
-      "community": 672,
+      "community": 673,
       "file_type": "code",
       "id": "sheetreturn_sheetreturntargetprops",
       "label": "sheetReturnTargetProps()",
@@ -336334,7 +336433,7 @@
       "source_location": "L131"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_skusearch_productskusearchadapters_ts",
       "label": "productSkuSearchAdapters.ts",
@@ -336343,7 +336442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoption",
       "label": "buildAdminSkuSearchOption()",
@@ -336352,7 +336451,7 @@
       "source_location": "L80"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productskusearchadapters_buildadminskusearchoptions",
       "label": "buildAdminSkuSearchOptions()",
@@ -336361,7 +336460,7 @@
       "source_location": "L132"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productskusearchadapters_compactjoin",
       "label": "compactJoin()",
@@ -336370,7 +336469,7 @@
       "source_location": "L73"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productskusearchadapters_groupadminskusearchoptionsbyproduct",
       "label": "groupAdminSkuSearchOptionsByProduct()",
@@ -336379,7 +336478,7 @@
       "source_location": "L138"
     },
     {
-      "community": 673,
+      "community": 674,
       "file_type": "code",
       "id": "productskusearchadapters_presentationtext",
       "label": "presentationText()",
@@ -336388,7 +336487,7 @@
       "source_location": "L66"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_stockops_skusearch_ts",
       "label": "skuSearch.ts",
@@ -336397,7 +336496,7 @@
       "source_location": "L1"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "skusearch_isbarcodeshapedsearchquery",
       "label": "isBarcodeShapedSearchQuery()",
@@ -336406,7 +336505,7 @@
       "source_location": "L49"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "skusearch_matchesskusearchterms",
       "label": "matchesSkuSearchTerms()",
@@ -336415,7 +336514,7 @@
       "source_location": "L11"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "skusearch_normalizeidentifier",
       "label": "normalizeIdentifier()",
@@ -336424,7 +336523,7 @@
       "source_location": "L53"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "skusearch_normalizeskusearchquery",
       "label": "normalizeSkuSearchQuery()",
@@ -336433,7 +336532,7 @@
       "source_location": "L7"
     },
     {
-      "community": 674,
+      "community": 675,
       "file_type": "code",
       "id": "skusearch_scoreskusearchterms",
       "label": "scoreSkuSearchTerms()",
@@ -336442,7 +336541,7 @@
       "source_location": "L18"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellroutes_ts",
       "label": "posAppShellRoutes.ts",
@@ -336451,7 +336550,7 @@
       "source_location": "L1"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "posappshellroutes_isexcludedfromposappshellcache",
       "label": "isExcludedFromPosAppShellCache()",
@@ -336460,7 +336559,7 @@
       "source_location": "L53"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellnavigationrequest",
       "label": "isPosAppShellNavigationRequest()",
@@ -336469,7 +336568,7 @@
       "source_location": "L71"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellroutepath",
       "label": "isPosAppShellRoutePath()",
@@ -336478,7 +336577,7 @@
       "source_location": "L48"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "posappshellroutes_isposappshellstaticassetrequest",
       "label": "isPosAppShellStaticAssetRequest()",
@@ -336487,7 +336586,7 @@
       "source_location": "L88"
     },
     {
-      "community": 675,
+      "community": 676,
       "file_type": "code",
       "id": "posappshellroutes_readheader",
       "label": "readHeader()",
@@ -336496,7 +336595,7 @@
       "source_location": "L107"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_posappshellserviceworkerstaging_test_ts",
       "label": "posAppShellServiceWorkerStaging.test.ts",
@@ -336505,7 +336604,7 @@
       "source_location": "L1"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_createserviceworkerfixture",
       "label": "createServiceWorkerFixture()",
@@ -336514,7 +336613,7 @@
       "source_location": "L32"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache",
       "label": "MemoryCache",
@@ -336523,7 +336622,7 @@
       "source_location": "L14"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_keys",
       "label": ".keys()",
@@ -336532,7 +336631,7 @@
       "source_location": "L27"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_match",
       "label": ".match()",
@@ -336541,7 +336640,7 @@
       "source_location": "L17"
     },
     {
-      "community": 676,
+      "community": 677,
       "file_type": "code",
       "id": "posappshellserviceworkerstaging_test_memorycache_put",
       "label": ".put()",
@@ -336550,7 +336649,7 @@
       "source_location": "L22"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "docs_shared_companionsection",
       "label": "CompanionSection()",
@@ -336559,7 +336658,7 @@
       "source_location": "L81"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "docs_shared_formatcategorylabel",
       "label": "formatCategoryLabel()",
@@ -336568,7 +336667,7 @@
       "source_location": "L7"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "docs_shared_formatdocdate",
       "label": "formatDocDate()",
@@ -336577,7 +336676,7 @@
       "source_location": "L11"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "docs_shared_severityindicator",
       "label": "SeverityIndicator()",
@@ -336586,7 +336685,7 @@
       "source_location": "L32"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "docs_shared_solutiondoccard",
       "label": "SolutionDocCard()",
@@ -336595,7 +336694,7 @@
       "source_location": "L48"
     },
     {
-      "community": 677,
+      "community": 678,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_docs_shared_tsx",
       "label": "-docs-shared.tsx",
@@ -336604,7 +336703,7 @@
       "source_location": "L1"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "index_route_view_democtabutton",
       "label": "DemoCtaButton()",
@@ -336613,7 +336712,7 @@
       "source_location": "L192"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "index_route_view_herogrid",
       "label": "HeroGrid()",
@@ -336622,7 +336721,7 @@
       "source_location": "L178"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "index_route_view_rest",
       "label": "rest()",
@@ -336631,7 +336730,7 @@
       "source_location": "L246"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "index_route_view_useheroshotrevealref",
       "label": "useHeroShotRevealRef()",
@@ -336640,7 +336739,7 @@
       "source_location": "L54"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "index_route_view_useheroshottiltref",
       "label": "useHeroShotTiltRef()",
@@ -336649,67 +336748,13 @@
       "source_location": "L107"
     },
     {
-      "community": 678,
+      "community": 679,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_index_route_view_tsx",
       "label": "-index-route-view.tsx",
       "norm_label": "-index-route-view.tsx",
       "source_file": "packages/athena-webapp/src/routes/-index-route-view.tsx",
       "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
-      "label": "procurement.index.tsx",
-      "norm_label": "procurement.index.tsx",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "procurement_index_getnextprocurementmodesearch",
-      "label": "getNextProcurementModeSearch()",
-      "norm_label": "getnextprocurementmodesearch()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "procurement_index_getnextprocurementpagesearch",
-      "label": "getNextProcurementPageSearch()",
-      "norm_label": "getnextprocurementpagesearch()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L37"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "procurement_index_getnextprocurementquerysearch",
-      "label": "getNextProcurementQuerySearch()",
-      "norm_label": "getnextprocurementquerysearch()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L47"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "procurement_index_getnextprocurementselectedskusearch",
-      "label": "getNextProcurementSelectedSkuSearch()",
-      "norm_label": "getnextprocurementselectedskusearch()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L62"
-    },
-    {
-      "community": 679,
-      "file_type": "code",
-      "id": "procurement_index_procurementroute",
-      "label": "ProcurementRoute()",
-      "norm_label": "procurementroute()",
-      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
-      "source_location": "L88"
     },
     {
       "community": 68,
@@ -336948,6 +336993,60 @@
     {
       "community": 680,
       "file_type": "code",
+      "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_procurement_index_tsx",
+      "label": "procurement.index.tsx",
+      "norm_label": "procurement.index.tsx",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "procurement_index_getnextprocurementmodesearch",
+      "label": "getNextProcurementModeSearch()",
+      "norm_label": "getnextprocurementmodesearch()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "procurement_index_getnextprocurementpagesearch",
+      "label": "getNextProcurementPageSearch()",
+      "norm_label": "getnextprocurementpagesearch()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L37"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "procurement_index_getnextprocurementquerysearch",
+      "label": "getNextProcurementQuerySearch()",
+      "norm_label": "getnextprocurementquerysearch()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L47"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "procurement_index_getnextprocurementselectedskusearch",
+      "label": "getNextProcurementSelectedSkuSearch()",
+      "norm_label": "getnextprocurementselectedskusearch()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L62"
+    },
+    {
+      "community": 680,
+      "file_type": "code",
+      "id": "procurement_index_procurementroute",
+      "label": "ProcurementRoute()",
+      "norm_label": "procurementroute()",
+      "source_file": "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx",
+      "source_location": "L88"
+    },
+    {
+      "community": 681,
+      "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_reports_weekly_lifecycle_test_tsx",
       "label": "weekly.lifecycle.test.tsx",
       "norm_label": "weekly.lifecycle.test.tsx",
@@ -336955,7 +337054,7 @@
       "source_location": "L1"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "weekly_lifecycle_test_installcompletedmovement",
       "label": "installCompletedMovement()",
@@ -336964,7 +337063,7 @@
       "source_location": "L283"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "weekly_lifecycle_test_isshareddemostandingread",
       "label": "isSharedDemoStandingRead()",
@@ -336973,7 +337072,7 @@
       "source_location": "L102"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "weekly_lifecycle_test_movementrow",
       "label": "movementRow()",
@@ -336982,7 +337081,7 @@
       "source_location": "L268"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "weekly_lifecycle_test_params",
       "label": "params()",
@@ -336991,7 +337090,7 @@
       "source_location": "L40"
     },
     {
-      "community": 680,
+      "community": 681,
       "file_type": "code",
       "id": "weekly_lifecycle_test_stubensuremutation",
       "label": "stubEnsureMutation()",
@@ -337000,7 +337099,7 @@
       "source_location": "L81"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "login_layout_completependingauthsync",
       "label": "completePendingAuthSync()",
@@ -337009,7 +337108,7 @@
       "source_location": "L145"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "login_layout_handlependingauthsync",
       "label": "handlePendingAuthSync()",
@@ -337018,7 +337117,7 @@
       "source_location": "L95"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "login_layout_navigationtargetforredirect",
       "label": "navigationTargetForRedirect()",
@@ -337027,7 +337126,7 @@
       "source_location": "L33"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "login_layout_sleep",
       "label": "sleep()",
@@ -337036,7 +337135,7 @@
       "source_location": "L29"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "login_layout_usedocumentscrolllock",
       "label": "useDocumentScrollLock()",
@@ -337045,7 +337144,7 @@
       "source_location": "L45"
     },
     {
-      "community": 681,
+      "community": 682,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_login_login_layout_tsx",
       "label": "-login-layout.tsx",
@@ -337054,7 +337153,7 @@
       "source_location": "L1"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "organizationsettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -337063,7 +337162,7 @@
       "source_location": "L155"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "organizationsettingsview_navigation",
       "label": "Navigation()",
@@ -337072,7 +337171,7 @@
       "source_location": "L197"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "organizationsettingsview_onsubmit",
       "label": "onSubmit()",
@@ -337081,7 +337180,7 @@
       "source_location": "L104"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "organizationsettingsview_organizationsettings",
       "label": "OrganizationSettings()",
@@ -337090,7 +337189,7 @@
       "source_location": "L25"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "organizationsettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -337099,7 +337198,7 @@
       "source_location": "L72"
     },
     {
-      "community": 682,
+      "community": 683,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_organization_components_organizationsettingsview_tsx",
       "label": "OrganizationSettingsView.tsx",
@@ -337108,7 +337207,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "packages_athena_webapp_src_settings_store_storesettingsview_tsx",
       "label": "StoreSettingsView.tsx",
@@ -337117,7 +337216,7 @@
       "source_location": "L1"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "storesettingsview_handledeleteallproductsinstore",
       "label": "handleDeleteAllProductsInStore()",
@@ -337126,7 +337225,7 @@
       "source_location": "L231"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "storesettingsview_handledeletestore",
       "label": "handleDeleteStore()",
@@ -337135,7 +337234,7 @@
       "source_location": "L167"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "storesettingsview_onsubmit",
       "label": "onSubmit()",
@@ -337144,7 +337243,7 @@
       "source_location": "L116"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "storesettingsview_savestorechanges",
       "label": "saveStoreChanges()",
@@ -337153,7 +337252,7 @@
       "source_location": "L83"
     },
     {
-      "community": 683,
+      "community": 684,
       "file_type": "code",
       "id": "storesettingsview_storesettings",
       "label": "StoreSettings()",
@@ -337162,7 +337261,7 @@
       "source_location": "L29"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyclosefixture",
       "label": "useDailyCloseFixture()",
@@ -337171,7 +337270,7 @@
       "source_location": "L102"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyopeningfixture",
       "label": "useDailyOpeningFixture()",
@@ -337180,7 +337279,7 @@
       "source_location": "L96"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "devfixtureactivation_usedailyoperationsfixture",
       "label": "useDailyOperationsFixture()",
@@ -337189,7 +337288,7 @@
       "source_location": "L90"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "devfixtureactivation_useposhubfixture",
       "label": "usePosHubFixture()",
@@ -337198,7 +337297,7 @@
       "source_location": "L108"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "devfixtureactivation_useworkspacefixture",
       "label": "useWorkspaceFixture()",
@@ -337207,7 +337306,7 @@
       "source_location": "L46"
     },
     {
-      "community": 684,
+      "community": 685,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_operations_devfixtureactivation_ts",
       "label": "devFixtureActivation.ts",
@@ -337216,7 +337315,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stories_storybook_shell_tsx",
       "label": "storybook-shell.tsx",
@@ -337225,7 +337324,7 @@
       "source_location": "L1"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "storybook_shell_storybookcallout",
       "label": "StorybookCallout()",
@@ -337234,7 +337333,7 @@
       "source_location": "L76"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "storybook_shell_storybooklist",
       "label": "StorybookList()",
@@ -337243,7 +337342,7 @@
       "source_location": "L55"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "storybook_shell_storybookpillrow",
       "label": "StorybookPillRow()",
@@ -337252,7 +337351,7 @@
       "source_location": "L88"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "storybook_shell_storybooksection",
       "label": "StorybookSection()",
@@ -337261,7 +337360,7 @@
       "source_location": "L34"
     },
     {
-      "community": 685,
+      "community": 686,
       "file_type": "code",
       "id": "storybook_shell_storybookshell",
       "label": "StorybookShell()",
@@ -337270,7 +337369,7 @@
       "source_location": "L13"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_postransaction_ts",
       "label": "posTransaction.ts",
@@ -337279,7 +337378,7 @@
       "source_location": "L1"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "postransaction_fetchpostransaction",
       "label": "fetchPosTransaction()",
@@ -337288,7 +337387,7 @@
       "source_location": "L69"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "postransaction_getbaseurl",
       "label": "getBaseUrl()",
@@ -337297,7 +337396,7 @@
       "source_location": "L57"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "postransaction_getpostransactionbyreceipttoken",
       "label": "getPosTransactionByReceiptToken()",
@@ -337306,7 +337405,7 @@
       "source_location": "L90"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror",
       "label": "PosTransactionReceiptError",
@@ -337315,7 +337414,7 @@
       "source_location": "L59"
     },
     {
-      "community": 686,
+      "community": 687,
       "file_type": "code",
       "id": "postransaction_postransactionreceipterror_constructor",
       "label": ".constructor()",
@@ -337324,7 +337423,7 @@
       "source_location": "L62"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_promocodes_ts",
       "label": "promoCodes.ts",
@@ -337333,7 +337432,7 @@
       "source_location": "L1"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "promocodes_getbaseurl",
       "label": "getBaseUrl()",
@@ -337342,7 +337441,7 @@
       "source_location": "L4"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "promocodes_getpromocodeitems",
       "label": "getPromoCodeItems()",
@@ -337351,7 +337450,7 @@
       "source_location": "L49"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "promocodes_getpromocodes",
       "label": "getPromoCodes()",
@@ -337360,7 +337459,7 @@
       "source_location": "L34"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "promocodes_getredeemedpromocodes",
       "label": "getRedeemedPromoCodes()",
@@ -337369,7 +337468,7 @@
       "source_location": "L74"
     },
     {
-      "community": 687,
+      "community": 688,
       "file_type": "code",
       "id": "promocodes_redeempromocode",
       "label": "redeemPromoCode()",
@@ -337378,7 +337477,7 @@
       "source_location": "L6"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "billingdetails_clearform",
       "label": "clearForm()",
@@ -337387,7 +337486,7 @@
       "source_location": "L173"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "billingdetails_enteredbillingaddressdetails",
       "label": "EnteredBillingAddressDetails()",
@@ -337396,7 +337495,7 @@
       "source_location": "L102"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "billingdetails_handleusebillingaddressonfile",
       "label": "handleUseBillingAddressOnFile()",
@@ -337405,7 +337504,7 @@
       "source_location": "L201"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "billingdetails_onsubmit",
       "label": "onSubmit()",
@@ -337414,7 +337513,7 @@
       "source_location": "L150"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "billingdetails_togglesameasdelivery",
       "label": "toggleSameAsDelivery()",
@@ -337423,66 +337522,12 @@
       "source_location": "L155"
     },
     {
-      "community": 688,
+      "community": 689,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_checkout_billingdetails_tsx",
       "label": "BillingDetails.tsx",
       "norm_label": "billingdetails.tsx",
       "source_file": "packages/storefront-webapp/src/components/checkout/BillingDetails.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "homehero_test_attachmedia",
-      "label": "attachMedia()",
-      "norm_label": "attachmedia()",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
-      "source_location": "L22"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "homehero_test_destroy",
-      "label": "destroy()",
-      "norm_label": "destroy()",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
-      "source_location": "L24"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "homehero_test_issupported",
-      "label": "isSupported()",
-      "norm_label": "issupported()",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
-      "source_location": "L18"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "homehero_test_loadsource",
-      "label": "loadSource()",
-      "norm_label": "loadsource()",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
-      "source_location": "L21"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "homehero_test_on",
-      "label": "on()",
-      "norm_label": "on()",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
-      "source_location": "L23"
-    },
-    {
-      "community": 689,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
-      "label": "HomeHero.test.tsx",
-      "norm_label": "homehero.test.tsx",
-      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
       "source_location": "L1"
     },
     {
@@ -337722,6 +337767,60 @@
     {
       "community": 690,
       "file_type": "code",
+      "id": "homehero_test_attachmedia",
+      "label": "attachMedia()",
+      "norm_label": "attachmedia()",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
+      "source_location": "L22"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "homehero_test_destroy",
+      "label": "destroy()",
+      "norm_label": "destroy()",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
+      "source_location": "L24"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "homehero_test_issupported",
+      "label": "isSupported()",
+      "norm_label": "issupported()",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
+      "source_location": "L18"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "homehero_test_loadsource",
+      "label": "loadSource()",
+      "norm_label": "loadsource()",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
+      "source_location": "L21"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "homehero_test_on",
+      "label": "on()",
+      "norm_label": "on()",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
+      "source_location": "L23"
+    },
+    {
+      "community": 690,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_components_home_homehero_test_tsx",
+      "label": "HomeHero.test.tsx",
+      "norm_label": "homehero.test.tsx",
+      "source_file": "packages/storefront-webapp/src/components/home/HomeHero.test.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 691,
+      "file_type": "code",
       "id": "mobileproductactions_collapseonpageclick",
       "label": "collapseOnPageClick()",
       "norm_label": "collapseonpageclick()",
@@ -337729,7 +337828,7 @@
       "source_location": "L76"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "mobileproductactions_handleconfirm",
       "label": "handleConfirm()",
@@ -337738,7 +337837,7 @@
       "source_location": "L120"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "mobileproductactions_handleprimaryaction",
       "label": "handlePrimaryAction()",
@@ -337747,7 +337846,7 @@
       "source_location": "L129"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "mobileproductactions_handlesecondaryaction",
       "label": "handleSecondaryAction()",
@@ -337756,7 +337855,7 @@
       "source_location": "L133"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "mobileproductactions_updateposition",
       "label": "updatePosition()",
@@ -337765,7 +337864,7 @@
       "source_location": "L44"
     },
     {
-      "community": 690,
+      "community": 691,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_mobileproductactions_tsx",
       "label": "MobileProductActions.tsx",
@@ -337774,7 +337873,7 @@
       "source_location": "L1"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "checkoutexpired_checkoutexpired",
       "label": "CheckoutExpired()",
@@ -337783,7 +337882,7 @@
       "source_location": "L9"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessiongeneric",
       "label": "CheckoutSessionGeneric()",
@@ -337792,7 +337891,7 @@
       "source_location": "L73"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "checkoutexpired_checkoutsessionnotfound",
       "label": "CheckoutSessionNotFound()",
@@ -337801,7 +337900,7 @@
       "source_location": "L54"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "checkoutexpired_handlesendemail",
       "label": "handleSendEmail()",
@@ -337810,7 +337909,7 @@
       "source_location": "L98"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "checkoutexpired_nocheckoutsession",
       "label": "NoCheckoutSession()",
@@ -337819,7 +337918,7 @@
       "source_location": "L33"
     },
     {
-      "community": 691,
+      "community": 692,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_states_checkout_expired_checkoutexpired_tsx",
       "label": "CheckoutExpired.tsx",
@@ -337828,7 +337927,7 @@
       "source_location": "L1"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "feeutils_getremainingforfreedelivery",
       "label": "getRemainingForFreeDelivery()",
@@ -337837,7 +337936,7 @@
       "source_location": "L138"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "feeutils_haswaiverconfigured",
       "label": "hasWaiverConfigured()",
@@ -337846,7 +337945,7 @@
       "source_location": "L100"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "feeutils_isanyfeewaived",
       "label": "isAnyFeeWaived()",
@@ -337855,7 +337954,7 @@
       "source_location": "L74"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "feeutils_isfeewaived",
       "label": "isFeeWaived()",
@@ -337864,7 +337963,7 @@
       "source_location": "L34"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "feeutils_meetsthreshold",
       "label": "meetsThreshold()",
@@ -337873,7 +337972,7 @@
       "source_location": "L17"
     },
     {
-      "community": 692,
+      "community": 693,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_lib_feeutils_ts",
       "label": "feeUtils.ts",
@@ -337882,7 +337981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "auth_verify_formattime",
       "label": "formatTime()",
@@ -337891,7 +337990,7 @@
       "source_location": "L149"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "auth_verify_handlecodechange",
       "label": "handleCodeChange()",
@@ -337900,7 +337999,7 @@
       "source_location": "L156"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "auth_verify_onsubmit",
       "label": "onSubmit()",
@@ -337909,7 +338008,7 @@
       "source_location": "L201"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "auth_verify_reportauthfailure",
       "label": "reportAuthFailure()",
@@ -337918,7 +338017,7 @@
       "source_location": "L93"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "auth_verify_resendverificationcode",
       "label": "resendVerificationCode()",
@@ -337927,7 +338026,7 @@
       "source_location": "L282"
     },
     {
-      "community": 693,
+      "community": 694,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_routes_auth_verify_tsx",
       "label": "auth.verify.tsx",
@@ -337936,7 +338035,7 @@
       "source_location": "L1"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "agent_scorecard_counts",
       "label": "counts()",
@@ -337945,7 +338044,7 @@
       "source_location": "L55"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "agent_scorecard_formatscorecard",
       "label": "formatScorecard()",
@@ -337954,7 +338053,7 @@
       "source_location": "L61"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "agent_scorecard_main",
       "label": "main()",
@@ -337963,7 +338062,7 @@
       "source_location": "L93"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "agent_scorecard_parsescorecardargs",
       "label": "parseScorecardArgs()",
@@ -337972,7 +338071,7 @@
       "source_location": "L23"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "agent_scorecard_seconds",
       "label": "seconds()",
@@ -337981,7 +338080,7 @@
       "source_location": "L54"
     },
     {
-      "community": 694,
+      "community": 695,
       "file_type": "code",
       "id": "scripts_agent_scorecard_ts",
       "label": "agent-scorecard.ts",
@@ -337990,7 +338089,7 @@
       "source_location": "L1"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "coverage_summary_test_coveragesummary",
       "label": "coverageSummary()",
@@ -337999,7 +338098,7 @@
       "source_location": "L27"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "coverage_summary_test_createfixtureroot",
       "label": "createFixtureRoot()",
@@ -338008,7 +338107,7 @@
       "source_location": "L15"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "coverage_summary_test_write",
       "label": "write()",
@@ -338017,7 +338116,7 @@
       "source_location": "L21"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "coverage_summary_test_writepackagesummaries",
       "label": "writePackageSummaries()",
@@ -338026,7 +338125,7 @@
       "source_location": "L38"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "coverage_summary_test_writerealbaselinesummaries",
       "label": "writeRealBaselineSummaries()",
@@ -338035,7 +338134,7 @@
       "source_location": "L54"
     },
     {
-      "community": 695,
+      "community": 696,
       "file_type": "code",
       "id": "scripts_coverage_summary_test_ts",
       "label": "coverage-summary.test.ts",
@@ -338044,7 +338143,7 @@
       "source_location": "L1"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "docs_solution_link_check_assertdocslinks",
       "label": "assertDocsLinks()",
@@ -338053,7 +338152,7 @@
       "source_location": "L148"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "docs_solution_link_check_classifylink",
       "label": "classifyLink()",
@@ -338062,7 +338161,7 @@
       "source_location": "L49"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "docs_solution_link_check_collectdocslinkfindings",
       "label": "collectDocsLinkFindings()",
@@ -338071,7 +338170,7 @@
       "source_location": "L85"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "docs_solution_link_check_collectsolutionslugs",
       "label": "collectSolutionSlugs()",
@@ -338080,7 +338179,7 @@
       "source_location": "L36"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "docs_solution_link_check_solutionsroot",
       "label": "solutionsRoot()",
@@ -338089,7 +338188,7 @@
       "source_location": "L31"
     },
     {
-      "community": 696,
+      "community": 697,
       "file_type": "code",
       "id": "scripts_docs_solution_link_check_ts",
       "label": "docs-solution-link-check.ts",
@@ -338098,7 +338197,7 @@
       "source_location": "L1"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "documentation_waiver_attestation_asobject",
       "label": "asObject()",
@@ -338107,7 +338206,7 @@
       "source_location": "L224"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "documentation_waiver_attestation_discoverdocumentationwaiverattestation",
       "label": "discoverDocumentationWaiverAttestation()",
@@ -338116,7 +338215,7 @@
       "source_location": "L230"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "documentation_waiver_attestation_nonempty",
       "label": "nonEmpty()",
@@ -338125,7 +338224,7 @@
       "source_location": "L97"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "documentation_waiver_attestation_parsedocumentationwaiverattestation",
       "label": "parseDocumentationWaiverAttestation()",
@@ -338134,7 +338233,7 @@
       "source_location": "L101"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "documentation_waiver_attestation_verifydocumentationwaiverattestation",
       "label": "verifyDocumentationWaiverAttestation()",
@@ -338143,7 +338242,7 @@
       "source_location": "L146"
     },
     {
-      "community": 697,
+      "community": 698,
       "file_type": "code",
       "id": "scripts_documentation_waiver_attestation_ts",
       "label": "documentation-waiver-attestation.ts",
@@ -338152,7 +338251,7 @@
       "source_location": "L1"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "graphify_check_collectrepocodefiles",
       "label": "collectRepoCodeFiles()",
@@ -338161,7 +338260,7 @@
       "source_location": "L73"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "graphify_check_collectstalegraphifyartifacts",
       "label": "collectStaleGraphifyArtifacts()",
@@ -338170,7 +338269,7 @@
       "source_location": "L125"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "graphify_check_copygraphifycheckinputs",
       "label": "copyGraphifyCheckInputs()",
@@ -338179,7 +338278,7 @@
       "source_location": "L107"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "graphify_check_fileexists",
       "label": "fileExists()",
@@ -338188,7 +338287,7 @@
       "source_location": "L64"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "graphify_check_rungraphifycheck",
       "label": "runGraphifyCheck()",
@@ -338197,66 +338296,12 @@
       "source_location": "L152"
     },
     {
-      "community": 698,
+      "community": 699,
       "file_type": "code",
       "id": "scripts_graphify_check_ts",
       "label": "graphify-check.ts",
       "norm_label": "graphify-check.ts",
       "source_file": "scripts/graphify-check.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "harness_contract_preflight_errormessage",
-      "label": "errorMessage()",
-      "norm_label": "errormessage()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L50"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "harness_contract_preflight_formathumanreport",
-      "label": "formatHumanReport()",
-      "norm_label": "formathumanreport()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L89"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "harness_contract_preflight_runfocusedcontracttests",
-      "label": "runFocusedContractTests()",
-      "norm_label": "runfocusedcontracttests()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "harness_contract_preflight_runharnesscontractpreflight",
-      "label": "runHarnessContractPreflight()",
-      "norm_label": "runharnesscontractpreflight()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "harness_contract_preflight_runharnesscontractpreflightcli",
-      "label": "runHarnessContractPreflightCli()",
-      "norm_label": "runharnesscontractpreflightcli()",
-      "source_file": "scripts/harness-contract-preflight.ts",
-      "source_location": "L216"
-    },
-    {
-      "community": 699,
-      "file_type": "code",
-      "id": "scripts_harness_contract_preflight_ts",
-      "label": "harness-contract-preflight.ts",
-      "norm_label": "harness-contract-preflight.ts",
-      "source_file": "scripts/harness-contract-preflight.ts",
       "source_location": "L1"
     },
     {
@@ -339144,6 +339189,60 @@
     {
       "community": 700,
       "file_type": "code",
+      "id": "harness_contract_preflight_errormessage",
+      "label": "errorMessage()",
+      "norm_label": "errormessage()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "harness_contract_preflight_formathumanreport",
+      "label": "formatHumanReport()",
+      "norm_label": "formathumanreport()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L89"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "harness_contract_preflight_runfocusedcontracttests",
+      "label": "runFocusedContractTests()",
+      "norm_label": "runfocusedcontracttests()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "harness_contract_preflight_runharnesscontractpreflight",
+      "label": "runHarnessContractPreflight()",
+      "norm_label": "runharnesscontractpreflight()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L116"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "harness_contract_preflight_runharnesscontractpreflightcli",
+      "label": "runHarnessContractPreflightCli()",
+      "norm_label": "runharnesscontractpreflightcli()",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L216"
+    },
+    {
+      "community": 700,
+      "file_type": "code",
+      "id": "scripts_harness_contract_preflight_ts",
+      "label": "harness-contract-preflight.ts",
+      "norm_label": "harness-contract-preflight.ts",
+      "source_file": "scripts/harness-contract-preflight.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 701,
+      "file_type": "code",
       "id": "harness_gate_obligations_test_evidence",
       "label": "evidence()",
       "norm_label": "evidence()",
@@ -339151,7 +339250,7 @@
       "source_location": "L26"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "harness_gate_obligations_test_failingdocs",
       "label": "failingDocs()",
@@ -339160,7 +339259,7 @@
       "source_location": "L125"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "harness_gate_obligations_test_input",
       "label": "input()",
@@ -339169,7 +339268,7 @@
       "source_location": "L46"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "harness_gate_obligations_test_resolution",
       "label": "resolution()",
@@ -339178,7 +339277,7 @@
       "source_location": "L78"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "harness_gate_obligations_test_waiverfor",
       "label": "waiverFor()",
@@ -339187,7 +339286,7 @@
       "source_location": "L689"
     },
     {
-      "community": 700,
+      "community": 701,
       "file_type": "code",
       "id": "scripts_harness_gate_obligations_test_ts",
       "label": "harness-gate-obligations.test.ts",
@@ -339196,7 +339295,7 @@
       "source_location": "L1"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "harness_inferential_review_test_commitfixturerepo",
       "label": "commitFixtureRepo()",
@@ -339205,7 +339304,7 @@
       "source_location": "L171"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "harness_inferential_review_test_createfixturerepo",
       "label": "createFixtureRepo()",
@@ -339214,7 +339313,7 @@
       "source_location": "L68"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "harness_inferential_review_test_gitfixtureenv",
       "label": "gitFixtureEnv()",
@@ -339223,7 +339322,7 @@
       "source_location": "L62"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "harness_inferential_review_test_runfixturecommand",
       "label": "runFixtureCommand()",
@@ -339232,7 +339331,7 @@
       "source_location": "L24"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "harness_inferential_review_test_write",
       "label": "write()",
@@ -339241,7 +339340,7 @@
       "source_location": "L18"
     },
     {
-      "community": 701,
+      "community": 702,
       "file_type": "code",
       "id": "scripts_harness_inferential_review_test_ts",
       "label": "harness-inferential-review.test.ts",
@@ -339250,7 +339349,7 @@
       "source_location": "L1"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationcapabilities",
       "label": "collectHarnessRepoValidationCapabilities()",
@@ -339259,7 +339358,7 @@
       "source_location": "L73"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "harness_repo_validation_collectharnessrepovalidationselection",
       "label": "collectHarnessRepoValidationSelection()",
@@ -339268,7 +339367,7 @@
       "source_location": "L50"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "harness_repo_validation_matchesharnessrepovalidationpath",
       "label": "matchesHarnessRepoValidationPath()",
@@ -339277,7 +339376,7 @@
       "source_location": "L42"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "harness_repo_validation_normalizerepopath",
       "label": "normalizeRepoPath()",
@@ -339286,7 +339385,7 @@
       "source_location": "L32"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "harness_repo_validation_sortuniquepaths",
       "label": "sortUniquePaths()",
@@ -339295,66 +339394,12 @@
       "source_location": "L36"
     },
     {
-      "community": 702,
+      "community": 703,
       "file_type": "code",
       "id": "scripts_harness_repo_validation_ts",
       "label": "harness-repo-validation.ts",
       "norm_label": "harness-repo-validation.ts",
       "source_file": "scripts/harness-repo-validation.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 703,
-      "file_type": "code",
-      "id": "policy_projection_check_test_capturecandidate",
-      "label": "captureCandidate()",
-      "norm_label": "capturecandidate()",
-      "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L266"
-    },
-    {
-      "community": 703,
-      "file_type": "code",
-      "id": "policy_projection_check_test_findingcodes",
-      "label": "findingCodes()",
-      "norm_label": "findingcodes()",
-      "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L44"
-    },
-    {
-      "community": 703,
-      "file_type": "code",
-      "id": "policy_projection_check_test_policydircopy",
-      "label": "policyDirCopy()",
-      "norm_label": "policydircopy()",
-      "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 703,
-      "file_type": "code",
-      "id": "policy_projection_check_test_readpolicyjson",
-      "label": "readPolicyJson()",
-      "norm_label": "readpolicyjson()",
-      "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 703,
-      "file_type": "code",
-      "id": "policy_projection_check_test_writepolicyjson",
-      "label": "writePolicyJson()",
-      "norm_label": "writepolicyjson()",
-      "source_file": "scripts/policy-projection-check.test.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 703,
-      "file_type": "code",
-      "id": "scripts_policy_projection_check_test_ts",
-      "label": "policy-projection-check.test.ts",
-      "norm_label": "policy-projection-check.test.ts",
-      "source_file": "scripts/policy-projection-check.test.ts",
       "source_location": "L1"
     },
     {
@@ -339364,7 +339409,7 @@
       "label": "coveredByProtectedTree()",
       "norm_label": "coveredbyprotectedtree()",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L100"
+      "source_location": "L101"
     },
     {
       "community": 704,
@@ -339373,7 +339418,7 @@
       "label": "equalStringArrays()",
       "norm_label": "equalstringarrays()",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L93"
+      "source_location": "L94"
     },
     {
       "community": 704,
@@ -339382,7 +339427,7 @@
       "label": "formatMechanicalSelection()",
       "norm_label": "formatmechanicalselection()",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L81"
+      "source_location": "L82"
     },
     {
       "community": 704,
@@ -339391,7 +339436,7 @@
       "label": "runPolicyProjectionCheck()",
       "norm_label": "runpolicyprojectioncheck()",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L106"
+      "source_location": "L107"
     },
     {
       "community": 704,
@@ -339400,7 +339445,7 @@
       "label": "sha256()",
       "norm_label": "sha256()",
       "source_file": "scripts/policy-projection-check.ts",
-      "source_location": "L89"
+      "source_location": "L90"
     },
     {
       "community": 704,
@@ -344103,51 +344148,6 @@
     {
       "community": 774,
       "file_type": "code",
-      "id": "currency_formatstoredamount",
-      "label": "formatStoredAmount()",
-      "norm_label": "formatstoredamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L9"
-    },
-    {
-      "community": 774,
-      "file_type": "code",
-      "id": "currency_todisplayamount",
-      "label": "toDisplayAmount()",
-      "norm_label": "todisplayamount()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L5"
-    },
-    {
-      "community": 774,
-      "file_type": "code",
-      "id": "currency_topesewas",
-      "label": "toPesewas()",
-      "norm_label": "topesewas()",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 774,
-      "file_type": "code",
-      "id": "packages_athena_webapp_shared_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/athena-webapp/shared/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 774,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_lib_currency_ts",
-      "label": "currency.ts",
-      "norm_label": "currency.ts",
-      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 775,
-      "file_type": "code",
       "id": "ordermath_formatdeliveryaddress",
       "label": "formatDeliveryAddress()",
       "norm_label": "formatdeliveryaddress()",
@@ -344155,7 +344155,7 @@
       "source_location": "L138"
     },
     {
-      "community": 775,
+      "community": 774,
       "file_type": "code",
       "id": "ordermath_getdiscountvalue",
       "label": "getDiscountValue()",
@@ -344164,7 +344164,7 @@
       "source_location": "L43"
     },
     {
-      "community": 775,
+      "community": 774,
       "file_type": "code",
       "id": "ordermath_getorderamount",
       "label": "getOrderAmount()",
@@ -344173,7 +344173,7 @@
       "source_location": "L118"
     },
     {
-      "community": 775,
+      "community": 774,
       "file_type": "code",
       "id": "ordermath_getproductdiscountvalue",
       "label": "getProductDiscountValue()",
@@ -344182,7 +344182,7 @@
       "source_location": "L100"
     },
     {
-      "community": 775,
+      "community": 774,
       "file_type": "code",
       "id": "packages_athena_webapp_shared_ordermath_ts",
       "label": "orderMath.ts",
@@ -344191,7 +344191,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 775,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_agent_streamreveal_ts",
       "label": "streamReveal.ts",
@@ -344200,7 +344200,7 @@
       "source_location": "L1"
     },
     {
-      "community": 776,
+      "community": 775,
       "file_type": "code",
       "id": "streamreveal_charactercount",
       "label": "characterCount()",
@@ -344209,7 +344209,7 @@
       "source_location": "L44"
     },
     {
-      "community": 776,
+      "community": 775,
       "file_type": "code",
       "id": "streamreveal_revealduration",
       "label": "revealDuration()",
@@ -344218,7 +344218,7 @@
       "source_location": "L25"
     },
     {
-      "community": 776,
+      "community": 775,
       "file_type": "code",
       "id": "streamreveal_revealedprefix",
       "label": "revealedPrefix()",
@@ -344227,7 +344227,7 @@
       "source_location": "L49"
     },
     {
-      "community": 776,
+      "community": 775,
       "file_type": "code",
       "id": "streamreveal_revealedprose",
       "label": "revealedProse()",
@@ -344236,7 +344236,7 @@
       "source_location": "L60"
     },
     {
-      "community": 777,
+      "community": 776,
       "file_type": "code",
       "id": "appsettingsview_appearancelabel",
       "label": "appearanceLabel()",
@@ -344245,7 +344245,7 @@
       "source_location": "L38"
     },
     {
-      "community": 777,
+      "community": 776,
       "file_type": "code",
       "id": "appsettingsview_cn",
       "label": "cn()",
@@ -344254,7 +344254,7 @@
       "source_location": "L154"
     },
     {
-      "community": 777,
+      "community": 776,
       "file_type": "code",
       "id": "appsettingsview_selectthememode",
       "label": "selectThemeMode()",
@@ -344263,7 +344263,7 @@
       "source_location": "L85"
     },
     {
-      "community": 777,
+      "community": 776,
       "file_type": "code",
       "id": "appsettingsview_transitiontimelabel",
       "label": "transitionTimeLabel()",
@@ -344272,7 +344272,7 @@
       "source_location": "L42"
     },
     {
-      "community": 777,
+      "community": 776,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_app_settings_appsettingsview_tsx",
       "label": "AppSettingsView.tsx",
@@ -344281,7 +344281,7 @@
       "source_location": "L1"
     },
     {
-      "community": 778,
+      "community": 777,
       "file_type": "code",
       "id": "dashboard_getperiodrange",
       "label": "getPeriodRange()",
@@ -344290,7 +344290,7 @@
       "source_location": "L19"
     },
     {
-      "community": 778,
+      "community": 777,
       "file_type": "code",
       "id": "dashboard_loadingsection",
       "label": "LoadingSection()",
@@ -344299,7 +344299,7 @@
       "source_location": "L49"
     },
     {
-      "community": 778,
+      "community": 777,
       "file_type": "code",
       "id": "dashboard_renderproductssection",
       "label": "renderProductsSection()",
@@ -344308,7 +344308,7 @@
       "source_location": "L341"
     },
     {
-      "community": 778,
+      "community": 777,
       "file_type": "code",
       "id": "dashboard_rendersalessection",
       "label": "renderSalesSection()",
@@ -344317,7 +344317,7 @@
       "source_location": "L321"
     },
     {
-      "community": 778,
+      "community": 777,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_dashboard_dashboard_tsx",
       "label": "Dashboard.tsx",
@@ -344326,7 +344326,7 @@
       "source_location": "L1"
     },
     {
-      "community": 779,
+      "community": 778,
       "file_type": "code",
       "id": "docsscrolltotop_cancel",
       "label": "cancel()",
@@ -344335,7 +344335,7 @@
       "source_location": "L87"
     },
     {
-      "community": 779,
+      "community": 778,
       "file_type": "code",
       "id": "docsscrolltotop_handleclick",
       "label": "handleClick()",
@@ -344344,7 +344344,7 @@
       "source_location": "L103"
     },
     {
-      "community": 779,
+      "community": 778,
       "file_type": "code",
       "id": "docsscrolltotop_read",
       "label": "read()",
@@ -344353,7 +344353,7 @@
       "source_location": "L37"
     },
     {
-      "community": 779,
+      "community": 778,
       "file_type": "code",
       "id": "docsscrolltotop_schedule",
       "label": "schedule()",
@@ -344362,12 +344362,57 @@
       "source_location": "L59"
     },
     {
-      "community": 779,
+      "community": 778,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_docs_docsscrolltotop_tsx",
       "label": "DocsScrollToTop.tsx",
       "norm_label": "docsscrolltotop.tsx",
       "source_file": "packages/athena-webapp/src/components/docs/DocsScrollToTop.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 779,
+      "file_type": "code",
+      "id": "herosectiontabs_handledisplaytypechange",
+      "label": "handleDisplayTypeChange()",
+      "norm_label": "handledisplaytypechange()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L61"
+    },
+    {
+      "community": 779,
+      "file_type": "code",
+      "id": "herosectiontabs_handleimageupdate",
+      "label": "handleImageUpdate()",
+      "norm_label": "handleimageupdate()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L57"
+    },
+    {
+      "community": 779,
+      "file_type": "code",
+      "id": "herosectiontabs_handleoverlaytoggle",
+      "label": "handleOverlayToggle()",
+      "norm_label": "handleoverlaytoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L98"
+    },
+    {
+      "community": 779,
+      "file_type": "code",
+      "id": "herosectiontabs_handletexttoggle",
+      "label": "handleTextToggle()",
+      "norm_label": "handletexttoggle()",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
+      "source_location": "L134"
+    },
+    {
+      "community": 779,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
+      "label": "HeroSectionTabs.tsx",
+      "norm_label": "herosectiontabs.tsx",
+      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
       "source_location": "L1"
     },
     {
@@ -344589,51 +344634,6 @@
     {
       "community": 780,
       "file_type": "code",
-      "id": "herosectiontabs_handledisplaytypechange",
-      "label": "handleDisplayTypeChange()",
-      "norm_label": "handledisplaytypechange()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L61"
-    },
-    {
-      "community": 780,
-      "file_type": "code",
-      "id": "herosectiontabs_handleimageupdate",
-      "label": "handleImageUpdate()",
-      "norm_label": "handleimageupdate()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L57"
-    },
-    {
-      "community": 780,
-      "file_type": "code",
-      "id": "herosectiontabs_handleoverlaytoggle",
-      "label": "handleOverlayToggle()",
-      "norm_label": "handleoverlaytoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L98"
-    },
-    {
-      "community": 780,
-      "file_type": "code",
-      "id": "herosectiontabs_handletexttoggle",
-      "label": "handleTextToggle()",
-      "norm_label": "handletexttoggle()",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L134"
-    },
-    {
-      "community": 780,
-      "file_type": "code",
-      "id": "packages_athena_webapp_src_components_homepage_herosectiontabs_tsx",
-      "label": "HeroSectionTabs.tsx",
-      "norm_label": "herosectiontabs.tsx",
-      "source_file": "packages/athena-webapp/src/components/homepage/HeroSectionTabs.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 781,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_homepage_reeluploader_tsx",
       "label": "ReelUploader.tsx",
       "norm_label": "reeluploader.tsx",
@@ -344641,7 +344641,7 @@
       "source_location": "L1"
     },
     {
-      "community": 781,
+      "community": 780,
       "file_type": "code",
       "id": "reeluploader_formatfilesize",
       "label": "formatFileSize()",
@@ -344650,7 +344650,7 @@
       "source_location": "L38"
     },
     {
-      "community": 781,
+      "community": 780,
       "file_type": "code",
       "id": "reeluploader_handlefileselect",
       "label": "handleFileSelect()",
@@ -344659,7 +344659,7 @@
       "source_location": "L64"
     },
     {
-      "community": 781,
+      "community": 780,
       "file_type": "code",
       "id": "reeluploader_handleupload",
       "label": "handleUpload()",
@@ -344668,7 +344668,7 @@
       "source_location": "L135"
     },
     {
-      "community": 781,
+      "community": 780,
       "file_type": "code",
       "id": "reeluploader_validatefile",
       "label": "validateFile()",
@@ -344677,7 +344677,7 @@
       "source_location": "L43"
     },
     {
-      "community": 782,
+      "community": 781,
       "file_type": "code",
       "id": "activityview_iscreatedaction",
       "label": "isCreatedAction()",
@@ -344686,7 +344686,7 @@
       "source_location": "L90"
     },
     {
-      "community": 782,
+      "community": 781,
       "file_type": "code",
       "id": "activityview_isfeedbackrequestaction",
       "label": "isFeedbackRequestAction()",
@@ -344695,7 +344695,7 @@
       "source_location": "L95"
     },
     {
-      "community": 782,
+      "community": 781,
       "file_type": "code",
       "id": "activityview_isrefundaction",
       "label": "isRefundAction()",
@@ -344704,7 +344704,7 @@
       "source_location": "L82"
     },
     {
-      "community": 782,
+      "community": 781,
       "file_type": "code",
       "id": "activityview_istransitionaction",
       "label": "isTransitionAction()",
@@ -344713,7 +344713,7 @@
       "source_location": "L85"
     },
     {
-      "community": 782,
+      "community": 781,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_activityview_tsx",
       "label": "ActivityView.tsx",
@@ -344722,7 +344722,7 @@
       "source_location": "L1"
     },
     {
-      "community": 783,
+      "community": 782,
       "file_type": "code",
       "id": "orderitemsview_handlerequestfeedback",
       "label": "handleRequestFeedback()",
@@ -344731,7 +344731,7 @@
       "source_location": "L113"
     },
     {
-      "community": 783,
+      "community": 782,
       "file_type": "code",
       "id": "orderitemsview_handlerestockall",
       "label": "handleRestockAll()",
@@ -344740,7 +344740,7 @@
       "source_location": "L349"
     },
     {
-      "community": 783,
+      "community": 782,
       "file_type": "code",
       "id": "orderitemsview_handlereturnitemtostock",
       "label": "handleReturnItemToStock()",
@@ -344749,7 +344749,7 @@
       "source_location": "L86"
     },
     {
-      "community": 783,
+      "community": 782,
       "file_type": "code",
       "id": "orderitemsview_handleupdateorderitem",
       "label": "handleUpdateOrderItem()",
@@ -344758,7 +344758,7 @@
       "source_location": "L62"
     },
     {
-      "community": 783,
+      "community": 782,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_orders_orderitemsview_tsx",
       "label": "OrderItemsView.tsx",
@@ -344767,7 +344767,7 @@
       "source_location": "L1"
     },
     {
-      "community": 784,
+      "community": 783,
       "file_type": "code",
       "id": "cashierauthdialog_test_buildlocalauthorityrecord",
       "label": "buildLocalAuthorityRecord()",
@@ -344776,7 +344776,7 @@
       "source_location": "L121"
     },
     {
-      "community": 784,
+      "community": 783,
       "file_type": "code",
       "id": "cashierauthdialog_test_renderdialog",
       "label": "renderDialog()",
@@ -344785,7 +344785,7 @@
       "source_location": "L152"
     },
     {
-      "community": 784,
+      "community": 783,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitcredentials",
       "label": "submitCredentials()",
@@ -344794,7 +344794,7 @@
       "source_location": "L216"
     },
     {
-      "community": 784,
+      "community": 783,
       "file_type": "code",
       "id": "cashierauthdialog_test_submitlockedcashierpin",
       "label": "submitLockedCashierPin()",
@@ -344803,7 +344803,7 @@
       "source_location": "L208"
     },
     {
-      "community": 784,
+      "community": 783,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_cashierauthdialog_test_tsx",
       "label": "CashierAuthDialog.test.tsx",
@@ -344812,7 +344812,7 @@
       "source_location": "L1"
     },
     {
-      "community": 785,
+      "community": 784,
       "file_type": "code",
       "id": "ordersummary_test_getbalancedueamount",
       "label": "getBalanceDueAmount()",
@@ -344821,7 +344821,7 @@
       "source_location": "L49"
     },
     {
-      "community": 785,
+      "community": 784,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduelabel",
       "label": "getBalanceDueLabel()",
@@ -344830,7 +344830,7 @@
       "source_location": "L66"
     },
     {
-      "community": 785,
+      "community": 784,
       "file_type": "code",
       "id": "ordersummary_test_getbalanceduepanel",
       "label": "getBalanceDuePanel()",
@@ -344839,7 +344839,7 @@
       "source_location": "L75"
     },
     {
-      "community": 785,
+      "community": 784,
       "file_type": "code",
       "id": "ordersummary_test_stripwhitespace",
       "label": "stripWhitespace()",
@@ -344848,7 +344848,7 @@
       "source_location": "L45"
     },
     {
-      "community": 785,
+      "community": 784,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_ordersummary_test_tsx",
       "label": "OrderSummary.test.tsx",
@@ -344857,7 +344857,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 785,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_pos_settings_possettingsview_test_tsx",
       "label": "POSSettingsView.test.tsx",
@@ -344866,7 +344866,7 @@
       "source_location": "L1"
     },
     {
-      "community": 786,
+      "community": 785,
       "file_type": "code",
       "id": "possettingsview_test_findtrigger",
       "label": "findTrigger()",
@@ -344875,7 +344875,7 @@
       "source_location": "L188"
     },
     {
-      "community": 786,
+      "community": 785,
       "file_type": "code",
       "id": "possettingsview_test_selectcontent",
       "label": "SelectContent()",
@@ -344884,7 +344884,7 @@
       "source_location": "L163"
     },
     {
-      "community": 786,
+      "community": 785,
       "file_type": "code",
       "id": "possettingsview_test_selectitem",
       "label": "SelectItem()",
@@ -344893,7 +344893,7 @@
       "source_location": "L166"
     },
     {
-      "community": 786,
+      "community": 785,
       "file_type": "code",
       "id": "possettingsview_test_selecttrigger",
       "label": "SelectTrigger()",
@@ -344902,7 +344902,7 @@
       "source_location": "L168"
     },
     {
-      "community": 787,
+      "community": 786,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_products_productslistview_tsx",
       "label": "ProductsListView.tsx",
@@ -344911,7 +344911,7 @@
       "source_location": "L1"
     },
     {
-      "community": 787,
+      "community": 786,
       "file_type": "code",
       "id": "productslistview_handlecategorypageindexchange",
       "label": "handleCategoryPageIndexChange()",
@@ -344920,7 +344920,7 @@
       "source_location": "L220"
     },
     {
-      "community": 787,
+      "community": 786,
       "file_type": "code",
       "id": "productslistview_handleclearcache",
       "label": "handleClearCache()",
@@ -344929,7 +344929,7 @@
       "source_location": "L108"
     },
     {
-      "community": 787,
+      "community": 786,
       "file_type": "code",
       "id": "productslistview_handlestorefrontvisibilitychange",
       "label": "handleStorefrontVisibilityChange()",
@@ -344938,7 +344938,7 @@
       "source_location": "L87"
     },
     {
-      "community": 787,
+      "community": 786,
       "file_type": "code",
       "id": "productslistview_productactionstogglegroup",
       "label": "ProductActionsToggleGroup()",
@@ -344947,7 +344947,7 @@
       "source_location": "L33"
     },
     {
-      "community": 788,
+      "community": 787,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_promo_codes_promocodeview_tsx",
       "label": "PromoCodeView.tsx",
@@ -344956,7 +344956,7 @@
       "source_location": "L1"
     },
     {
-      "community": 788,
+      "community": 787,
       "file_type": "code",
       "id": "promocodeview_handleaddpromocode",
       "label": "handleAddPromoCode()",
@@ -344965,7 +344965,7 @@
       "source_location": "L158"
     },
     {
-      "community": 788,
+      "community": 787,
       "file_type": "code",
       "id": "promocodeview_handleupdatepromocode",
       "label": "handleUpdatePromoCode()",
@@ -344974,7 +344974,7 @@
       "source_location": "L231"
     },
     {
-      "community": 788,
+      "community": 787,
       "file_type": "code",
       "id": "promocodeview_updatehomepagediscountcode",
       "label": "updateHomepageDiscountCode()",
@@ -344983,7 +344983,7 @@
       "source_location": "L324"
     },
     {
-      "community": 788,
+      "community": 787,
       "file_type": "code",
       "id": "promocodeview_updateleaveareviewdiscountcode",
       "label": "updateLeaveAReviewDiscountCode()",
@@ -344992,7 +344992,7 @@
       "source_location": "L379"
     },
     {
-      "community": 789,
+      "community": 788,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_reports_reportsoverviewview_test_tsx",
       "label": "ReportsOverviewView.test.tsx",
@@ -345001,7 +345001,7 @@
       "source_location": "L1"
     },
     {
-      "community": 789,
+      "community": 788,
       "file_type": "code",
       "id": "reportsoverviewview_test_expectanimatedmetrics",
       "label": "expectAnimatedMetrics()",
@@ -345010,7 +345010,7 @@
       "source_location": "L450"
     },
     {
-      "community": 789,
+      "community": 788,
       "file_type": "code",
       "id": "reportsoverviewview_test_harness",
       "label": "Harness()",
@@ -345019,7 +345019,7 @@
       "source_location": "L173"
     },
     {
-      "community": 789,
+      "community": 788,
       "file_type": "code",
       "id": "reportsoverviewview_test_linkedrange",
       "label": "linkedRange()",
@@ -345028,13 +345028,58 @@
       "source_location": "L584"
     },
     {
-      "community": 789,
+      "community": 788,
       "file_type": "code",
       "id": "reportsoverviewview_test_snapshot",
       "label": "snapshot()",
       "norm_label": "snapshot()",
       "source_file": "packages/athena-webapp/src/components/reports/ReportsOverviewView.test.tsx",
       "source_location": "L87"
+    },
+    {
+      "community": 789,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
+      "label": "reportRouteSearch.ts",
+      "norm_label": "reportroutesearch.ts",
+      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 789,
+      "file_type": "code",
+      "id": "reportroutesearch_overviewsearchfromweeklyreturn",
+      "label": "overviewSearchFromWeeklyReturn()",
+      "norm_label": "overviewsearchfromweeklyreturn()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
+      "source_location": "L148"
+    },
+    {
+      "community": 789,
+      "file_type": "code",
+      "id": "reportroutesearch_parseunitssheetfocussearch",
+      "label": "parseUnitsSheetFocusSearch()",
+      "norm_label": "parseunitssheetfocussearch()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
+      "source_location": "L81"
+    },
+    {
+      "community": 789,
+      "file_type": "code",
+      "id": "reportroutesearch_unitssheetfocussearchvalue",
+      "label": "unitsSheetFocusSearchValue()",
+      "norm_label": "unitssheetfocussearchvalue()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
+      "source_location": "L72"
+    },
+    {
+      "community": 789,
+      "file_type": "code",
+      "id": "reportroutesearch_weeklyreturnsearchfromoverview",
+      "label": "weeklyReturnSearchFromOverview()",
+      "norm_label": "weeklyreturnsearchfromoverview()",
+      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
+      "source_location": "L125"
     },
     {
       "community": 79,
@@ -345255,51 +345300,6 @@
     {
       "community": 790,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_reports_reportroutesearch_ts",
-      "label": "reportRouteSearch.ts",
-      "norm_label": "reportroutesearch.ts",
-      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 790,
-      "file_type": "code",
-      "id": "reportroutesearch_overviewsearchfromweeklyreturn",
-      "label": "overviewSearchFromWeeklyReturn()",
-      "norm_label": "overviewsearchfromweeklyreturn()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
-      "source_location": "L148"
-    },
-    {
-      "community": 790,
-      "file_type": "code",
-      "id": "reportroutesearch_parseunitssheetfocussearch",
-      "label": "parseUnitsSheetFocusSearch()",
-      "norm_label": "parseunitssheetfocussearch()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
-      "source_location": "L81"
-    },
-    {
-      "community": 790,
-      "file_type": "code",
-      "id": "reportroutesearch_unitssheetfocussearchvalue",
-      "label": "unitsSheetFocusSearchValue()",
-      "norm_label": "unitssheetfocussearchvalue()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
-      "source_location": "L72"
-    },
-    {
-      "community": 790,
-      "file_type": "code",
-      "id": "reportroutesearch_weeklyreturnsearchfromoverview",
-      "label": "weeklyReturnSearchFromOverview()",
-      "norm_label": "weeklyreturnsearchfromoverview()",
-      "source_file": "packages/athena-webapp/src/components/reports/reportRouteSearch.ts",
-      "source_location": "L125"
-    },
-    {
-      "community": 791,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_components_store_pulse_storepulsesummaryview_tsx",
       "label": "StorePulseSummaryView.tsx",
       "norm_label": "storepulsesummaryview.tsx",
@@ -345307,7 +345307,7 @@
       "source_location": "L1"
     },
     {
-      "community": 791,
+      "community": 790,
       "file_type": "code",
       "id": "storepulsesummaryview_formatcomparisonhelper",
       "label": "formatComparisonHelper()",
@@ -345316,7 +345316,7 @@
       "source_location": "L165"
     },
     {
-      "community": 791,
+      "community": 790,
       "file_type": "code",
       "id": "storepulsesummaryview_formatxaxistick",
       "label": "formatXAxisTick()",
@@ -345325,7 +345325,7 @@
       "source_location": "L379"
     },
     {
-      "community": 791,
+      "community": 790,
       "file_type": "code",
       "id": "storepulsesummaryview_gettrendvalue",
       "label": "getTrendValue()",
@@ -345334,7 +345334,7 @@
       "source_location": "L312"
     },
     {
-      "community": 791,
+      "community": 790,
       "file_type": "code",
       "id": "storepulsesummaryview_helper",
       "label": "helper()",
@@ -345343,7 +345343,7 @@
       "source_location": "L202"
     },
     {
-      "community": 792,
+      "community": 791,
       "file_type": "code",
       "id": "date_time_picker_handleclear",
       "label": "handleClear()",
@@ -345352,7 +345352,7 @@
       "source_location": "L101"
     },
     {
-      "community": 792,
+      "community": 791,
       "file_type": "code",
       "id": "date_time_picker_handledateselect",
       "label": "handleDateSelect()",
@@ -345361,7 +345361,7 @@
       "source_location": "L55"
     },
     {
-      "community": 792,
+      "community": 791,
       "file_type": "code",
       "id": "date_time_picker_handletimeblur",
       "label": "handleTimeBlur()",
@@ -345370,7 +345370,7 @@
       "source_location": "L77"
     },
     {
-      "community": 792,
+      "community": 791,
       "file_type": "code",
       "id": "date_time_picker_handletimechange",
       "label": "handleTimeChange()",
@@ -345379,7 +345379,7 @@
       "source_location": "L65"
     },
     {
-      "community": 792,
+      "community": 791,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_date_time_picker_tsx",
       "label": "date-time-picker.tsx",
@@ -345388,7 +345388,7 @@
       "source_location": "L1"
     },
     {
-      "community": 793,
+      "community": 792,
       "file_type": "code",
       "id": "custom_modal_example_basicmodalexample",
       "label": "BasicModalExample()",
@@ -345397,7 +345397,7 @@
       "source_location": "L7"
     },
     {
-      "community": 793,
+      "community": 792,
       "file_type": "code",
       "id": "custom_modal_example_customclosebuttonexample",
       "label": "CustomCloseButtonExample()",
@@ -345406,7 +345406,7 @@
       "source_location": "L69"
     },
     {
-      "community": 793,
+      "community": 792,
       "file_type": "code",
       "id": "custom_modal_example_custompositionmodalexample",
       "label": "CustomPositionModalExample()",
@@ -345415,7 +345415,7 @@
       "source_location": "L44"
     },
     {
-      "community": 793,
+      "community": 792,
       "file_type": "code",
       "id": "custom_modal_example_fullscreenmodalexample",
       "label": "FullScreenModalExample()",
@@ -345424,7 +345424,7 @@
       "source_location": "L103"
     },
     {
-      "community": 793,
+      "community": 792,
       "file_type": "code",
       "id": "packages_athena_webapp_src_components_ui_modals_custom_modal_example_tsx",
       "label": "custom-modal-example.tsx",
@@ -345433,7 +345433,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 793,
       "file_type": "code",
       "id": "packages_athena_webapp_src_hooks_useexpenselocalruntime_ts",
       "label": "useExpenseLocalRuntime.ts",
@@ -345442,7 +345442,7 @@
       "source_location": "L1"
     },
     {
-      "community": 794,
+      "community": 793,
       "file_type": "code",
       "id": "useexpenselocalruntime_createlocalid",
       "label": "createLocalId()",
@@ -345451,7 +345451,7 @@
       "source_location": "L23"
     },
     {
-      "community": 794,
+      "community": 793,
       "file_type": "code",
       "id": "useexpenselocalruntime_getexpenselocalstore",
       "label": "getExpenseLocalStore()",
@@ -345460,7 +345460,7 @@
       "source_location": "L12"
     },
     {
-      "community": 794,
+      "community": 793,
       "file_type": "code",
       "id": "useexpenselocalruntime_notifyexpenselocaleventappended",
       "label": "notifyExpenseLocalEventAppended()",
@@ -345469,7 +345469,7 @@
       "source_location": "L17"
     },
     {
-      "community": 794,
+      "community": 793,
       "file_type": "code",
       "id": "useexpenselocalruntime_useexpenselocalruntime",
       "label": "useExpenseLocalRuntime()",
@@ -345478,7 +345478,7 @@
       "source_location": "L31"
     },
     {
-      "community": 795,
+      "community": 794,
       "file_type": "code",
       "id": "appmessagesprovider_appmessagesprovider",
       "label": "AppMessagesProvider()",
@@ -345487,7 +345487,7 @@
       "source_location": "L28"
     },
     {
-      "community": 795,
+      "community": 794,
       "file_type": "code",
       "id": "appmessagesprovider_areblockersequal",
       "label": "areBlockersEqual()",
@@ -345496,7 +345496,7 @@
       "source_location": "L215"
     },
     {
-      "community": 795,
+      "community": 794,
       "file_type": "code",
       "id": "appmessagesprovider_aremessagesequal",
       "label": "areMessagesEqual()",
@@ -345505,7 +345505,7 @@
       "source_location": "L185"
     },
     {
-      "community": 795,
+      "community": 794,
       "file_type": "code",
       "id": "appmessagesprovider_getpreferredvariant",
       "label": "getPreferredVariant()",
@@ -345514,7 +345514,7 @@
       "source_location": "L203"
     },
     {
-      "community": 795,
+      "community": 794,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessagesprovider_tsx",
       "label": "AppMessagesProvider.tsx",
@@ -345523,7 +345523,7 @@
       "source_location": "L1"
     },
     {
-      "community": 796,
+      "community": 795,
       "file_type": "code",
       "id": "appactionblockers_compareappactionblockers",
       "label": "compareAppActionBlockers()",
@@ -345532,7 +345532,7 @@
       "source_location": "L41"
     },
     {
-      "community": 796,
+      "community": 795,
       "file_type": "code",
       "id": "appactionblockers_getselectedappactionblocker",
       "label": "getSelectedAppActionBlocker()",
@@ -345541,7 +345541,7 @@
       "source_location": "L26"
     },
     {
-      "community": 796,
+      "community": 795,
       "file_type": "code",
       "id": "appactionblockers_isvalidappactionblockerinput",
       "label": "isValidAppActionBlockerInput()",
@@ -345550,7 +345550,7 @@
       "source_location": "L30"
     },
     {
-      "community": 796,
+      "community": 795,
       "file_type": "code",
       "id": "appactionblockers_sortappactionblockers",
       "label": "sortAppActionBlockers()",
@@ -345559,7 +345559,7 @@
       "source_location": "L22"
     },
     {
-      "community": 796,
+      "community": 795,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appactionblockers_ts",
       "label": "appActionBlockers.ts",
@@ -345568,7 +345568,7 @@
       "source_location": "L1"
     },
     {
-      "community": 797,
+      "community": 796,
       "file_type": "code",
       "id": "appmessages_compareappmessages",
       "label": "compareAppMessages()",
@@ -345577,7 +345577,7 @@
       "source_location": "L39"
     },
     {
-      "community": 797,
+      "community": 796,
       "file_type": "code",
       "id": "appmessages_getselectedappmessage",
       "label": "getSelectedAppMessage()",
@@ -345586,7 +345586,7 @@
       "source_location": "L27"
     },
     {
-      "community": 797,
+      "community": 796,
       "file_type": "code",
       "id": "appmessages_isvalidappmessageinput",
       "label": "isValidAppMessageInput()",
@@ -345595,7 +345595,7 @@
       "source_location": "L31"
     },
     {
-      "community": 797,
+      "community": 796,
       "file_type": "code",
       "id": "appmessages_sortappmessages",
       "label": "sortAppMessages()",
@@ -345604,7 +345604,7 @@
       "source_location": "L23"
     },
     {
-      "community": 797,
+      "community": 796,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_messages_appmessages_ts",
       "label": "appMessages.ts",
@@ -345613,7 +345613,7 @@
       "source_location": "L1"
     },
     {
-      "community": 798,
+      "community": 797,
       "file_type": "code",
       "id": "appupdatereload_cleartrackedbeforeunloadhandlers",
       "label": "clearTrackedBeforeUnloadHandlers()",
@@ -345622,7 +345622,7 @@
       "source_location": "L85"
     },
     {
-      "community": 798,
+      "community": 797,
       "file_type": "code",
       "id": "appupdatereload_getcapture",
       "label": "getCapture()",
@@ -345631,7 +345631,7 @@
       "source_location": "L102"
     },
     {
-      "community": 798,
+      "community": 797,
       "file_type": "code",
       "id": "appupdatereload_installappupdateunloadpromptbypass",
       "label": "installAppUpdateUnloadPromptBypass()",
@@ -345640,7 +345640,7 @@
       "source_location": "L13"
     },
     {
-      "community": 798,
+      "community": 797,
       "file_type": "code",
       "id": "appupdatereload_reloadbrowserforappupdate",
       "label": "reloadBrowserForAppUpdate()",
@@ -345649,7 +345649,7 @@
       "source_location": "L74"
     },
     {
-      "community": 798,
+      "community": 797,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_app_update_appupdatereload_ts",
       "label": "appUpdateReload.ts",
@@ -345658,7 +345658,7 @@
       "source_location": "L1"
     },
     {
-      "community": 799,
+      "community": 798,
       "file_type": "code",
       "id": "browserfingerprint_buffertohex",
       "label": "bufferToHex()",
@@ -345667,7 +345667,7 @@
       "source_location": "L18"
     },
     {
-      "community": 799,
+      "community": 798,
       "file_type": "code",
       "id": "browserfingerprint_collectbrowserinfo",
       "label": "collectBrowserInfo()",
@@ -345676,7 +345676,7 @@
       "source_location": "L23"
     },
     {
-      "community": 799,
+      "community": 798,
       "file_type": "code",
       "id": "browserfingerprint_generatebrowserfingerprint",
       "label": "generateBrowserFingerprint()",
@@ -345685,7 +345685,7 @@
       "source_location": "L65"
     },
     {
-      "community": 799,
+      "community": 798,
       "file_type": "code",
       "id": "browserfingerprint_hashfingerprintsource",
       "label": "hashFingerprintSource()",
@@ -345694,13 +345694,58 @@
       "source_location": "L45"
     },
     {
-      "community": 799,
+      "community": 798,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_browserfingerprint_ts",
       "label": "browserFingerprint.ts",
       "norm_label": "browserfingerprint.ts",
       "source_file": "packages/athena-webapp/src/lib/browserFingerprint.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 799,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
+      "label": "runCommand.ts",
+      "norm_label": "runcommand.ts",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 799,
+      "file_type": "code",
+      "id": "runcommand_extracttraceid",
+      "label": "extractTraceId()",
+      "norm_label": "extracttraceid()",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 799,
+      "file_type": "code",
+      "id": "runcommand_getshareddemodenial",
+      "label": "getSharedDemoDenial()",
+      "norm_label": "getshareddemodenial()",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L48"
+    },
+    {
+      "community": 799,
+      "file_type": "code",
+      "id": "runcommand_isapprovalrequiredresult",
+      "label": "isApprovalRequiredResult()",
+      "norm_label": "isapprovalrequiredresult()",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 799,
+      "file_type": "code",
+      "id": "runcommand_runcommand",
+      "label": "runCommand()",
+      "norm_label": "runcommand()",
+      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
+      "source_location": "L68"
     },
     {
       "community": 8,
@@ -346569,51 +346614,6 @@
     {
       "community": 800,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_errors_runcommand_ts",
-      "label": "runCommand.ts",
-      "norm_label": "runcommand.ts",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 800,
-      "file_type": "code",
-      "id": "runcommand_extracttraceid",
-      "label": "extractTraceId()",
-      "norm_label": "extracttraceid()",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 800,
-      "file_type": "code",
-      "id": "runcommand_getshareddemodenial",
-      "label": "getSharedDemoDenial()",
-      "norm_label": "getshareddemodenial()",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L48"
-    },
-    {
-      "community": 800,
-      "file_type": "code",
-      "id": "runcommand_isapprovalrequiredresult",
-      "label": "isApprovalRequiredResult()",
-      "norm_label": "isapprovalrequiredresult()",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L34"
-    },
-    {
-      "community": 800,
-      "file_type": "code",
-      "id": "runcommand_runcommand",
-      "label": "runCommand()",
-      "norm_label": "runcommand()",
-      "source_file": "packages/athena-webapp/src/lib/errors/runCommand.ts",
-      "source_location": "L68"
-    },
-    {
-      "community": 801,
-      "file_type": "code",
       "id": "imageutils_test_arraybuffer",
       "label": "arrayBuffer()",
       "norm_label": "arraybuffer()",
@@ -346621,7 +346621,7 @@
       "source_location": "L78"
     },
     {
-      "community": 801,
+      "community": 800,
       "file_type": "code",
       "id": "imageutils_test_constructor",
       "label": "constructor()",
@@ -346630,7 +346630,7 @@
       "source_location": "L74"
     },
     {
-      "community": 801,
+      "community": 800,
       "file_type": "code",
       "id": "imageutils_test_mockimage",
       "label": "MockImage",
@@ -346639,7 +346639,7 @@
       "source_location": "L103"
     },
     {
-      "community": 801,
+      "community": 800,
       "file_type": "code",
       "id": "imageutils_test_mockimage_src",
       "label": ".src()",
@@ -346648,7 +346648,7 @@
       "source_location": "L109"
     },
     {
-      "community": 801,
+      "community": 800,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_test_ts",
       "label": "imageUtils.test.ts",
@@ -346657,7 +346657,7 @@
       "source_location": "L1"
     },
     {
-      "community": 802,
+      "community": 801,
       "file_type": "code",
       "id": "imageutils_convertimagestojpg",
       "label": "convertImagesToJpg()",
@@ -346666,7 +346666,7 @@
       "source_location": "L75"
     },
     {
-      "community": 802,
+      "community": 801,
       "file_type": "code",
       "id": "imageutils_convertimagestowebp",
       "label": "convertImagesToWebp()",
@@ -346675,7 +346675,7 @@
       "source_location": "L26"
     },
     {
-      "community": 802,
+      "community": 801,
       "file_type": "code",
       "id": "imageutils_converttojpg",
       "label": "convertToJpg()",
@@ -346684,7 +346684,7 @@
       "source_location": "L38"
     },
     {
-      "community": 802,
+      "community": 801,
       "file_type": "code",
       "id": "imageutils_getuploadimagesdata",
       "label": "getUploadImagesData()",
@@ -346693,7 +346693,7 @@
       "source_location": "L4"
     },
     {
-      "community": 802,
+      "community": 801,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_imageutils_ts",
       "label": "imageUtils.ts",
@@ -346702,7 +346702,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 802,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_convex_registergateway_ts",
       "label": "registerGateway.ts",
@@ -346711,7 +346711,7 @@
       "source_location": "L1"
     },
     {
-      "community": 803,
+      "community": 802,
       "file_type": "code",
       "id": "registergateway_mapregisterstatedto",
       "label": "mapRegisterStateDto()",
@@ -346720,7 +346720,7 @@
       "source_location": "L13"
     },
     {
-      "community": 803,
+      "community": 802,
       "file_type": "code",
       "id": "registergateway_mapterminaldto",
       "label": "mapTerminalDto()",
@@ -346729,7 +346729,7 @@
       "source_location": "L31"
     },
     {
-      "community": 803,
+      "community": 802,
       "file_type": "code",
       "id": "registergateway_useconvexregisterstate",
       "label": "useConvexRegisterState()",
@@ -346738,7 +346738,7 @@
       "source_location": "L37"
     },
     {
-      "community": 803,
+      "community": 802,
       "file_type": "code",
       "id": "registergateway_useconvexterminalbyfingerprint",
       "label": "useConvexTerminalByFingerprint()",
@@ -346747,7 +346747,7 @@
       "source_location": "L59"
     },
     {
-      "community": 804,
+      "community": 803,
       "file_type": "code",
       "id": "expenselocalcommandgateway_createexpenselocalcommandgateway",
       "label": "createExpenseLocalCommandGateway()",
@@ -346756,7 +346756,7 @@
       "source_location": "L55"
     },
     {
-      "community": 804,
+      "community": 803,
       "file_type": "code",
       "id": "expenselocalcommandgateway_itempayload",
       "label": "itemPayload()",
@@ -346765,7 +346765,7 @@
       "source_location": "L282"
     },
     {
-      "community": 804,
+      "community": 803,
       "file_type": "code",
       "id": "expenselocalcommandgateway_reasonpayload",
       "label": "reasonPayload()",
@@ -346774,7 +346774,7 @@
       "source_location": "L303"
     },
     {
-      "community": 804,
+      "community": 803,
       "file_type": "code",
       "id": "expenselocalcommandgateway_resolvestaffprooftoken",
       "label": "resolveStaffProofToken()",
@@ -346783,7 +346783,7 @@
       "source_location": "L310"
     },
     {
-      "community": 804,
+      "community": 803,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_expenselocalcommandgateway_ts",
       "label": "expenseLocalCommandGateway.ts",
@@ -346792,7 +346792,7 @@
       "source_location": "L1"
     },
     {
-      "community": 805,
+      "community": 804,
       "file_type": "code",
       "id": "localcommandgateway_test_appendopendrawer",
       "label": "appendOpenDrawer()",
@@ -346801,7 +346801,7 @@
       "source_location": "L22"
     },
     {
-      "community": 805,
+      "community": 804,
       "file_type": "code",
       "id": "localcommandgateway_test_blockdrawerauthority",
       "label": "blockDrawerAuthority()",
@@ -346810,7 +346810,7 @@
       "source_location": "L34"
     },
     {
-      "community": 805,
+      "community": 804,
       "file_type": "code",
       "id": "localcommandgateway_test_createblockedsalegateway",
       "label": "createBlockedSaleGateway()",
@@ -346819,7 +346819,7 @@
       "source_location": "L48"
     },
     {
-      "community": 805,
+      "community": 804,
       "file_type": "code",
       "id": "localcommandgateway_test_salecommandinput",
       "label": "saleCommandInput()",
@@ -346828,7 +346828,7 @@
       "source_location": "L11"
     },
     {
-      "community": 805,
+      "community": 804,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localcommandgateway_test_ts",
       "label": "localCommandGateway.test.ts",
@@ -346837,7 +346837,7 @@
       "source_location": "L1"
     },
     {
-      "community": 806,
+      "community": 805,
       "file_type": "code",
       "id": "localregisterreader_readlatestdrawerauthoritystate",
       "label": "readLatestDrawerAuthorityState()",
@@ -346846,7 +346846,7 @@
       "source_location": "L325"
     },
     {
-      "community": 806,
+      "community": 805,
       "file_type": "code",
       "id": "localregisterreader_readprojectedlocalregistermodel",
       "label": "readProjectedLocalRegisterModel()",
@@ -346855,7 +346855,7 @@
       "source_location": "L129"
     },
     {
-      "community": 806,
+      "community": 805,
       "file_type": "code",
       "id": "localregisterreader_readscopedpagesorfallback",
       "label": "readScopedPagesOrFallback()",
@@ -346864,7 +346864,7 @@
       "source_location": "L266"
     },
     {
-      "community": 806,
+      "community": 805,
       "file_type": "code",
       "id": "localregisterreader_readscopedposlocalevents",
       "label": "readScopedPosLocalEvents()",
@@ -346873,7 +346873,7 @@
       "source_location": "L86"
     },
     {
-      "community": 806,
+      "community": 805,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_localregisterreader_ts",
       "label": "localRegisterReader.ts",
@@ -346882,7 +346882,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 806,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_registerreadmodel_test_ts",
       "label": "registerReadModel.test.ts",
@@ -346891,7 +346891,7 @@
       "source_location": "L1"
     },
     {
-      "community": 807,
+      "community": 806,
       "file_type": "code",
       "id": "registerreadmodel_test_errorcodes",
       "label": "errorCodes()",
@@ -346900,7 +346900,7 @@
       "source_location": "L1565"
     },
     {
-      "community": 807,
+      "community": 806,
       "file_type": "code",
       "id": "registerreadmodel_test_event",
       "label": "event()",
@@ -346909,7 +346909,7 @@
       "source_location": "L1569"
     },
     {
-      "community": 807,
+      "community": 806,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftevent",
       "label": "serviceDraftEvent()",
@@ -346918,7 +346918,7 @@
       "source_location": "L1611"
     },
     {
-      "community": 807,
+      "community": 806,
       "file_type": "code",
       "id": "registerreadmodel_test_servicedraftprelude",
       "label": "serviceDraftPrelude()",
@@ -346927,7 +346927,7 @@
       "source_location": "L1593"
     },
     {
-      "community": 808,
+      "community": 807,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_runtimereadiness_ts",
       "label": "runtimeReadiness.ts",
@@ -346936,7 +346936,7 @@
       "source_location": "L1"
     },
     {
-      "community": 808,
+      "community": 807,
       "file_type": "code",
       "id": "runtimereadiness_emptyposterminalruntimereadiness",
       "label": "emptyPosTerminalRuntimeReadiness()",
@@ -346945,7 +346945,7 @@
       "source_location": "L39"
     },
     {
-      "community": 808,
+      "community": 807,
       "file_type": "code",
       "id": "runtimereadiness_getruntimevisibleactiveregistersession",
       "label": "getRuntimeVisibleActiveRegisterSession()",
@@ -346954,7 +346954,7 @@
       "source_location": "L165"
     },
     {
-      "community": 808,
+      "community": 807,
       "file_type": "code",
       "id": "runtimereadiness_refreshterminalruntimereadiness",
       "label": "refreshTerminalRuntimeReadiness()",
@@ -346963,7 +346963,7 @@
       "source_location": "L51"
     },
     {
-      "community": 808,
+      "community": 807,
       "file_type": "code",
       "id": "runtimereadiness_toruntimeactiveregistersession",
       "label": "toRuntimeActiveRegisterSession()",
@@ -346972,7 +346972,7 @@
       "source_location": "L179"
     },
     {
-      "community": 809,
+      "community": 808,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_pos_infrastructure_local_useregisterlifecycleauthorityruntime_ts",
       "label": "useRegisterLifecycleAuthorityRuntime.ts",
@@ -346981,7 +346981,7 @@
       "source_location": "L1"
     },
     {
-      "community": 809,
+      "community": 808,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_applysnapshot",
       "label": "applySnapshot()",
@@ -346990,7 +346990,7 @@
       "source_location": "L389"
     },
     {
-      "community": 809,
+      "community": 808,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_isregisterlifecyclerepairclassification",
       "label": "isRegisterLifecycleRepairClassification()",
@@ -346999,7 +346999,7 @@
       "source_location": "L554"
     },
     {
-      "community": 809,
+      "community": 808,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_toobservation",
       "label": "toObservation()",
@@ -347008,13 +347008,58 @@
       "source_location": "L523"
     },
     {
-      "community": 809,
+      "community": 808,
       "file_type": "code",
       "id": "useregisterlifecycleauthorityruntime_useregisterlifecycleauthorityruntime",
       "label": "useRegisterLifecycleAuthorityRuntime()",
       "norm_label": "useregisterlifecycleauthorityruntime()",
       "source_file": "packages/athena-webapp/src/lib/pos/infrastructure/local/useRegisterLifecycleAuthorityRuntime.ts",
       "source_location": "L53"
+    },
+    {
+      "community": 809,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
+      "label": "transactionUtils.ts",
+      "norm_label": "transactionutils.ts",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 809,
+      "file_type": "code",
+      "id": "transactionutils_calculatechange",
+      "label": "calculateChange()",
+      "norm_label": "calculatechange()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 809,
+      "file_type": "code",
+      "id": "transactionutils_formatcurrency",
+      "label": "formatCurrency()",
+      "norm_label": "formatcurrency()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L29"
+    },
+    {
+      "community": 809,
+      "file_type": "code",
+      "id": "transactionutils_formattimestamp",
+      "label": "formatTimestamp()",
+      "norm_label": "formattimestamp()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L49"
+    },
+    {
+      "community": 809,
+      "file_type": "code",
+      "id": "transactionutils_generatetransactionnumber",
+      "label": "generateTransactionNumber()",
+      "norm_label": "generatetransactionnumber()",
+      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
+      "source_location": "L14"
     },
     {
       "community": 81,
@@ -347235,51 +347280,6 @@
     {
       "community": 810,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_lib_pos_transactionutils_ts",
-      "label": "transactionUtils.ts",
-      "norm_label": "transactionutils.ts",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 810,
-      "file_type": "code",
-      "id": "transactionutils_calculatechange",
-      "label": "calculateChange()",
-      "norm_label": "calculatechange()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 810,
-      "file_type": "code",
-      "id": "transactionutils_formatcurrency",
-      "label": "formatCurrency()",
-      "norm_label": "formatcurrency()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L29"
-    },
-    {
-      "community": 810,
-      "file_type": "code",
-      "id": "transactionutils_formattimestamp",
-      "label": "formatTimestamp()",
-      "norm_label": "formattimestamp()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L49"
-    },
-    {
-      "community": 810,
-      "file_type": "code",
-      "id": "transactionutils_generatetransactionnumber",
-      "label": "generateTransactionNumber()",
-      "norm_label": "generatetransactionnumber()",
-      "source_file": "packages/athena-webapp/src/lib/pos/transactionUtils.ts",
-      "source_location": "L14"
-    },
-    {
-      "community": 811,
-      "file_type": "code",
       "id": "packages_athena_webapp_src_lib_runtimebuildmetadata_ts",
       "label": "runtimeBuildMetadata.ts",
       "norm_label": "runtimebuildmetadata.ts",
@@ -347287,7 +347287,7 @@
       "source_location": "L1"
     },
     {
-      "community": 811,
+      "community": 810,
       "file_type": "code",
       "id": "runtimebuildmetadata_getinitialruntimebuildmetadata",
       "label": "getInitialRuntimeBuildMetadata()",
@@ -347296,7 +347296,7 @@
       "source_location": "L16"
     },
     {
-      "community": 811,
+      "community": 810,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizedeploymetadata",
       "label": "normalizeDeployMetadata()",
@@ -347305,7 +347305,7 @@
       "source_location": "L49"
     },
     {
-      "community": 811,
+      "community": 810,
       "file_type": "code",
       "id": "runtimebuildmetadata_normalizemetadatavalue",
       "label": "normalizeMetadataValue()",
@@ -347314,7 +347314,7 @@
       "source_location": "L63"
     },
     {
-      "community": 811,
+      "community": 810,
       "file_type": "code",
       "id": "runtimebuildmetadata_readruntimebuildmetadata",
       "label": "readRuntimeBuildMetadata()",
@@ -347323,7 +347323,7 @@
       "source_location": "L32"
     },
     {
-      "community": 812,
+      "community": 811,
       "file_type": "code",
       "id": "packages_athena_webapp_src_lib_timelineutils_ts",
       "label": "timelineUtils.ts",
@@ -347332,7 +347332,7 @@
       "source_location": "L1"
     },
     {
-      "community": 812,
+      "community": 811,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevent",
       "label": "enrichTimelineEvent()",
@@ -347341,7 +347341,7 @@
       "source_location": "L184"
     },
     {
-      "community": 812,
+      "community": 811,
       "file_type": "code",
       "id": "timelineutils_enrichtimelineevents",
       "label": "enrichTimelineEvents()",
@@ -347350,7 +347350,7 @@
       "source_location": "L200"
     },
     {
-      "community": 812,
+      "community": 811,
       "file_type": "code",
       "id": "timelineutils_gettimerangelabel",
       "label": "getTimeRangeLabel()",
@@ -347359,7 +347359,7 @@
       "source_location": "L244"
     },
     {
-      "community": 812,
+      "community": 811,
       "file_type": "code",
       "id": "timelineutils_groupeventsbytimeframe",
       "label": "groupEventsByTimeframe()",
@@ -347368,7 +347368,7 @@
       "source_location": "L206"
     },
     {
-      "community": 813,
+      "community": 812,
       "file_type": "code",
       "id": "packages_athena_webapp_src_offline_registerposappshellserviceworker_ts",
       "label": "registerPosAppShellServiceWorker.ts",
@@ -347377,7 +347377,7 @@
       "source_location": "L1"
     },
     {
-      "community": 813,
+      "community": 812,
       "file_type": "code",
       "id": "registerposappshellserviceworker_isposappshellserviceworkerregistration",
       "label": "isPosAppShellServiceWorkerRegistration()",
@@ -347386,7 +347386,7 @@
       "source_location": "L52"
     },
     {
-      "community": 813,
+      "community": 812,
       "file_type": "code",
       "id": "registerposappshellserviceworker_registerposappshellserviceworker",
       "label": "registerPosAppShellServiceWorker()",
@@ -347395,7 +347395,7 @@
       "source_location": "L6"
     },
     {
-      "community": 813,
+      "community": 812,
       "file_type": "code",
       "id": "registerposappshellserviceworker_resetposappshellserviceworkerregistrationfortest",
       "label": "resetPosAppShellServiceWorkerRegistrationForTest()",
@@ -347404,7 +347404,7 @@
       "source_location": "L20"
     },
     {
-      "community": 813,
+      "community": 812,
       "file_type": "code",
       "id": "registerposappshellserviceworker_unregisterposappshellserviceworkerfordev",
       "label": "unregisterPosAppShellServiceWorkerForDev()",
@@ -347413,7 +347413,7 @@
       "source_location": "L24"
     },
     {
-      "community": 814,
+      "community": 813,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routetree_browser_boundary_test_ts",
       "label": "routeTree.browser-boundary.test.ts",
@@ -347422,7 +347422,7 @@
       "source_location": "L1"
     },
     {
-      "community": 814,
+      "community": 813,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_browsersourceroots",
       "label": "browserSourceRoots()",
@@ -347431,7 +347431,7 @@
       "source_location": "L150"
     },
     {
-      "community": 814,
+      "community": 813,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_collectsourcefiles",
       "label": "collectSourceFiles()",
@@ -347440,7 +347440,7 @@
       "source_location": "L102"
     },
     {
-      "community": 814,
+      "community": 813,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_findillegalconveximports",
       "label": "findIllegalConvexImports()",
@@ -347449,7 +347449,7 @@
       "source_location": "L120"
     },
     {
-      "community": 814,
+      "community": 813,
       "file_type": "code",
       "id": "routetree_browser_boundary_test_toprojectconvexpath",
       "label": "toProjectConvexPath()",
@@ -347458,7 +347458,7 @@
       "source_location": "L72"
     },
     {
-      "community": 815,
+      "community": 814,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_root_tsx",
       "label": "__root.tsx",
@@ -347467,7 +347467,7 @@
       "source_location": "L1"
     },
     {
-      "community": 815,
+      "community": 814,
       "file_type": "code",
       "id": "root_getathenadocumenttitle",
       "label": "getAthenaDocumentTitle()",
@@ -347476,7 +347476,7 @@
       "source_location": "L89"
     },
     {
-      "community": 815,
+      "community": 814,
       "file_type": "code",
       "id": "root_rootcomponent",
       "label": "RootComponent()",
@@ -347485,7 +347485,7 @@
       "source_location": "L62"
     },
     {
-      "community": 815,
+      "community": 814,
       "file_type": "code",
       "id": "root_rootdocument",
       "label": "RootDocument()",
@@ -347494,7 +347494,7 @@
       "source_location": "L72"
     },
     {
-      "community": 815,
+      "community": 814,
       "file_type": "code",
       "id": "root_rootnotfound",
       "label": "RootNotFound()",
@@ -347503,7 +347503,7 @@
       "source_location": "L48"
     },
     {
-      "community": 816,
+      "community": 815,
       "file_type": "code",
       "id": "packages_athena_webapp_src_routes_authed_orgurlslug_store_storeurlslug_traces_traceid_tsx",
       "label": "$traceId.tsx",
@@ -347512,7 +347512,7 @@
       "source_location": "L1"
     },
     {
-      "community": 816,
+      "community": 815,
       "file_type": "code",
       "id": "traceid_hasorgnotfoundpayload",
       "label": "hasOrgNotFoundPayload()",
@@ -347521,7 +347521,7 @@
       "source_location": "L10"
     },
     {
-      "community": 816,
+      "community": 815,
       "file_type": "code",
       "id": "traceid_workflowtraceroute",
       "label": "WorkflowTraceRoute()",
@@ -347530,7 +347530,7 @@
       "source_location": "L85"
     },
     {
-      "community": 816,
+      "community": 815,
       "file_type": "code",
       "id": "traceid_workflowtraceroutecontent",
       "label": "WorkflowTraceRouteContent()",
@@ -347539,7 +347539,7 @@
       "source_location": "L19"
     },
     {
-      "community": 816,
+      "community": 815,
       "file_type": "code",
       "id": "traceid_workflowtracerouteshell",
       "label": "WorkflowTraceRouteShell()",
@@ -347548,7 +347548,7 @@
       "source_location": "L50"
     },
     {
-      "community": 817,
+      "community": 816,
       "file_type": "code",
       "id": "expensestore_expensecartitemsourcekey",
       "label": "expenseCartItemSourceKey()",
@@ -347557,7 +347557,7 @@
       "source_location": "L179"
     },
     {
-      "community": 817,
+      "community": 816,
       "file_type": "code",
       "id": "expensestore_ispendingoptimisticexpensecartitem",
       "label": "isPendingOptimisticExpenseCartItem()",
@@ -347566,7 +347566,7 @@
       "source_location": "L197"
     },
     {
-      "community": 817,
+      "community": 816,
       "file_type": "code",
       "id": "expensestore_mapexpensesessioncartitemtocartitem",
       "label": "mapExpenseSessionCartItemToCartItem()",
@@ -347575,7 +347575,7 @@
       "source_location": "L213"
     },
     {
-      "community": 817,
+      "community": 816,
       "file_type": "code",
       "id": "expensestore_sessionitemrepresentscartitem",
       "label": "sessionItemRepresentsCartItem()",
@@ -347584,7 +347584,7 @@
       "source_location": "L201"
     },
     {
-      "community": 817,
+      "community": 816,
       "file_type": "code",
       "id": "packages_athena_webapp_src_stores_expensestore_ts",
       "label": "expenseStore.ts",
@@ -347593,7 +347593,7 @@
       "source_location": "L1"
     },
     {
-      "community": 818,
+      "community": 817,
       "file_type": "code",
       "id": "analytics_getproductviewcount",
       "label": "getProductViewCount()",
@@ -347602,7 +347602,7 @@
       "source_location": "L93"
     },
     {
-      "community": 818,
+      "community": 817,
       "file_type": "code",
       "id": "analytics_logout",
       "label": "logout()",
@@ -347611,7 +347611,7 @@
       "source_location": "L75"
     },
     {
-      "community": 818,
+      "community": 817,
       "file_type": "code",
       "id": "analytics_postanalytics",
       "label": "postAnalytics()",
@@ -347620,7 +347620,7 @@
       "source_location": "L4"
     },
     {
-      "community": 818,
+      "community": 817,
       "file_type": "code",
       "id": "analytics_updateanalyticsowner",
       "label": "updateAnalyticsOwner()",
@@ -347629,7 +347629,7 @@
       "source_location": "L47"
     },
     {
-      "community": 818,
+      "community": 817,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_analytics_ts",
       "label": "analytics.ts",
@@ -347638,7 +347638,7 @@
       "source_location": "L1"
     },
     {
-      "community": 819,
+      "community": 818,
       "file_type": "code",
       "id": "category_getallcategories",
       "label": "getAllCategories()",
@@ -347647,7 +347647,7 @@
       "source_location": "L11"
     },
     {
-      "community": 819,
+      "community": 818,
       "file_type": "code",
       "id": "category_getallcategorieswithsubcategories",
       "label": "getAllCategoriesWithSubcategories()",
@@ -347656,7 +347656,7 @@
       "source_location": "L25"
     },
     {
-      "community": 819,
+      "community": 818,
       "file_type": "code",
       "id": "category_getbaseurl",
       "label": "getBaseUrl()",
@@ -347665,7 +347665,7 @@
       "source_location": "L9"
     },
     {
-      "community": 819,
+      "community": 818,
       "file_type": "code",
       "id": "category_getcategory",
       "label": "getCategory()",
@@ -347674,12 +347674,57 @@
       "source_location": "L39"
     },
     {
-      "community": 819,
+      "community": 818,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_api_category_ts",
       "label": "category.ts",
       "norm_label": "category.ts",
       "source_file": "packages/storefront-webapp/src/api/category.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 819,
+      "file_type": "code",
+      "id": "onlineorder_getbaseurl",
+      "label": "getBaseUrl()",
+      "norm_label": "getbaseurl()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L4"
+    },
+    {
+      "community": 819,
+      "file_type": "code",
+      "id": "onlineorder_getorder",
+      "label": "getOrder()",
+      "norm_label": "getorder()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L24"
+    },
+    {
+      "community": 819,
+      "file_type": "code",
+      "id": "onlineorder_getorders",
+      "label": "getOrders()",
+      "norm_label": "getorders()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L6"
+    },
+    {
+      "community": 819,
+      "file_type": "code",
+      "id": "onlineorder_updateordersowner",
+      "label": "updateOrdersOwner()",
+      "norm_label": "updateordersowner()",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
+      "source_location": "L42"
+    },
+    {
+      "community": 819,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
+      "label": "onlineOrder.ts",
+      "norm_label": "onlineorder.ts",
+      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
       "source_location": "L1"
     },
     {
@@ -347901,51 +347946,6 @@
     {
       "community": 820,
       "file_type": "code",
-      "id": "onlineorder_getbaseurl",
-      "label": "getBaseUrl()",
-      "norm_label": "getbaseurl()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L4"
-    },
-    {
-      "community": 820,
-      "file_type": "code",
-      "id": "onlineorder_getorder",
-      "label": "getOrder()",
-      "norm_label": "getorder()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L24"
-    },
-    {
-      "community": 820,
-      "file_type": "code",
-      "id": "onlineorder_getorders",
-      "label": "getOrders()",
-      "norm_label": "getorders()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L6"
-    },
-    {
-      "community": 820,
-      "file_type": "code",
-      "id": "onlineorder_updateordersowner",
-      "label": "updateOrdersOwner()",
-      "norm_label": "updateordersowner()",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L42"
-    },
-    {
-      "community": 820,
-      "file_type": "code",
-      "id": "packages_storefront_webapp_src_api_onlineorder_ts",
-      "label": "onlineOrder.ts",
-      "norm_label": "onlineorder.ts",
-      "source_file": "packages/storefront-webapp/src/api/onlineOrder.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 821,
-      "file_type": "code",
       "id": "packages_storefront_webapp_src_api_storefrontuser_ts",
       "label": "storeFrontUser.ts",
       "norm_label": "storefrontuser.ts",
@@ -347953,7 +347953,7 @@
       "source_location": "L1"
     },
     {
-      "community": 821,
+      "community": 820,
       "file_type": "code",
       "id": "storefrontuser_getactiveuser",
       "label": "getActiveUser()",
@@ -347962,7 +347962,7 @@
       "source_location": "L23"
     },
     {
-      "community": 821,
+      "community": 820,
       "file_type": "code",
       "id": "storefrontuser_getbaseurl",
       "label": "getBaseUrl()",
@@ -347971,7 +347971,7 @@
       "source_location": "L5"
     },
     {
-      "community": 821,
+      "community": 820,
       "file_type": "code",
       "id": "storefrontuser_getguest",
       "label": "getGuest()",
@@ -347980,7 +347980,7 @@
       "source_location": "L7"
     },
     {
-      "community": 821,
+      "community": 820,
       "file_type": "code",
       "id": "storefrontuser_updateuser",
       "label": "updateUser()",
@@ -347989,7 +347989,7 @@
       "source_location": "L41"
     },
     {
-      "community": 822,
+      "community": 821,
       "file_type": "code",
       "id": "homepage_enableprompts",
       "label": "enablePrompts()",
@@ -347998,7 +347998,7 @@
       "source_location": "L137"
     },
     {
-      "community": 822,
+      "community": 821,
       "file_type": "code",
       "id": "homepage_handleclickonleavereviewbutton",
       "label": "handleClickOnLeaveReviewButton()",
@@ -348007,7 +348007,7 @@
       "source_location": "L173"
     },
     {
-      "community": 822,
+      "community": 821,
       "file_type": "code",
       "id": "homepage_handlescroll",
       "label": "handleScroll()",
@@ -348016,7 +348016,7 @@
       "source_location": "L105"
     },
     {
-      "community": 822,
+      "community": 821,
       "file_type": "code",
       "id": "homepage_homepagereadyshell",
       "label": "HomePageReadyShell()",
@@ -348025,7 +348025,7 @@
       "source_location": "L31"
     },
     {
-      "community": 822,
+      "community": 821,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_homepage_tsx",
       "label": "HomePage.tsx",
@@ -348034,7 +348034,7 @@
       "source_location": "L1"
     },
     {
-      "community": 823,
+      "community": 822,
       "file_type": "code",
       "id": "homepagecontent_resolvehomepagecontent",
       "label": "resolveHomepageContent()",
@@ -348043,7 +348043,7 @@
       "source_location": "L102"
     },
     {
-      "community": 823,
+      "community": 822,
       "file_type": "code",
       "id": "homepagecontent_todisplayproduct",
       "label": "toDisplayProduct()",
@@ -348052,7 +348052,7 @@
       "source_location": "L70"
     },
     {
-      "community": 823,
+      "community": 822,
       "file_type": "code",
       "id": "homepagecontent_todisplaysku",
       "label": "toDisplaySku()",
@@ -348061,7 +348061,7 @@
       "source_location": "L54"
     },
     {
-      "community": 823,
+      "community": 822,
       "file_type": "code",
       "id": "homepagecontent_tofeatureditem",
       "label": "toFeaturedItem()",
@@ -348070,7 +348070,7 @@
       "source_location": "L78"
     },
     {
-      "community": 823,
+      "community": 822,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_home_homepagecontent_ts",
       "label": "homePageContent.ts",
@@ -348079,7 +348079,7 @@
       "source_location": "L1"
     },
     {
-      "community": 824,
+      "community": 823,
       "file_type": "code",
       "id": "inventorylevelbadge_lowstockbadge",
       "label": "LowStockBadge()",
@@ -348088,7 +348088,7 @@
       "source_location": "L14"
     },
     {
-      "community": 824,
+      "community": 823,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastbadge",
       "label": "SellingFastBadge()",
@@ -348097,7 +348097,7 @@
       "source_location": "L22"
     },
     {
-      "community": 824,
+      "community": 823,
       "file_type": "code",
       "id": "inventorylevelbadge_sellingfastsignal",
       "label": "SellingFastSignal()",
@@ -348106,7 +348106,7 @@
       "source_location": "L30"
     },
     {
-      "community": 824,
+      "community": 823,
       "file_type": "code",
       "id": "inventorylevelbadge_soldoutbadge",
       "label": "SoldOutBadge()",
@@ -348115,12 +348115,57 @@
       "source_location": "L3"
     },
     {
-      "community": 824,
+      "community": 823,
       "file_type": "code",
       "id": "packages_storefront_webapp_src_components_product_page_inventorylevelbadge_tsx",
       "label": "InventoryLevelBadge.tsx",
       "norm_label": "inventorylevelbadge.tsx",
       "source_file": "packages/storefront-webapp/src/components/product-page/InventoryLevelBadge.tsx",
+      "source_location": "L1"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "currency_formatstoredamount",
+      "label": "formatStoredAmount()",
+      "norm_label": "formatstoredamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L9"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "currency_todisplayamount",
+      "label": "toDisplayAmount()",
+      "norm_label": "todisplayamount()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L5"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "currency_topesewas",
+      "label": "toPesewas()",
+      "norm_label": "topesewas()",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "packages_athena_webapp_shared_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/athena-webapp/shared/currency.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 824,
+      "file_type": "code",
+      "id": "packages_storefront_webapp_src_lib_currency_ts",
+      "label": "currency.ts",
+      "norm_label": "currency.ts",
+      "source_file": "packages/storefront-webapp/src/lib/currency.ts",
       "source_location": "L1"
     },
     {

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 3328
-- Graph nodes: 14939
-- Graph edges: 18683
+- Graph nodes: 14940
+- Graph edges: 18686
 - Communities: 3252
 
 ## Graph Hotspots

--- a/scripts/policy-projection-check.test.ts
+++ b/scripts/policy-projection-check.test.ts
@@ -342,6 +342,66 @@ describe("policy projection comparison", () => {
     expect(findingCodes(result)).toContain("lens_persona_defect");
   });
 
+  // The agreement rule compares three axes at once, so each axis needs its own
+  // witness: a test that moves two of them at once is satisfied by whichever
+  // clause happens to fire, and the other clause can then be deleted unnoticed.
+  test("a compiled lens bound to a lens identity the document never declared is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    snapshot.compiled.snapshot.reviewLenses[0].lensId = "lens.renamed";
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
+  test("a compiled lens filed under a category the document never declared is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    snapshot.compiled.snapshot.reviewLenses[0].category = "additional";
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
+  // Every other mutation removes a member; these malform one, which is what
+  // holds the two format rules to their shape rather than to mere presence.
+  test("a charter identity that is not a well-formed persona id is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const document = await readPolicyJson(copyDir, "repository-policy.json");
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    // Carried on both sides so the agreement rule stays quiet and the red is
+    // attributable to the identity format rule alone.
+    document.reviewLenses[0].personaId = "persona.Outcome_Correctness";
+    snapshot.compiled.snapshot.reviewLenses[0].personaId = "persona.Outcome_Correctness";
+    await writePolicyJson(copyDir, "repository-policy.json", document);
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
+  test("a resolved charter digest that is not a sha256 is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    // Hex, but far short of a sha256: a rule checking only the alphabet
+    // rather than the width would accept this.
+    snapshot.compiled.snapshot.reviewLenses[0].personaDigest = "abc123";
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
   test("the tracked document references shipped charters by identity alone", async () => {
     const document = await readPolicyJson(policyDir, "repository-policy.json");
     const snapshot = await readPolicyJson(policyDir, "compiled-snapshot.json");

--- a/scripts/policy-projection-check.test.ts
+++ b/scripts/policy-projection-check.test.ts
@@ -284,6 +284,21 @@ describe("policy projection comparison", () => {
     expect(result.status).toBe("fail");
     expect(findingCodes(result)).toContain("lens_persona_defect");
     expect(findingCodes(result)).not.toContain("report_input_stale");
+
+    // The other direction: a snapshot short of a lens the document declares,
+    // which is the ordinary shape of a stale recompile. Without the count
+    // comparison the per-member walk dereferences a missing compiled lens and
+    // the sensor degrades from the lens verdict to an untyped shape error.
+    const short = await policyDirCopy();
+    const shortSnapshot = await readPolicyJson(short, "compiled-snapshot.json");
+    shortSnapshot.compiled.snapshot.reviewLenses.pop();
+    await writePolicyJson(short, "compiled-snapshot.json", shortSnapshot);
+    await restampPolicyDigests(short);
+
+    const shortResult = await runPolicyProjectionCheck(rootDir, { policyDir: short });
+    expect(shortResult.status).toBe("fail");
+    expect(findingCodes(shortResult)).toContain("lens_persona_defect");
+    expect(findingCodes(shortResult)).not.toContain("artifact_unreadable");
   });
 
   test("a document with no review lenses cannot satisfy the per-lens charter claim by emptiness", async () => {

--- a/scripts/policy-projection-check.test.ts
+++ b/scripts/policy-projection-check.test.ts
@@ -184,6 +184,156 @@ describe("policy projection comparison", () => {
     expect(result.status).toBe("fail");
     expect(findingCodes(result)).toContain("adjudication_incomplete");
   });
+  // Every mutation below re-stamps the recorded input digests before running
+  // the sensor. Without that, the digest pins fail on any edit at all and a
+  // lens defect would be credited to a check that never read a lens. The
+  // control test directly below proves the re-stamp itself returns green, so a
+  // red result in the mutations is attributable to the lens block alone.
+  async function restampPolicyDigests(dir: string) {
+    const digestOf = async (file: string) =>
+      createHash("sha256").update(await readFile(path.join(dir, file))).digest("hex");
+    const documentDigest = await digestOf("repository-policy.json");
+    const adaptersDigest = await digestOf("adapters.json");
+    const oracleDigest = await digestOf("pre-cutover-oracle.json");
+
+    const snapshot = await readPolicyJson(dir, "compiled-snapshot.json");
+    snapshot.inputDigests["repository-policy.json"] = documentDigest;
+    snapshot.inputDigests["adapters.json"] = adaptersDigest;
+    await writePolicyJson(dir, "compiled-snapshot.json", snapshot);
+
+    const report = await readPolicyJson(dir, "comparison-report.json");
+    report.inputs["repository-policy.json"] = documentDigest;
+    report.inputs["adapters.json"] = adaptersDigest;
+    report.inputs["pre-cutover-oracle.json"] = oracleDigest;
+    report.inputs["compiled-snapshot.json"] = await digestOf("compiled-snapshot.json");
+    report.inputs["compiledDigest"] = snapshot.compiled.compiledDigest;
+    await writePolicyJson(dir, "comparison-report.json", report);
+  }
+
+  test("re-stamping the recorded digests without mutating anything stays green", async () => {
+    const copyDir = await policyDirCopy();
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.findings).toEqual([]);
+    expect(result.status).toBe("pass");
+  });
+
+  test("a lens that names no reviewer charter is caught after re-stamping", async () => {
+    const copyDir = await policyDirCopy();
+    const document = await readPolicyJson(copyDir, "repository-policy.json");
+    delete document.reviewLenses[0].personaId;
+    await writePolicyJson(copyDir, "repository-policy.json", document);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+    // Attributable: the digest pins are satisfied, so nothing else fired.
+    expect(findingCodes(result)).not.toContain("snapshot_input_stale");
+    expect(findingCodes(result)).not.toContain("report_input_stale");
+  });
+
+  test("an added lens carrying no reviewer charter is caught even when the counts agree", async () => {
+    const copyDir = await policyDirCopy();
+    const document = await readPolicyJson(copyDir, "repository-policy.json");
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    // Added to both sides, so the count comparison is satisfied and only the
+    // per-member enumeration can catch it.
+    document.reviewLenses.push({ lensId: "lens.additional", category: "additional" });
+    snapshot.compiled.snapshot.reviewLenses.push({
+      lensId: "lens.additional",
+      category: "additional",
+    });
+    await writePolicyJson(copyDir, "repository-policy.json", document);
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+    expect(findingCodes(result)).not.toContain("snapshot_input_stale");
+    expect(findingCodes(result)).not.toContain("report_input_stale");
+  });
+
+  test("a document with no review lenses cannot satisfy the per-lens charter claim by emptiness", async () => {
+    const copyDir = await policyDirCopy();
+    const document = await readPolicyJson(copyDir, "repository-policy.json");
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    document.reviewLenses = [];
+    snapshot.compiled.snapshot.reviewLenses = [];
+    await writePolicyJson(copyDir, "repository-policy.json", document);
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
+  test("a compiled lens that lost its resolved charter digest is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    delete snapshot.compiled.snapshot.reviewLenses[1].personaDigest;
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+    expect(findingCodes(result)).not.toContain("report_input_stale");
+  });
+
+  test("a document that pins charter bytes is caught, because Athena owns no charter", async () => {
+    const copyDir = await policyDirCopy();
+    const document = await readPolicyJson(copyDir, "repository-policy.json");
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    // The digest is the one compilation actually resolved, so this is the
+    // plausible mistake: correct bytes, wrong reference form.
+    document.reviewLenses[0].personaDigest =
+      snapshot.compiled.snapshot.reviewLenses[0].personaDigest;
+    await writePolicyJson(copyDir, "repository-policy.json", document);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
+  test("a compiled lens bound to a charter the document did not name is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    snapshot.compiled.snapshot.reviewLenses[1].personaId = "persona.testing-policy";
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
+  });
+
+  test("the tracked document references shipped charters by identity alone", async () => {
+    const document = await readPolicyJson(policyDir, "repository-policy.json");
+    const snapshot = await readPolicyJson(policyDir, "compiled-snapshot.json");
+    // Pinned by name, not derived from the file, so retargeting a lens at a
+    // different charter is a deliberate two-place edit.
+    expect(
+      document.reviewLenses.map((lens: { lensId: string; personaId: string }) => [
+        lens.lensId,
+        lens.personaId,
+      ]),
+    ).toEqual([
+      ["lens.outcome-correctness", "persona.outcome-correctness"],
+      ["lens.adversarial-testing", "persona.adversarial"],
+    ]);
+    for (const lens of document.reviewLenses) {
+      expect(lens.personaDigest).toBeUndefined();
+    }
+    for (const lens of snapshot.compiled.snapshot.reviewLenses) {
+      expect(lens.personaDigest).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
 });
 
 describe("pre-cutover oracle blocker parity with the live authority", () => {

--- a/scripts/policy-projection-check.test.ts
+++ b/scripts/policy-projection-check.test.ts
@@ -299,6 +299,21 @@ describe("policy projection comparison", () => {
     expect(shortResult.status).toBe("fail");
     expect(findingCodes(shortResult)).toContain("lens_persona_defect");
     expect(findingCodes(shortResult)).not.toContain("artifact_unreadable");
+
+    // A snapshot with no lens list at all, rather than a short one. Kept as
+    // its own fixture: replacing the short one with this would stop witnessing
+    // the count comparison, and replacing this one with the short would stop
+    // witnessing the shape guard.
+    const absent = await policyDirCopy();
+    const absentSnapshot = await readPolicyJson(absent, "compiled-snapshot.json");
+    delete absentSnapshot.compiled.snapshot.reviewLenses;
+    await writePolicyJson(absent, "compiled-snapshot.json", absentSnapshot);
+    await restampPolicyDigests(absent);
+
+    const absentResult = await runPolicyProjectionCheck(rootDir, { policyDir: absent });
+    expect(absentResult.status).toBe("fail");
+    expect(findingCodes(absentResult)).toContain("lens_persona_defect");
+    expect(findingCodes(absentResult)).not.toContain("artifact_unreadable");
   });
 
   test("a document with no review lenses cannot satisfy the per-lens charter claim by emptiness", async () => {
@@ -314,6 +329,23 @@ describe("policy projection comparison", () => {
     const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
     expect(result.status).toBe("fail");
     expect(findingCodes(result)).toContain("lens_persona_defect");
+
+    // A document carrying no lens list at all, rather than an empty one. The
+    // emptied fixture above cannot witness the shape guard, because an empty
+    // array satisfies it.
+    const absent = await policyDirCopy();
+    const absentDocument = await readPolicyJson(absent, "repository-policy.json");
+    const absentSnapshot = await readPolicyJson(absent, "compiled-snapshot.json");
+    delete absentDocument.reviewLenses;
+    delete absentSnapshot.compiled.snapshot.reviewLenses;
+    await writePolicyJson(absent, "repository-policy.json", absentDocument);
+    await writePolicyJson(absent, "compiled-snapshot.json", absentSnapshot);
+    await restampPolicyDigests(absent);
+
+    const absentResult = await runPolicyProjectionCheck(rootDir, { policyDir: absent });
+    expect(absentResult.status).toBe("fail");
+    expect(findingCodes(absentResult)).toContain("lens_persona_defect");
+    expect(findingCodes(absentResult)).not.toContain("artifact_unreadable");
   });
 
   test("a compiled lens that lost its resolved charter digest is caught", async () => {

--- a/scripts/policy-projection-check.test.ts
+++ b/scripts/policy-projection-check.test.ts
@@ -222,8 +222,15 @@ describe("policy projection comparison", () => {
   test("a lens that names no reviewer charter is caught after re-stamping", async () => {
     const copyDir = await policyDirCopy();
     const document = await readPolicyJson(copyDir, "repository-policy.json");
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    // Dropped from BOTH sides, which is what a genuine recompile of a
+    // charterless lens produces. Dropping it from the document alone would
+    // leave the two sides disagreeing, and the red would come from the
+    // agreement rule below rather than from the rule this test names.
     delete document.reviewLenses[0].personaId;
+    delete snapshot.compiled.snapshot.reviewLenses[0].personaId;
     await writePolicyJson(copyDir, "repository-policy.json", document);
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
     await restampPolicyDigests(copyDir);
 
     const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
@@ -244,6 +251,9 @@ describe("policy projection comparison", () => {
     snapshot.compiled.snapshot.reviewLenses.push({
       lensId: "lens.additional",
       category: "additional",
+      // Well-formed on every other axis, so the only thing wrong with the
+      // added lens is the charter it does not name.
+      personaDigest: "b".repeat(64),
     });
     await writePolicyJson(copyDir, "repository-policy.json", document);
     await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
@@ -253,6 +263,26 @@ describe("policy projection comparison", () => {
     expect(result.status).toBe("fail");
     expect(findingCodes(result)).toContain("lens_persona_defect");
     expect(findingCodes(result)).not.toContain("snapshot_input_stale");
+    expect(findingCodes(result)).not.toContain("report_input_stale");
+  });
+
+  test("a compiled snapshot carrying a lens the document never declared is caught", async () => {
+    const copyDir = await policyDirCopy();
+    const snapshot = await readPolicyJson(copyDir, "compiled-snapshot.json");
+    // Added to the snapshot alone. Enumerating the document's lenses walks
+    // only its own two, so nothing but the count comparison reaches this.
+    snapshot.compiled.snapshot.reviewLenses.push({
+      lensId: "lens.ghost",
+      category: "testing-policy",
+      personaId: "persona.simplicity",
+      personaDigest: "c".repeat(64),
+    });
+    await writePolicyJson(copyDir, "compiled-snapshot.json", snapshot);
+    await restampPolicyDigests(copyDir);
+
+    const result = await runPolicyProjectionCheck(rootDir, { policyDir: copyDir });
+    expect(result.status).toBe("fail");
+    expect(findingCodes(result)).toContain("lens_persona_defect");
     expect(findingCodes(result)).not.toContain("report_input_stale");
   });
 

--- a/scripts/policy-projection-check.ts
+++ b/scripts/policy-projection-check.ts
@@ -61,6 +61,7 @@ export type PolicyProjectionFinding = {
     | "phase_drift"
     | "obligation_drift"
     | "authority_drift"
+    | "lens_persona_defect"
     | "leaf_mapping_defect"
     | "aggregate_registered_as_leaf"
     | "mechanical_activation_drift"
@@ -135,6 +136,12 @@ export async function runPolicyProjectionCheck(
     grantedFinishLines: string[];
     grantedAuthority: string[];
     forbiddenAuthority: string[];
+    reviewLenses: {
+      lensId: string;
+      category: string;
+      personaId?: string;
+      personaDigest?: string;
+    }[];
     obligations: { obligationId: string }[];
     requiredCapabilities: { capabilityId: string; kind: string; version: string }[];
     checkpoints?: { stageId: string; additionalProtectedPaths: string[] }[];
@@ -179,6 +186,12 @@ export async function runPolicyProjectionCheck(
         grantedFinishLines: string[];
         grantedAuthority: string[];
         obligations: { obligationId: string }[];
+        reviewLenses: {
+          lensId: string;
+          category: string;
+          personaId?: string;
+          personaDigest?: string;
+        }[];
       };
       capabilities: { capabilityId: string }[];
       checkpointGrants: { stageId: string; grant: { protectedPaths: string[] } }[];
@@ -396,6 +409,64 @@ export async function runPolicyProjectionCheck(
       "authority_drift",
       "the recorded compiled snapshot obligations do not match the declarative document obligations",
     );
+  }
+
+  // -- Each lens names the reviewer charter it hands its reviewer ------------
+  // Enumerated off the document's own lens list, and off the snapshot's own
+  // lens list, position by position. A claim phrased over "every lens" is
+  // satisfied for free by a document that declares none and by a snapshot the
+  // document never reaches, so the count is pinned first and each member is
+  // then named individually.
+  const documentLenses = document.reviewLenses;
+  const snapshotLenses = snapshot.compiled.snapshot.reviewLenses;
+  if (!Array.isArray(documentLenses) || documentLenses.length === 0) {
+    emit(
+      "lens_persona_defect",
+      "the declarative document activates no review lens; the review floor is not lowered by omission and a per-lens charter claim over an empty list proves nothing",
+    );
+  } else if (!Array.isArray(snapshotLenses) || snapshotLenses.length !== documentLenses.length) {
+    emit(
+      "lens_persona_defect",
+      `the document declares ${documentLenses.length} review lens(es) and the recorded compiled snapshot carries ${
+        Array.isArray(snapshotLenses) ? snapshotLenses.length : 0
+      }; the snapshot is not a compile of this document`,
+    );
+  } else {
+    documentLenses.forEach((lens, index) => {
+      const compiled = snapshotLenses[index];
+      if (typeof lens.personaId !== "string" || !/^persona\.[a-z0-9-]+$/.test(lens.personaId)) {
+        emit(
+          "lens_persona_defect",
+          `document lens ${lens.lensId ?? `#${index}`} names no reviewer charter; personaId is a required member of a lens declaration and the policy does not compile without it`,
+        );
+      }
+      // Athena references shipped charters by identity alone. Pinning charter
+      // bytes here would claim repository-owned charters this repository does
+      // not carry, and would put advancing the shipped set behind an edit to
+      // this document.
+      if (lens.personaDigest !== undefined) {
+        emit(
+          "lens_persona_defect",
+          `document lens ${lens.lensId ?? `#${index}`} pins charter bytes; Athena supplies no repository-owned charter, so its lenses reference shipped charters by identity and the digest is bound at compilation instead`,
+        );
+      }
+      if (
+        compiled.lensId !== lens.lensId ||
+        compiled.category !== lens.category ||
+        compiled.personaId !== lens.personaId
+      ) {
+        emit(
+          "lens_persona_defect",
+          `document lens ${lens.lensId ?? `#${index}`} (${lens.category}, ${lens.personaId}) does not match the recorded compiled lens ${compiled.lensId} (${compiled.category}, ${compiled.personaId})`,
+        );
+      }
+      if (typeof compiled.personaDigest !== "string" || !/^[0-9a-f]{64}$/.test(compiled.personaDigest)) {
+        emit(
+          "lens_persona_defect",
+          `compiled lens ${compiled.lensId ?? `#${index}`} carries no resolved charter digest; identity alone is what the document declares, and compilation is where those bytes get bound`,
+        );
+      }
+    });
   }
 
   // -- Leaf mapping: each proposed leaf maps exactly once --------------------


### PR DESCRIPTION
## What broke

`personaId` became a **required** member of the closed lens declaration in the harness policy compiler (`packages/kernel/src/policy/document.ts`, `LENS_RULES`). Athena's `.agents/policy/repository-policy.json` declared two lenses and neither named a reviewer charter, so the policy no longer compiled.

Reproduced before fixing, against the compiler at `agent-delivery-harness` `a13ae38046a1043deacbc80b7ad079abf81ea58a`:

```
missing_member  /document/reviewLenses/0/personaId
missing_member  /document/reviewLenses/1/personaId
```

Nothing was failing in CI because `scripts/policy-projection-check.ts` compares against the recorded snapshot rather than recompiling live. The break would have landed at the cutover.

## The mapping

| lens | category | charter |
|---|---|---|
| `lens.outcome-correctness` | `outcome-correctness` | `persona.outcome-correctness` |
| `lens.adversarial-testing` | `testing-policy` | `persona.adversarial` |

Athena's delivery review runs a correctness reviewer and an adversarial reviewer — `ce-correctness-reviewer` and `ce-adversarial-reviewer` in `.agents/skills/ce-code-review/references/persona-catalog.md`, keyed as `correctness` and `adversarial` in the review telemetry.

`lens.adversarial-testing` maps to `persona.adversarial`, not `persona.testing-policy`, because the category is a taxonomy slot rather than a statement about the charter. The already-recorded `adversarial-lens-category` adjudication exists precisely because `REVIEW_LENS_CATEGORIES` has no adversarial member: "Athena's delivery review runs an outcome-correctness lens and an adversarial lens; the compiled policy vocabulary has no adversarial category." Binding this lens to the testing-policy charter would hand Athena's adversarial reviewer an evidence-vacuity brief it does not run, and would make that adjudication meaningless.

The sibling `agent-delivery-harness` policy maps its identically-named lens to `persona.testing-policy`. That is its own reviewer practice with its own repository-owned charters, not a precedent for Athena's reviewer set.

No lens was collapsed to fit, and no lens was invented to consume a charter — Athena declares no testing lens today, so `persona.testing-policy` goes unused here.

## Reference form

Both lenses reference shipped charters **by identity alone**. No `personaDigest` in the document: that form is for repository-owned charters at a protected path, and Athena supplies none. Pinning charter bytes in the adopter document would put advancing the shipped charter set behind an edit to this file, which is the coupling identity-only referencing exists to avoid. Confirmed against the compiler: adding a `personaDigest` to a document lens — even with the correct bytes — is rejected `persona_unresolvable`, because the adopter form resolves only against `origin: "adopter"` charters.

The digests are bound in the compiled snapshot instead, resolved from the pinned composition archive `9ce12f12c4096e346154ef377fc89187c9168944d6e59b9d6596feb98e57d2ed`:

- `persona.outcome-correctness` → `a5d96a825150e40b840cd91b55c2d7480f5ee7e481004464062afb8ef5430e2c`
- `persona.adversarial` → `ae9969a9835d66a8fd0b4dca434915f23e2904b5f3865035f887583338571b0d`

## Artifacts

`compiled-snapshot.json` is a real recompile, not a hand edit — both review lenses reproduced it byte-for-byte from the compiler independently. `policyDigest` `795c6433…`, `compiledDigest` `170269c5…`. `compiledWith.commit` advances to `a13ae38…` and a `personaSource` block records which composition the identities resolved against.

**The pre-cutover oracle is byte-identical** and still hashes to its pinned `76b3e7d79294…`. No oracle recharacterization. No authority field moved: `grantedAuthority`, `forbiddenAuthority`, `grantedFinishLines`, obligations, capabilities and checkpoint grants are unchanged.

`comparison-report.json` re-records the input digests and adds two adjudications: `lens-persona-by-identity` (the mapping and its reasoning) and `shadow-activation-product-pin-predates-personas`, deferred — `shadow-activation.json` pins the shadow-window product at `8635ea8`, an ancestor of `a13ae38`, so it carries no shipped charters. The shadow window holds no delivery authority and no sensor recompiles under that pin, so no active gate is affected. Advancing it is a separate deliberate re-pin.

## The sensor

The projection check previously read **no lens at all** — the entire declaration was unguarded, and "every lens declares a persona" would have passed for free. It now enumerates the document's own lens list and the snapshot's, position by position, pinning the count first so the claim cannot be satisfied by an empty list.

## Mutation evidence

Five review rounds. Four of them found a defect, each one granularity finer than the last, all in the test file rather than the sensor:

| round | finding | severity |
|---|---|---|
| 1 | mutation tests red for the wrong reason — a sibling rule supplied the red, leaving the persona-required and lens-count rules suite-dead | P2 + P3 |
| 2 | deletion pinned, weakening not — the agreement rule's `lensId`/`category` clauses and both format regexes unwitnessed | P2 + P3 |
| 3 | the count rule half-witnessed — narrowing `!==` to `>` survived, and the short-snapshot direction degraded to an untyped shape error | P1 |
| 4 | the two `Array.isArray` shape guards unwitnessed, producing that same degradation | P2 |
| 5 | zero findings from both lenses, zero changes | — |

Final campaign, every mutant killed, baseline 30 pass / 0 fail / 98 expects:

**Rule deletion** — empty-list 1, count 1, persona-required 3, no-digest-pin 1, agreement 3, compiled-digest 2.

**Clause weakening** — drop `lensId` clause 1, drop `category` clause 1, loosen persona regex to `/^persona/` 1, loosen digest regex to `/^[0-9a-f]+$/` 1, count `!==`→`>` 1, count `!==`→`<` 1, drop document `Array.isArray` 1, drop snapshot `Array.isArray` 1, `length === 0`→`< 0` 1.

Attribution is established rather than assumed. Every mutation test re-stamps the recorded input digests before running the sensor, so the digest pins are satisfied and cannot supply the red; a control test asserts a pure re-stamp with no mutation stays green. Each fixture was run standalone with the full finding list printed, and each produces exactly one finding from exactly the rule it names. A comment-only no-op change to the sensor leaves the suite green, so nothing here is a byte pin masquerading as coverage.

## Known and reasoned, not gaps

- The compiled `personaDigest` is shape-checked but never bound to the charter the lens names; swapping the two digests and re-stamping passes. Both lenses declined this deliberately: the document references charters by identity **by design**, so there is no in-repo counterpart to check bytes against, and closing it would need a charter allow-list or an in-repo dependency on the harness compiler — machinery this repository's simplicity rule forbids.
- `personaId` is likewise not validated against a catalog. Retargeting a lens or inventing an identity is caught by a different mechanism: the hardcoded pair assertion in `the tracked document references shipped charters by identity alone`, which runs against the real policy directory.
- A snapshot lens list of `null`s surfaces as `artifact_unreadable` rather than `lens_persona_defect` — still blocking, degraded diagnostic only, and needs a hand-crafted `null`.
- Dropping the `typeof compiled.personaDigest !== "string"` guard survives, distinguishable only by a one-element-array digest that no compiler or hand-editor emits. Reported by the round-5 adversarial lens and accepted rather than witnessed, since a fixture for it would be machinery for an unreachable input.

## Delivery mode

Manual gate loop. See the Linear evidence comment for the shadow-mode outcome and the typed blocker.
