### PR TITLE
[V26-1508]: Re-pin Athena's shadow activation to a product carrying the writer and the persona set

### DIFF
--- a/.agents/policy/shadow-activation.json
+++ b/.agents/policy/shadow-activation.json
@@ -1,14 +1,14 @@
 {
   "spec": "athena-shadow-activation/1",
   "repositoryId": "athena",
-  "recordedAt": "2026-08-30T22:10:00Z",
+  "recordedAt": "2026-08-31T15:40:00Z",
   "purpose": "Athena's activation metadata for the read-only shadow window: the composed delivery product is installed and its run-pinned projection is materialized into managed delivery worktrees, while `bun run pr:athena` remains the repository's only delivery authority. The discovery-scoping mechanism itself is product-owned; this document carries only Athena's activation of it and the positions the exactly-one-discovery guard enforces.",
   "installationMode": "shadow",
   "deliveryAuthority": "none",
   "comparisonAuthority": "bun run pr:athena",
   "product": {
     "repository": "agent-delivery-harness",
-    "commit": "8635ea8aca18f27f660b3551b950ffb7e6ad22dd",
+    "commit": "0c874281d5b6f22fdf844500496c8329935fb8ae",
     "compositionProfile": "production",
     "compositionProfileNote": "the fixture profile registers deliveries only in the disposable repositories its install receipt names, so an installation serving repository athena must carry the production profile; the read-only posture comes from this document's shadow installation mode, not from the profile",
     "qualificationRecords": [
@@ -64,21 +64,23 @@
     "absentOrNegative": "excluded from the comparison set",
     "writtenInto": ".agents/policy/shadow-milestone-gate-record.json",
     "whatTheGuardChecks": "the record's declared source and its shape — the guard reads the gate-record artifact and cannot itself verify that the bytes came from the binding",
-    "whatProvenanceRestsOn": "two things outside the guard: .agents is an additionally protected path in every checkpoint grant of .agents/policy/repository-policy.json, so no execution grant may write the gate record; and the binding-side writer that emits the entry. That writer is not present in the product at the pinned commit, so until it ships the entry has no admissible producer and the comparison set stays empty — which is the correct outcome, not a gap the guard papers over"
+    "whatProvenanceRestsOn": "two things outside the guard: the binding-side writer that emits the entry, and the protected-path property that keeps the artifact out of every session's reach. The writer ships in the product at the pinned commit, so an entry now has an admissible producer; the remaining rest-point is that .agents is an additionally protected path in every checkpoint grant of .agents/policy/repository-policy.json, so no execution grant may write the gate record and the only thing that can author an entry is the binding"
   },
   "vendoredDiscoveryLayout": {
     "owner": "scripts/shadow-discovery-guard.ts",
     "note": "the guard owns the layout's path set and its pinned byte digest; they are not duplicated here so there is one place to change and one place to review"
   },
   "characterization": {
-    "method": "a disposable shadow install of the composed product followed by one projection materialization into a managed delivery worktree, driven through the product's own installer and Claude Code binding; no Athena byte and no host configuration outside the disposable directories was touched",
+    "productCommit": "0c874281d5b6f22fdf844500496c8329935fb8ae",
+    "method": "a disposable shadow install of the composed product, one projection materialization into a managed delivery worktree, one interception of an invocation naming a receipted projection entry, one gate-record emission, and one compilation of this repository's live repository-policy.json against the pinned composition's charter set — all driven through the product's own installer, Claude Code binding, model-external interceptor, and policy compiler. The repository under characterization was a disposable scratch repository in a temp directory; no Athena byte and no host configuration outside the disposable directories was touched, and no host runtime was launched",
     "compositionProfile": "confirmation-fixture, with the disposable repository identity athena-shadow-characterization — the characterization ran in a scratch repository, so it used the qualification profile rather than the production profile the real Athena installation carries",
-    "observedAt": "2026-08-30T22:02:00Z",
+    "observedAt": "2026-08-31T15:22:00Z",
     "observed": {
-      "generationDigest": "29e56eb637a54a42882825dabbff1f0fcd27594b887b6db1ac587d146940c4f3",
-      "installationId": "install-646341843f375857f12689e020c05ab3",
+      "generationDigest": "4745a372fce1584afc90bf41a579802353da48dd95b352dce78eaf8447af20a5",
+      "installationId": "install-8f4fd55cecb07431b2c0b446af5a2991",
       "projectionDigest": "6791217c94ce2cafe5aa802c057ad4db11d874920b68fbf9598bb1f86e34539e",
       "managedWorktree": {
+        "path": ".worktrees/managed/athena-shadow-characterization-1",
         "projectionPresent": true,
         "gitStatusPorcelain": "",
         "consumptionMarker": {
@@ -96,8 +98,40 @@
       "nonManagedWorktree": {
         "projectionPresent": false,
         "consumptionMarkerRead": "consumption_marker_missing"
+      },
+      "gateRecordEntry": {
+        "id": "athena-shadow-characterization-1",
+        "category": "operations",
+        "countedInComparisonSet": true,
+        "projectionConsumption": {
+          "source": "binding",
+          "affirmative": true,
+          "projectionDigest": "6791217c94ce2cafe5aa802c057ad4db11d874920b68fbf9598bb1f86e34539e",
+          "marker": {
+            "deliveryId": "athena-shadow-characterization-1",
+            "fence": 1,
+            "consumed": "skills/agent-skills-core-v1.zip"
+          }
+        }
+      },
+      "policyCompilation": {
+        "compiledDigest": "170269c54fbfcbe1fef2442fcb40bbdc2d9e7f130505f7b8be95fc5605b1e0f5",
+        "resolvedLenses": [
+          {
+            "lensId": "lens.outcome-correctness",
+            "category": "outcome-correctness",
+            "personaId": "persona.outcome-correctness",
+            "personaDigest": "a5d96a825150e40b840cd91b55c2d7480f5ee7e481004464062afb8ef5430e2c"
+          },
+          {
+            "lensId": "lens.adversarial-testing",
+            "category": "testing-policy",
+            "personaId": "persona.adversarial",
+            "personaDigest": "ae9969a9835d66a8fd0b4dca434915f23e2904b5f3865035f887583338571b0d"
+          }
+        ]
       }
     },
-    "conclusion": "the projection landed only in the managed delivery worktree, was invisible to git there, left the repository root and the non-managed worktree untouched, and produced a consumption record the binding — not the session — authored"
+    "conclusion": "the projection landed only in the managed delivery worktree, was invisible to git there, left the repository root and the non-managed worktree untouched, produced a consumption record the binding — not the session — authored, and compiled this repository's live policy with both lens charter references resolved out of the pinned composition. The same characterization replayed against the previous pin 8635ea8aca18f27f660b3551b950ffb7e6ad22dd reproduced that pin's recorded generation digest 29e56eb637a54a42882825dabbff1f0fcd27594b887b6db1ac587d146940c4f3, and there the identical allowed interception recorded no consumption observation, no writer existed to emit an entry, and the live policy did not compile at all — the pinned grammar had no charter member, so both lens charter references were rejected as unknown. That difference is what the re-pin buys, and it was observed rather than argued: the interception was allowed at both pins, so the missing observation at the old one is the absent mechanism and not a denied invocation"
   }
 }

--- a/.agents/policy/shadow-activation.json
+++ b/.agents/policy/shadow-activation.json
@@ -77,7 +77,7 @@
     "observedAt": "2026-08-31T15:22:00Z",
     "observed": {
       "generationDigest": "4745a372fce1584afc90bf41a579802353da48dd95b352dce78eaf8447af20a5",
-      "installationId": "install-8f4fd55cecb07431b2c0b446af5a2991",
+      "installationId": "install-c3c84494425828a3d17030c9e205e44f",
       "projectionDigest": "6791217c94ce2cafe5aa802c057ad4db11d874920b68fbf9598bb1f86e34539e",
       "managedWorktree": {
         "path": ".worktrees/managed/athena-shadow-characterization-1",

--- a/.agents/policy/shadow-milestone-gate-record.json
+++ b/.agents/policy/shadow-milestone-gate-record.json
@@ -1,8 +1,8 @@
 {
   "spec": "athena-shadow-milestone-gate-record/1",
   "repositoryId": "athena",
-  "purpose": "The shadow milestone's measurement artifact: one entry per shadow delivery, carrying the binding-sourced projection-consumption record alongside the intervention and blocked-share measurements the milestone gate compares against the frozen manual-choreography baseline. A measurement artifact, not a journal. Entries are to be written by the product's binding — that writer is not present at the product's pinned commit, so no entry has an admissible producer yet and this list is correctly empty. Its location is already outside every execution grant's writable paths: `.agents` is an additionally protected path in all three checkpoint grants of .agents/policy/repository-policy.json, so no session may author an entry.",
-  "recordedAt": "2026-08-30T22:10:00Z",
+  "purpose": "The shadow milestone's measurement artifact: one entry per shadow delivery, carrying the binding-sourced projection-consumption record alongside the intervention and blocked-share measurements the milestone gate compares against the frozen manual-choreography baseline. A measurement artifact, not a journal. Entries are written by the product's binding, which ships at the product's pinned commit; this list is empty because no shadow delivery has run yet, not because no producer exists. Its location is already outside every execution grant's writable paths: `.agents` is an additionally protected path in all three checkpoint grants of .agents/policy/repository-policy.json, so no session may author an entry.",
+  "recordedAt": "2026-08-31T15:40:00Z",
   "status": "awaiting-shadow-deliveries",
   "baseline": {
     "repository": "agent-delivery-harness",

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -202043,7 +202043,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_test_ts",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L53",
+      "source_location": "L61",
       "target": "shadow_discovery_guard_test_bindingsourceddelivery",
       "weight": 1
     },
@@ -202055,7 +202055,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_test_ts",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L20",
+      "source_location": "L21",
       "target": "shadow_discovery_guard_test_codes",
       "weight": 1
     },
@@ -202067,7 +202067,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_test_ts",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L32",
+      "source_location": "L33",
       "target": "shadow_discovery_guard_test_plantedtree",
       "weight": 1
     },
@@ -202079,7 +202079,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_test_ts",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L24",
+      "source_location": "L25",
       "target": "shadow_discovery_guard_test_readpolicy",
       "weight": 1
     },
@@ -202091,7 +202091,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L171",
+      "source_location": "L184",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -202103,7 +202103,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L293",
+      "source_location": "L312",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -202115,7 +202115,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L166",
+      "source_location": "L179",
       "target": "shadow_discovery_guard_exposuresymlinkentries",
       "weight": 1
     },
@@ -202127,7 +202127,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L221",
+      "source_location": "L234",
       "target": "shadow_discovery_guard_ishex64",
       "weight": 1
     },
@@ -202139,7 +202139,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L210",
+      "source_location": "L223",
       "target": "shadow_discovery_guard_ismanageddeliveryworktree",
       "weight": 1
     },
