### PR TITLE
[V26-1529]: Record the open pre-M1 blocker

### DIFF
--- a/.agents/policy/shadow-milestone-gate-record.json
+++ b/.agents/policy/shadow-milestone-gate-record.json
@@ -4,7 +4,9 @@
   "purpose": "Athena's adopter-local V26-1467 M1 comparison authority: one entry per binding-admitted Athena shadow delivery, carrying the binding-sourced projection-consumption record alongside the intervention and blocked-share measurements compared against the frozen manual-choreography baseline. The harness repository's separate record is product self-dogfood evidence; it neither fills nor duplicates this record's three delivery slots. A measurement artifact, not a journal. Entries are written only by the installed binding after its host-neutral observation contract accepts a Claude-qualified full direct canonical workflow Read and its writer derives the delivery repository identity, then verifies the literal protected Athena target and record repositoryId before mutation. This list is empty because no binding-admitted Athena shadow delivery is recorded. Its location is outside every execution grant's writable paths: `.agents` is additionally protected in .agents/policy/repository-policy.json. Nothing here claims runtime enforcement, M1 success, or cutover readiness.",
   "recordedAt": "2026-09-01T07:15:00Z",
   "status": "awaiting-shadow-deliveries",
-  "openPreM1Blockers": [],
+  "openPreM1Blockers": [
+    "V26-1527"
+  ],
   "baseline": {
     "repository": "agent-delivery-harness",
     "path": "qualifications/manual-choreography-baseline.json",

--- a/.agents/policy/shadow-milestone-gate-verdict.json
+++ b/.agents/policy/shadow-milestone-gate-verdict.json
@@ -1,11 +1,11 @@
 {
   "spec": "shadow-milestone-gate-verdict/1",
   "status": "incomplete",
-  "summary": "the M1 shadow gate is not scorable: no_observed_consumption",
+  "summary": "the M1 shadow gate is not scorable: pre_m1_blockers_unresolved",
   "incomplete": [
     {
-      "code": "no_observed_consumption",
-      "message": "no delivery has been observed consuming a projection, so there is no comparison set to score; this is the absence of a measurement, not a measured absence"
+      "code": "pre_m1_blockers_unresolved",
+      "message": "the gate record still names 1 open pre-M1 blocker(s); no delivery is enumerated until the list is explicitly empty"
     }
   ],
   "failures": [],
@@ -24,8 +24,10 @@
       ]
     },
     "gateRecord": {
-      "path": "/Users/kwamina/athena/.worktrees/codex/managed-agent-delivery-system-plan/.agents/policy/shadow-milestone-gate-record.json",
-      "openPreM1Blockers": [],
+      "path": "/Users/kwamina/athena/.worktrees/codex/v26-1529-pre-m1-blocker/.agents/policy/shadow-milestone-gate-record.json",
+      "openPreM1Blockers": [
+        "V26-1527"
+      ],
       "countedDeliveryIds": [],
       "excludedDeliveries": [],
       "perDeliveryWindows": [],


### PR DESCRIPTION
## Summary

- list V26-1527 as Athena’s open pre-M1 blocker
- regenerate the existing shadow verdict to fail closed with `pre_m1_blockers_unresolved`
- keep the comparison set empty and the shadow score null

## Why

Athena cannot count a managed shadow while neither host has a qualified native pre-registration confirmation producer. The gate record incorrectly showed no open blockers even though production registration remains Tier 0. This corrects the evidence layer only; it adds no runtime or shadow automation.

## Validation

- existing `score:milestone --write` regenerated the verdict
- `bun scripts/shadow-discovery-guard.ts`
- `bun scripts/policy-projection-check.ts`
- 93 focused tests passed
- exact-candidate security review passed with zero findings
- `bun run pr:athena`

https://linear.app/v26-labs/issue/V26-1529/record-the-open-pre-m1-host-capability-blocker