@@ -202151,7 +202151,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L200",
+      "source_location": "L213",
       "target": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "weight": 1
     },
@@ -202163,7 +202163,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L141",
+      "source_location": "L154",
       "target": "shadow_discovery_guard_rungit",
       "weight": 1
     },
@@ -202175,7 +202175,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L225",
+      "source_location": "L238",
       "target": "shadow_discovery_guard_runshadowdiscoveryguard",
       "weight": 1
     },
@@ -202187,7 +202187,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L137",
+      "source_location": "L150",
       "target": "shadow_discovery_guard_sha256",
       "weight": 1
     },
@@ -202199,7 +202199,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L155",
+      "source_location": "L168",
       "target": "shadow_discovery_guard_trackedentries",
       "weight": 1
     },
@@ -202211,7 +202211,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L191",
+      "source_location": "L204",
       "target": "shadow_discovery_guard_vendoreddiscoverylayoutpathspec",
       "weight": 1
     },
@@ -203351,7 +203351,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_exposuresymlinkentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L173",
+      "source_location": "L186",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -203363,7 +203363,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_sha256",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L176",
+      "source_location": "L189",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -203375,7 +203375,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_trackedentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L172",
+      "source_location": "L185",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -203387,7 +203387,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L349",
+      "source_location": "L439",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203399,7 +203399,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_ishex64",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L465",
+      "source_location": "L555",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203411,7 +203411,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_ismanageddeliveryworktree",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L399",
+      "source_location": "L489",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203423,7 +203423,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L371",
+      "source_location": "L461",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203435,7 +203435,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_trackedentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L167",
+      "source_location": "L180",
       "target": "shadow_discovery_guard_exposuresymlinkentries",
       "weight": 1
     },
@@ -203447,7 +203447,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_rungit",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L201",
+      "source_location": "L214",
       "target": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "weight": 1
     },
@@ -203459,7 +203459,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_vendoreddiscoverylayoutpathspec",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L205",
+      "source_location": "L218",
       "target": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "weight": 1
     },
@@ -203471,7 +203471,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_runshadowdiscoveryguard",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L265",
+      "source_location": "L283",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203483,7 +203483,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_test_readpolicy",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L37",
+      "source_location": "L39",
       "target": "shadow_discovery_guard_test_plantedtree",
       "weight": 1
     },
@@ -203495,7 +203495,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_rungit",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L156",
+      "source_location": "L169",
       "target": "shadow_discovery_guard_trackedentries",
       "weight": 1
     },
@@ -203507,7 +203507,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_exposuresymlinkentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L194",
+      "source_location": "L207",
       "target": "shadow_discovery_guard_vendoreddiscoverylayoutpathspec",
       "weight": 1
     },
@@ -290188,7 +290188,7 @@
       "label": "computeVendoredDiscoveryLayoutDigest()",
       "norm_label": "computevendoreddiscoverylayoutdigest()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L171"
+      "source_location": "L184"
     },
     {
       "community": 279,
@@ -290197,7 +290197,7 @@
       "label": "evaluateShadowArtifacts()",
       "norm_label": "evaluateshadowartifacts()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L293"
+      "source_location": "L312"
     },
     {
       "community": 279,
@@ -290206,7 +290206,7 @@
       "label": "exposureSymlinkEntries()",
       "norm_label": "exposuresymlinkentries()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L166"
+      "source_location": "L179"
     },
     {
       "community": 279,
@@ -290215,7 +290215,7 @@
       "label": "isHex64()",
       "norm_label": "ishex64()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L221"
+      "source_location": "L234"
     },
     {
       "community": 279,
@@ -290224,7 +290224,7 @@
       "label": "isManagedDeliveryWorktree()",
       "norm_label": "ismanageddeliveryworktree()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L210"
+      "source_location": "L223"
     },
     {
       "community": 279,
@@ -290233,7 +290233,7 @@
       "label": "observeVendoredDiscoveryLayoutWorkingTree()",
       "norm_label": "observevendoreddiscoverylayoutworkingtree()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L200"
+      "source_location": "L213"
     },
     {
       "community": 279,
@@ -290242,7 +290242,7 @@
       "label": "runGit()",
       "norm_label": "rungit()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L141"
+      "source_location": "L154"
     },
     {
       "community": 279,
@@ -290251,7 +290251,7 @@
       "label": "runShadowDiscoveryGuard()",
       "norm_label": "runshadowdiscoveryguard()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L225"
+      "source_location": "L238"
     },
     {
       "community": 279,
@@ -290260,7 +290260,7 @@
       "label": "sha256()",
       "norm_label": "sha256()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L137"
+      "source_location": "L150"
     },
     {
       "community": 279,
@@ -290269,7 +290269,7 @@
       "label": "trackedEntries()",
       "norm_label": "trackedentries()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L155"
+      "source_location": "L168"
     },
     {
       "community": 279,
@@ -290278,7 +290278,7 @@
       "label": "vendoredDiscoveryLayoutPathspec()",
       "norm_label": "vendoreddiscoverylayoutpathspec()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L191"
+      "source_location": "L204"
     },
     {
       "community": 2790,
@@ -348940,7 +348940,7 @@
       "label": "bindingSourcedDelivery()",
       "norm_label": "bindingsourceddelivery()",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L53"
+      "source_location": "L61"
     },
     {
       "community": 837,
@@ -348949,7 +348949,7 @@
       "label": "codes()",
       "norm_label": "codes()",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L20"
+      "source_location": "L21"
     },
     {
       "community": 837,
@@ -348958,7 +348958,7 @@
       "label": "plantedTree()",
       "norm_label": "plantedtree()",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L32"
+      "source_location": "L33"
     },
     {
       "community": 837,
@@ -348967,7 +348967,7 @@
       "label": "readPolicy()",
       "norm_label": "readpolicy()",
       "source_file": "scripts/shadow-discovery-guard.test.ts",
-      "source_location": "L24"
+      "source_location": "L25"
     },
     {
       "community": 838,

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -202091,7 +202091,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L184",
+      "source_location": "L191",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -202103,7 +202103,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L312",
+      "source_location": "L319",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -202115,7 +202115,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L179",
+      "source_location": "L186",
       "target": "shadow_discovery_guard_exposuresymlinkentries",
       "weight": 1
     },
@@ -202127,7 +202127,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L234",
+      "source_location": "L241",
       "target": "shadow_discovery_guard_ishex64",
       "weight": 1
     },
@@ -202139,7 +202139,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L223",
+      "source_location": "L230",
       "target": "shadow_discovery_guard_ismanageddeliveryworktree",
       "weight": 1
     },
@@ -202151,7 +202151,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L213",
+      "source_location": "L220",
       "target": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "weight": 1
     },
@@ -202163,7 +202163,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L154",
+      "source_location": "L161",
       "target": "shadow_discovery_guard_rungit",
       "weight": 1
     },
@@ -202175,7 +202175,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L238",
+      "source_location": "L245",
       "target": "shadow_discovery_guard_runshadowdiscoveryguard",
       "weight": 1
     },
@@ -202187,7 +202187,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L150",
+      "source_location": "L157",
       "target": "shadow_discovery_guard_sha256",
       "weight": 1
     },
@@ -202199,7 +202199,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L168",
+      "source_location": "L175",
       "target": "shadow_discovery_guard_trackedentries",
       "weight": 1
     },
@@ -202211,7 +202211,7 @@
       "relation": "contains",
       "source": "scripts_shadow_discovery_guard_ts",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L204",
+      "source_location": "L211",
       "target": "shadow_discovery_guard_vendoreddiscoverylayoutpathspec",
       "weight": 1
     },
@@ -203351,7 +203351,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_exposuresymlinkentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L186",
+      "source_location": "L193",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -203363,7 +203363,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_sha256",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L189",
+      "source_location": "L196",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -203375,7 +203375,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_trackedentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L185",
+      "source_location": "L192",
       "target": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "weight": 1
     },
@@ -203387,7 +203387,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_computevendoreddiscoverylayoutdigest",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L439",
+      "source_location": "L445",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203399,7 +203399,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_ishex64",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L555",
+      "source_location": "L561",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203411,7 +203411,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_ismanageddeliveryworktree",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L489",
+      "source_location": "L495",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203423,7 +203423,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L461",
+      "source_location": "L467",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203435,7 +203435,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_trackedentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L180",
+      "source_location": "L187",
       "target": "shadow_discovery_guard_exposuresymlinkentries",
       "weight": 1
     },
@@ -203447,7 +203447,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_rungit",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L214",
+      "source_location": "L221",
       "target": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "weight": 1
     },
@@ -203459,7 +203459,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_vendoreddiscoverylayoutpathspec",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L218",
+      "source_location": "L225",
       "target": "shadow_discovery_guard_observevendoreddiscoverylayoutworkingtree",
       "weight": 1
     },
@@ -203471,7 +203471,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_runshadowdiscoveryguard",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L283",
+      "source_location": "L290",
       "target": "shadow_discovery_guard_evaluateshadowartifacts",
       "weight": 1
     },
@@ -203495,7 +203495,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_rungit",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L169",
+      "source_location": "L176",
       "target": "shadow_discovery_guard_trackedentries",
       "weight": 1
     },
@@ -203507,7 +203507,7 @@
       "relation": "calls",
       "source": "shadow_discovery_guard_exposuresymlinkentries",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L207",
+      "source_location": "L214",
       "target": "shadow_discovery_guard_vendoreddiscoverylayoutpathspec",
       "weight": 1
     },
@@ -290188,7 +290188,7 @@
       "label": "computeVendoredDiscoveryLayoutDigest()",
       "norm_label": "computevendoreddiscoverylayoutdigest()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L184"
+      "source_location": "L191"
     },
     {
       "community": 279,
@@ -290197,7 +290197,7 @@
       "label": "evaluateShadowArtifacts()",
       "norm_label": "evaluateshadowartifacts()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L312"
+      "source_location": "L319"
     },
     {
       "community": 279,
@@ -290206,7 +290206,7 @@
       "label": "exposureSymlinkEntries()",
       "norm_label": "exposuresymlinkentries()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L179"
+      "source_location": "L186"
     },
     {
       "community": 279,
@@ -290215,7 +290215,7 @@
       "label": "isHex64()",
       "norm_label": "ishex64()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L234"
+      "source_location": "L241"
     },
     {
       "community": 279,
@@ -290224,7 +290224,7 @@
       "label": "isManagedDeliveryWorktree()",
       "norm_label": "ismanageddeliveryworktree()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L223"
+      "source_location": "L230"
     },
     {
       "community": 279,
@@ -290233,7 +290233,7 @@
       "label": "observeVendoredDiscoveryLayoutWorkingTree()",
       "norm_label": "observevendoreddiscoverylayoutworkingtree()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L213"
+      "source_location": "L220"
     },
     {
       "community": 279,
@@ -290242,7 +290242,7 @@
       "label": "runGit()",
       "norm_label": "rungit()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L154"
+      "source_location": "L161"
     },
     {
       "community": 279,
@@ -290251,7 +290251,7 @@
       "label": "runShadowDiscoveryGuard()",
       "norm_label": "runshadowdiscoveryguard()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L238"
+      "source_location": "L245"
     },
     {
       "community": 279,
@@ -290260,7 +290260,7 @@
       "label": "sha256()",
       "norm_label": "sha256()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L150"
+      "source_location": "L157"
     },
     {
       "community": 279,
@@ -290269,7 +290269,7 @@
       "label": "trackedEntries()",
       "norm_label": "trackedentries()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L168"
+      "source_location": "L175"
     },
     {
       "community": 279,
@@ -290278,7 +290278,7 @@
       "label": "vendoredDiscoveryLayoutPathspec()",
       "norm_label": "vendoreddiscoverylayoutpathspec()",
       "source_file": "scripts/shadow-discovery-guard.ts",
-      "source_location": "L204"
+      "source_location": "L211"
     },
     {
       "community": 2790,

--- a/scripts/shadow-discovery-guard.test.ts
+++ b/scripts/shadow-discovery-guard.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import {
+  REPOSITORY_POLICY_FILE,
   SHADOW_ACTIVATION_FILE,
   SHADOW_GATE_RECORD_FILE,
   VENDORED_DISCOVERY_LAYOUT_DIGEST,
@@ -32,12 +33,15 @@ async function readPolicy(file: string) {
 async function plantedTree(edit: {
   activation?: (value: any) => void;
   gateRecord?: (value: any) => void;
+  repositoryPolicy?: (value: any) => void;
 }) {
   const dir = await mkdtemp(path.join(tmpdir(), "athena-shadow-guard-"));
   const activation = await readPolicy(SHADOW_ACTIVATION_FILE);
   const gateRecord = await readPolicy(SHADOW_GATE_RECORD_FILE);
+  const repositoryPolicy = await readPolicy(REPOSITORY_POLICY_FILE);
   edit.activation?.(activation);
   edit.gateRecord?.(gateRecord);
+  edit.repositoryPolicy?.(repositoryPolicy);
   await writeFile(
     path.join(dir, SHADOW_ACTIVATION_FILE),
     `${JSON.stringify(activation, null, 2)}\n`,
@@ -45,6 +49,10 @@ async function plantedTree(edit: {
   await writeFile(
     path.join(dir, SHADOW_GATE_RECORD_FILE),
     `${JSON.stringify(gateRecord, null, 2)}\n`,
+  );
+  await writeFile(
+    path.join(dir, REPOSITORY_POLICY_FILE),
+    `${JSON.stringify(repositoryPolicy, null, 2)}\n`,
   );
   return dir;
 }
@@ -126,6 +134,147 @@ describe("shadow-window posture", () => {
   test("a missing artifact is a finding rather than a silent pass", async () => {
     const emptyDir = await mkdtemp(path.join(tmpdir(), "athena-shadow-guard-empty-"));
     const result = await runShadowDiscoveryGuard(rootDir, { policyDir: emptyDir });
+    expect(codes(result)).toContain("artifact_unreadable");
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("the pinned product and the evidence recorded about it", () => {
+  test("the tracked characterization names the pinned commit, as a full object id", async () => {
+    const activation = await readPolicy(SHADOW_ACTIVATION_FILE);
+    expect(activation.product.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(activation.characterization.productCommit).toBe(activation.product.commit);
+  });
+
+  test("the tracked characterization records resolving a charter for every declared lens", async () => {
+    // Named members, not a count: a compilation that resolved some other lens
+    // set would satisfy a count and satisfy nothing else, and the defect this
+    // repository actually hit was a specific charter reference the pinned
+    // product could not resolve.
+    const activation = await readPolicy(SHADOW_ACTIVATION_FILE);
+    const policy = await readPolicy(REPOSITORY_POLICY_FILE);
+    const resolved = activation.characterization.observed.policyCompilation.resolvedLenses;
+    expect(
+      resolved.map((lens: any) => [lens.lensId, lens.personaId]).sort(),
+    ).toEqual([
+      ["lens.adversarial-testing", "persona.adversarial"],
+      ["lens.outcome-correctness", "persona.outcome-correctness"],
+    ]);
+    expect(
+      policy.reviewLenses.map((lens: any) => [lens.lensId, lens.personaId]).sort(),
+    ).toEqual([
+      ["lens.adversarial-testing", "persona.adversarial"],
+      ["lens.outcome-correctness", "persona.outcome-correctness"],
+    ]);
+    // Every resolved lens is bound to the charter bytes it resolved to, so the
+    // record names a specific charter rather than an identity that could be
+    // satisfied by anything shipping under that name later.
+    for (const lens of resolved) expect(lens.personaDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("reverting the pin without re-characterizing is a finding", async () => {
+    const policyDirCopy = await plantedTree({
+      activation: (value) => {
+        value.product.commit = "8635ea8aca18f27f660b3551b950ffb7e6ad22dd";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterization_pin_mismatch");
+  });
+
+  test("moving the characterization off the pin is the same finding", async () => {
+    // The mirror of the row above: the defect is the two disagreeing, not the
+    // product member specifically, so the guard must not be satisfied by
+    // re-stamping the evidence's commit instead of re-observing it.
+    const policyDirCopy = await plantedTree({
+      activation: (value) => {
+        value.characterization.productCommit = "8635ea8aca18f27f660b3551b950ffb7e6ad22dd";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterization_pin_mismatch");
+  });
+
+  test("a characterization that names no commit is a finding", async () => {
+    const policyDirCopy = await plantedTree({
+      activation: (value) => {
+        delete value.characterization.productCommit;
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterization_pin_mismatch");
+  });
+
+  test("an abbreviated pin is a finding, whatever the characterization says", async () => {
+    // An abbreviation names a commit only until a colliding prefix exists, so
+    // it is refused even when the recorded evidence agrees with it.
+    const policyDirCopy = await plantedTree({
+      activation: (value) => {
+        value.product.commit = "0c87428";
+        value.characterization.productCommit = "0c87428";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterization_pin_mismatch");
+  });
+
+  test("a lens the pinned product was never shown to resolve is a finding", async () => {
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses.push({
+          lensId: "lens.security",
+          category: "security",
+          personaId: "persona.security",
+        });
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterized_lenses_stale");
+  });
+
+  test("re-pointing a declared lens at another charter is a finding", async () => {
+    // The exact mapping this repository chose: lens.adversarial-testing sits
+    // in the testing-policy category and references persona.adversarial. A
+    // guard that only counted lenses would pass this silently.
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses[1].personaId = "persona.testing-policy";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterized_lenses_stale");
+  });
+
+  test("dropping a declared lens is a finding", async () => {
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses = [value.reviewLenses[0]];
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterized_lenses_stale");
+  });
+
+  test("reordering the declared lenses is not a finding", async () => {
+    // The comparison is over the lens set, not the document's order: a
+    // reordering changes no charter reference, and a guard that fired on it
+    // would demand a re-characterization for nothing.
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses = [...value.reviewLenses].reverse();
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).not.toContain("characterized_lenses_stale");
+  });
+
+  test("a policy document with no lens list is an unreadable artifact, not a crash", async () => {
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses = "two";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
     expect(codes(result)).toContain("artifact_unreadable");
     expect(result.status).toBe("fail");
   });

--- a/scripts/shadow-discovery-guard.test.ts
+++ b/scripts/shadow-discovery-guard.test.ts
@@ -166,9 +166,10 @@ describe("the pinned product and the evidence recorded about it", () => {
       ["lens.adversarial-testing", "persona.adversarial"],
       ["lens.outcome-correctness", "persona.outcome-correctness"],
     ]);
-    // Every resolved lens is bound to the charter bytes it resolved to, so the
-    // record names a specific charter rather than an identity that could be
-    // satisfied by anything shipping under that name later.
+    // Each resolved lens carries the digest of the charter bytes the pinned
+    // composition resolved it to. Athena holds no copy of that composition, so
+    // this asserts the shape only — that a charter digest was recorded at all,
+    // not that these bytes are the charter's.
     for (const lens of resolved) expect(lens.personaDigest).toMatch(/^[0-9a-f]{64}$/);
   });
 
@@ -239,6 +240,30 @@ describe("the pinned product and the evidence recorded about it", () => {
     const policyDirCopy = await plantedTree({
       repositoryPolicy: (value) => {
         value.reviewLenses[1].personaId = "persona.testing-policy";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterized_lenses_stale");
+  });
+
+  test("re-pointing a declared lens at another category is a finding", async () => {
+    // The category is a taxonomy slot the compilation resolved under, and it
+    // is part of the identity the guard compares. Mutating only the charter
+    // reference would leave this component of that identity unwitnessed, and a
+    // later narrowing of the comparison would ship green.
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses[1].category = "outcome-correctness";
+      },
+    });
+    const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });
+    expect(codes(result)).toContain("characterized_lenses_stale");
+  });
+
+  test("renaming a declared lens is a finding", async () => {
+    const policyDirCopy = await plantedTree({
+      repositoryPolicy: (value) => {
+        value.reviewLenses[1].lensId = "lens.adversarial";
       },
     });
     const result = await runShadowDiscoveryGuard(rootDir, { policyDir: policyDirCopy });

--- a/scripts/shadow-discovery-guard.ts
+++ b/scripts/shadow-discovery-guard.ts
@@ -12,7 +12,7 @@ import { POLICY_PROJECTION_DIR } from "./policy-projection-check";
  * The composed delivery product is installed in shadow mode and materializes
  * its run-pinned projection into managed delivery worktrees, while `bun run
  * pr:athena` stays the repository's only delivery authority. This guard holds
- * the four positions that window depends on, and holds nothing else:
+ * the five positions that window depends on, and holds nothing else:
  *
  *   - POSTURE. The activation metadata must still say shadow, and must not
  *     claim delivery authority.
@@ -28,6 +28,15 @@ import { POLICY_PROJECTION_DIR } from "./policy-projection-check";
  *     worktree. The repository root and every non-managed worktree keep the
  *     vendored generation authoritative. What is checked is the root of the
  *     tree the guard is invoked in, not every directory beneath it.
+ *   - PIN EVIDENCE. The activation pins the installed product at one commit,
+ *     and the characterization it records is evidence about that exact commit
+ *     and no other. So the characterization names the commit it observed, the
+ *     guard requires the two to agree, and the charter references the
+ *     compilation resolved are checked against the lenses this repository's
+ *     policy document actually declares. Moving the pin without re-observing,
+ *     and moving a lens without recompiling, are the two ways the activation
+ *     and the policy come to describe incompatible worlds — which is the state
+ *     this position exists to refuse, having already happened once.
  *   - CONSUMPTION. A delivery counts toward the milestone's comparison set
  *     only on a record that declares the binding as its source and carries the
  *     binding's marker fields for this delivery and fence. The guard checks
@@ -56,6 +65,8 @@ import { POLICY_PROJECTION_DIR } from "./policy-projection-check";
  */
 export const SHADOW_ACTIVATION_FILE = "shadow-activation.json";
 export const SHADOW_GATE_RECORD_FILE = "shadow-milestone-gate-record.json";
+/** The policy document whose lenses the recorded compilation must still describe. */
+export const REPOSITORY_POLICY_FILE = "repository-policy.json";
 
 /**
  * The vendored generation tree. Every tracked entry under it is part of the
@@ -87,6 +98,8 @@ export type ShadowGuardFindingCode =
   | "activation_not_shadow"
   | "delivery_authority_claimed"
   | "exclusivity_position_unsupported"
+  | "characterization_pin_mismatch"
+  | "characterized_lenses_stale"
   | "vendored_layout_drift"
   | "projection_outside_managed_worktree"
   | "discovery_exclusivity_violation"
@@ -240,7 +253,7 @@ export async function runShadowDiscoveryGuard(
     options.policyDir ?? path.join(rootDir, POLICY_PROJECTION_DIR);
 
   const documents = new Map<string, any>();
-  for (const file of [SHADOW_ACTIVATION_FILE, SHADOW_GATE_RECORD_FILE]) {
+  for (const file of [SHADOW_ACTIVATION_FILE, SHADOW_GATE_RECORD_FILE, REPOSITORY_POLICY_FILE]) {
     try {
       documents.set(
         file,
@@ -257,7 +270,12 @@ export async function runShadowDiscoveryGuard(
   }
   const activation = documents.get(SHADOW_ACTIVATION_FILE);
   const gateRecord = documents.get(SHADOW_GATE_RECORD_FILE);
-  if (activation === undefined || gateRecord === undefined) {
+  const repositoryPolicy = documents.get(REPOSITORY_POLICY_FILE);
+  if (
+    activation === undefined ||
+    gateRecord === undefined ||
+    repositoryPolicy === undefined
+  ) {
     return { status: "fail", findings, observations, countedDeliveryIds };
   }
 
@@ -267,6 +285,7 @@ export async function runShadowDiscoveryGuard(
       options,
       activation,
       gateRecord,
+      repositoryPolicy,
       countedDeliveryIds,
       emit,
       observe,
@@ -295,12 +314,21 @@ async function evaluateShadowArtifacts(input: {
   options: ShadowGuardOptions;
   activation: any;
   gateRecord: any;
+  repositoryPolicy: any;
   countedDeliveryIds: string[];
   emit: (code: ShadowGuardFindingCode, message: string) => void;
   observe: (code: ShadowGuardObservationCode, message: string) => void;
 }) {
-  const { rootDir, options, activation, gateRecord, countedDeliveryIds, emit, observe } =
-    input;
+  const {
+    rootDir,
+    options,
+    activation,
+    gateRecord,
+    repositoryPolicy,
+    countedDeliveryIds,
+    emit,
+    observe,
+  } = input;
 
   // ── Posture ───────────────────────────────────────────────────────────────
   if (activation.installationMode !== "shadow") {
@@ -339,6 +367,68 @@ async function evaluateShadowArtifacts(input: {
       )} carries the grading ${JSON.stringify(
         provingHost?.exclusivityGrading,
       )}; only an exclusivity-graded host can deliver one`,
+    );
+  }
+
+  // ── The pin and the evidence recorded about it ────────────────────────────
+  //
+  // The pin is a full object id, not an abbreviation: an abbreviated id names
+  // a commit only until the repository grows one that shares its prefix, and
+  // an installation that resolves to a different tree than the one
+  // characterized is exactly what the evidence binding below exists to stop.
+  const pin = activation.product?.commit;
+  const characterizedPin = activation.characterization?.productCommit;
+  if (typeof pin !== "string" || !/^[0-9a-f]{40}$/.test(pin)) {
+    emit(
+      "characterization_pin_mismatch",
+      `the activation pins the product at ${JSON.stringify(
+        pin,
+      )}, which is not a full 40-character object id`,
+    );
+  } else if (characterizedPin !== pin) {
+    // Evidence binds to the commit it was taken at. Moving the pin without
+    // re-running the characterization leaves the activation describing a
+    // product nobody observed, which is how the activation and the policy
+    // came to describe incompatible worlds in the first place.
+    emit(
+      "characterization_pin_mismatch",
+      `the activation pins the product at ${pin} and records a characterization observed at ${JSON.stringify(
+        characterizedPin,
+      )}; the recorded evidence is about one commit and the installation is about another, so re-run the characterization at the pinned commit rather than carrying the old observation forward`,
+    );
+  }
+
+  // The compilation the characterization recorded is what says this
+  // repository's policy is compilable by the pinned product at all. It is
+  // evidence about the lens set that existed when it ran, so a lens the
+  // document has since added, dropped, or re-pointed leaves it describing a
+  // policy this repository no longer carries.
+  const lensIdentity = (lens: any) =>
+    JSON.stringify([lens?.lensId ?? null, lens?.category ?? null, lens?.personaId ?? null]);
+  const sorted = (lenses: any[]) => lenses.map(lensIdentity).sort();
+  const declaredLenses: any[] = repositoryPolicy.reviewLenses;
+  const compiledLenses: any[] =
+    activation.characterization?.observed?.policyCompilation?.resolvedLenses ?? [];
+  if (!Array.isArray(declaredLenses)) {
+    throw new Error(
+      `${REPOSITORY_POLICY_FILE} does not declare a review-lens list`,
+    );
+  }
+  const declared = sorted(declaredLenses);
+  const compiled = sorted(compiledLenses);
+  if (
+    declared.length !== compiled.length ||
+    declared.some((entry, index) => entry !== compiled[index])
+  ) {
+    emit(
+      "characterized_lenses_stale",
+      `the characterization at ${JSON.stringify(
+        characterizedPin,
+      )} records resolving ${JSON.stringify(
+        compiled,
+      )}, and ${POLICY_PROJECTION_DIR}/${REPOSITORY_POLICY_FILE} now declares ${JSON.stringify(
+        declared,
+      )}; a lens the pinned product was never shown to resolve is a charter reference with no evidence behind it, so recompile against the pinned product and record what it resolved`,
     );
   }
 
@@ -555,7 +645,7 @@ if (import.meta.main) {
   const result = await runShadowDiscoveryGuard(rootDir);
   if (result.status === "pass") {
     console.log(
-      "[shadow-discovery-guard] Shadow-window posture holds: shadow-mode activation, byte-neutral vendored discovery layout, projection scoped to managed delivery worktrees, and binding-sourced consumption records only.",
+      "[shadow-discovery-guard] Shadow-window posture holds: shadow-mode activation, characterization evidence bound to the pinned product and the declared lenses, byte-neutral vendored discovery layout, projection scoped to managed delivery worktrees, and binding-sourced consumption records only.",
     );
   } else {
     console.log(

--- a/scripts/shadow-discovery-guard.ts
+++ b/scripts/shadow-discovery-guard.ts
@@ -33,10 +33,17 @@ import { POLICY_PROJECTION_DIR } from "./policy-projection-check";
  *     and no other. So the characterization names the commit it observed, the
  *     guard requires the two to agree, and the charter references the
  *     compilation resolved are checked against the lenses this repository's
- *     policy document actually declares. Moving the pin without re-observing,
- *     and moving a lens without recompiling, are the two ways the activation
- *     and the policy come to describe incompatible worlds — which is the state
- *     this position exists to refuse, having already happened once.
+ *     policy document actually declares. Moving the pin and leaving the
+ *     evidence behind, and moving a lens without recompiling, are the two ways
+ *     the activation and the policy come to describe incompatible worlds —
+ *     which is the state this position exists to refuse, having already
+ *     happened once. What it holds is that the two cannot silently DIVERGE:
+ *     both fields live in this one hand-editable document, and Athena carries
+ *     no copy of the product to check either against, so an editor who bumps
+ *     the pin and restamps the evidence's commit in the same edit satisfies
+ *     it. That is the honest limit of a self-attested artifact, and the
+ *     lens comparison below is what still fails on such an edit whenever the
+ *     restamped evidence stops describing the declared lens set.
  *   - CONSUMPTION. A delivery counts toward the milestone's comparison set
  *     only on a record that declares the binding as its source and carries the
  *     binding's marker fields for this delivery and fence. The guard checks
@@ -386,10 +393,10 @@ async function evaluateShadowArtifacts(input: {
       )}, which is not a full 40-character object id`,
     );
   } else if (characterizedPin !== pin) {
-    // Evidence binds to the commit it was taken at. Moving the pin without
-    // re-running the characterization leaves the activation describing a
-    // product nobody observed, which is how the activation and the policy
-    // came to describe incompatible worlds in the first place.
+    // Evidence names the commit it was taken at. Moving the pin and leaving
+    // the evidence behind leaves the activation describing a product nobody
+    // observed, which is how the activation and the policy came to describe
+    // incompatible worlds in the first place.
     emit(
       "characterization_pin_mismatch",
       `the activation pins the product at ${pin} and records a characterization observed at ${JSON.stringify(
@@ -406,14 +413,13 @@ async function evaluateShadowArtifacts(input: {
   const lensIdentity = (lens: any) =>
     JSON.stringify([lens?.lensId ?? null, lens?.category ?? null, lens?.personaId ?? null]);
   const sorted = (lenses: any[]) => lenses.map(lensIdentity).sort();
+  // A policy document or a recorded compilation of the wrong shape throws out
+  // of `sorted` and lands in this function's shared catch as an unreadable
+  // artifact — the same policy every other position here applies, and one
+  // fewer bespoke throw to keep witnessed.
   const declaredLenses: any[] = repositoryPolicy.reviewLenses;
   const compiledLenses: any[] =
     activation.characterization?.observed?.policyCompilation?.resolvedLenses ?? [];
-  if (!Array.isArray(declaredLenses)) {
-    throw new Error(
-      `${REPOSITORY_POLICY_FILE} does not declare a review-lens list`,
-    );
-  }
   const declared = sorted(declaredLenses);
   const compiled = sorted(compiledLenses);
   if (


### PR DESCRIPTION
## What moved

`.agents/policy/shadow-activation.json` pinned the composed delivery product at `8635ea8`. Two things were false about that pin.

The binding-side gate-record writer **ships** — it merged at `646314a` (V26-1493), and both shadow artifacts still asserted it was absent.

And the pin **predates the shipped reviewer charter set** (`a13ae38`, V26-1492). V26-1497 had just added `personaId` references to both of Athena's lenses, so a product at the old pin could not compile the policy document this same repository carries. The activation and the policy described incompatible worlds.

The pin moves to `0c874281d5b6f22fdf844500496c8329935fb8ae`, the sentences the old pin made true are corrected in both artifacts, and the characterization is re-run and re-recorded at the new pin.

Installation mode, delivery authority, `comparisonAuthority`, the projection contract, the exclusivity position, `hosts`, `qualificationRecords`, the baseline, and the comparison-set requirement are byte-identical to base. `repository-policy.json` is not in the diff. The pre-cutover oracle did not move, so no two-place recharacterization was needed.

## The characterization ran at both pins

Disposable clones of the product at each pin, driven through the product's own installer, Claude Code binding, model-external interceptor, and policy compiler. No host runtime was launched; no real Claude Code or Codex configuration directory was read or written; no Athena byte outside this diff was touched.

| | old pin `8635ea8` | new pin `0c87428` |
|---|---|---|
| generation digest | `29e56eb6…` — **reproduces the digest the old activation already recorded** | `4745a372…` |
| projection into the managed worktree | materialized, git-invisible, marker present | same |
| interception of an invocation naming a receipted entry | **allowed**, no consumption observation recorded | **allowed**, observation recorded |
| gate-record writer in the pinned tree | absent | present; entry emitted matching the consumption-record contract field for field |
| compiling Athena's live `repository-policy.json` | **rejected** — `unknown_member` at `/document/reviewLenses/0/personaId` and `/1/personaId`; the pinned grammar has no charter member | compiled; both lenses resolved |

That the old pin reproduced its own recorded generation digest is the validity control on the rig. That the interception was **allowed at both pins** is the control that separates "the mechanism is absent" from "the invocation was denied" — the missing observation at the old pin is the absent mechanism.

Acceptance criterion 2, demonstrated rather than asserted:

```
lens.outcome-correctness  → persona.outcome-correctness  a5d96a82…
lens.adversarial-testing  → persona.adversarial          ae9969a9…
```

`persona.adversarial`, not `persona.testing-policy` — the category is a taxonomy slot, and the mapping V26-1497 chose is preserved.

## Qualification records at the new pin

- `manual-choreography-baseline.json` — byte-identical between the two pins.
- `host-admission-capabilities.json` — changed, and read. The `discoveryScopingExclusivity` gradings the activation cites are byte-identical between the pins, and both hosts stay `exclusivity-ungraded`. The changes are an added Claude Code `commonGitAuthorityPathProtected: unsupported` declaration and a scoped Codex re-verification.
- `claude-code-integration.json` — changed, and read. One `knownLimitations` sentence was tightened to match that declaration.

Neither change falsifies anything the activation asserts, so no record needed re-pinning.

## Two guard positions now hold the evidence to its pin

`characterization_pin_mismatch` — the recorded characterization must name the commit the activation installs, as a full 40-character object id.

`characterized_lenses_stale` — the lens set the recorded compilation resolved must still be the lens set `repository-policy.json` declares, compared on `(lensId, category, personaId)` and order-insensitively.

**What these hold, stated without overclaim:** both fields live in this one hand-editable document, and Athena carries no copy of the product to check either against. An editor who bumps the pin and restamps the evidence's commit in the same edit passes. That is the honest limit of a self-attested artifact, and it is stated in the docstring, the pin-branch comment, and the tests. Reverting the pin *alone*, or moving a lens *alone*, each fails a named test.

## Verification

Root scripts suite: **1796 pass / 0 fail**. The guard suite went **47 → 60** tests, **75 → 93** assertions. Full webapp and storefront suites green (10 755 tests).

Mutation table — both directions, with the failing test named:

| mutation | failing test |
|---|---|
| pin reverted to `8635ea8` in the tracked activation | `the tracked characterization names the pinned commit, as a full object id` |
| pin/evidence agreement rule disabled | `reverting the pin without re-characterizing is a finding` |
| pin format rule disabled | `an abbreviated pin is a finding, whatever the characterization says` |
| pin rule made unconditional (denies everything) | `the tracked activation and gate record pass the guard` |
| lens comparison disabled | `a lens the pinned product was never shown to resolve is a finding` |
| lens comparison made unconditional | `reordering the declared lenses is not a finding` |
| `lensIdentity` drops `category` | `re-pointing a declared lens at another category is a finding` |
| `lensIdentity` drops `lensId` | `renaming a declared lens is a finding` |
| `lensIdentity` drops `personaId` | `re-pointing a declared lens at another charter is a finding` |
| binding-source requirement loosened | `an agent-supplied consumption claim is rejected` |
| binding-source requirement made unconditional | `an affirmative binding-sourced record counts toward the comparison set` |
| **comment-only no-op (control)** | **no test failed — so every red above is behavioural** |

The full guard finding list was printed under every mutation: each planted defect produced exactly one finding of the intended code, with no sibling rule firing.

## Review

Two lenses, `lens.outcome-correctness` (`persona.outcome-correctness`) and `lens.adversarial-testing` (`persona.adversarial`), each in an isolated worktree with `node_modules` resolving inside it. Two rounds; converged at `61756c12` with both returning zero findings and changing nothing.

Round one raised eight findings, none blocking. Five actionable ones were resolved: a re-recorded `installationId` that named an install no observation record carried; the `category` and `lensId` components of the lens identity being suite-dead; the pin position's prose claiming more than the mechanism holds; a bespoke throw for a malformed lens list that was mutation-equivalent to the shared catch (removed rather than given a test — the delegate it hands to *is* witnessed, which the throw never was); and a charter-digest comment claiming byte binding where it asserts a shape.

Three were recorded as advisory rather than fixed, with reasons: the `repositoryPolicy` clause in the fatal-undefined check and the `?? []` default on `resolvedLenses` are both unwitnessed but fail closed, with no statable wrong outcome; and the guard's pass-line console summary reads as shorthand under the restamp case, which the docstring now qualifies — acting on it would be scope creep on a settled prose fix.

Both lenses re-ran the previous round's mutations against the *current* test file and found no suite-dead rule anywhere in the guard, new or pre-existing. The adversarial lens also found and corrected a defect in its own survivor detector — its earlier rule would have scored a deliberately-broken module as a survivor — so this round's numbers were measured with a tightened instrument and the previous round's were not.

Closes V26-1508.
