### PR TITLE
[V26-1082]: Anchor the Daily Close open-POS-session filter to the requested day

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 14828 nodes · 18482 edges · 3241 communities detected
+- 14828 nodes · 18483 edges · 3241 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3731,40 +3731,40 @@ Cohesion: 0.16
 Nodes (18): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), formatConvexDnsFailure(), formatConvexTerminationFailure(), isGenericFetchFailure(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi() (+10 more)
 
 ### Community 113 - "Community 113"
-Cohesion: 0.18
-Nodes (16): collectSources(), findDisallowedImports(), findIndirectComponentMountViolations(), findKernelImportViolations(), findLeafImportViolations(), findProductSurfaceImports(), findProfileImportViolations(), findRegistrationShimViolations() (+8 more)
-
-### Community 114 - "Community 114"
 Cohesion: 0.16
 Nodes (17): AgentReadPortBindingError, computeReadResultHash(), contractViolation(), createAgentReadPortRegistry(), cursorBindingDigest(), dispatchAgentReadPort(), filterValueValid(), finishAgentReadEnvelope() (+9 more)
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.26
 Nodes (19): buildProviderRegistry(), createIntelligenceRun(), defaultFakeOutput(), failedGenerationResult(), failRunBestEffort(), getBundleSnapshotFields(), getStoreInsightsSnapshotFallback(), isActivityTrend() (+11 more)
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.21
 Nodes (16): arrayDetail(), buildInventoryReviewDetail(), buildSyncSaleSummary(), classifyRegisterSessionSyncReview(), findProjectedRegisterSessionIdForRepairableMissingMapping(), findTransactionIdForSyncEvent(), hasInventoryReviewWorkItemForProjectedSale(), isNonSaleMissingRegisterSessionMappingConflict() (+8 more)
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.12
 Nodes (6): allowlist(), metrics(), missingDayResult(), posture(), seedStoreWithDay(), seedWeeklyStore()
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.11
 Nodes (4): insertFact(), period(), receipt(), withCloses()
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.14
 Nodes (9): ensureDemoCredentialWithCtx(), ensureDemoRoleAssignmentWithCtx(), ensureDemoStaffAccessWithCtx(), ensureSharedDemoRegisterFoundationWithCtx(), ensureSharedDemoSeededTerminalWithCtx(), migrateSharedDemoStoryWithCtx(), reconcileSharedDemoCatalogWithCtx(), repairSharedDemoSeededTerminalBindingWithCtx() (+1 more)
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.16
 Nodes (14): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+6 more)
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.13
 Nodes (9): composeAthenaThreadKey(), describeAthenaTrailUnavailable(), describeAthenaUnavailable(), describeProvisionalWithdrawal(), encodeThreadKey(), hashToken(), isThreadKeySafeCharacter(), snapshotAthenaContext() (+1 more)
+
+### Community 121 - "Community 121"
+Cohesion: 0.18
+Nodes (16): collectSources(), findDisallowedImports(), findIndirectComponentMountViolations(), findKernelImportViolations(), findLeafImportViolations(), findProductSurfaceImports(), findProfileImportViolations(), findRegistrationShimViolations() (+8 more)
 
 ### Community 122 - "Community 122"
 Cohesion: 0.11
@@ -4544,59 +4544,59 @@ Nodes (0):
 
 ### Community 316 - "Community 316"
 Cohesion: 0.33
-Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 317 - "Community 317"
+Cohesion: 0.33
+Nodes (8): landingFunnelHourlyLimit(), parseBoundedPositiveInteger(), resolveWalkthroughAllowedOrigins(), walkthroughAllowedOrigins(), walkthroughDailyPerEmailLimit(), walkthroughHourlyGlobalLimit(), walkthroughHourlyNotificationLimit(), walkthroughMaxBodyBytes()
+
+### Community 318 - "Community 318"
 Cohesion: 0.31
 Nodes (7): analyticsRead(), checkoutSessionOrderScope(), externalReferenceOrderScope(), idArg(), onlineOrderRead(), reviewRead(), storeFrontRead()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.29
 Nodes (7): adjustmentSalesDelta(), adjustmentSettlementAmount(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), listAppliedTransactionAdjustmentsForDay(), readAppliedTransactionAdjustmentsForDay(), sourceCompletenessEntry()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.38
 Nodes (7): assertNoBusinessEventConflict(), buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.58
 Nodes (9): amendRepairWithCtx(), createRepairWithCtx(), pauseRepair(), processRepairBatchWithCtx(), readCurrentGroup(), recordRepairAuditEvent(), requireEvidence(), resumeRepairWithCtx() (+1 more)
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.33
 Nodes (8): classifyFinalizedLineageRepairConflicts(), classifyRepairCandidate(), countRepairableFinalizedLineageLines(), getProvisionalImportSku(), isClosedRegisterRepairReplayConflict(), isFinalizedLineageRepairConflict(), isProvisionalRowChangedConflict(), skipped()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 324 - "Community 324"
+### Community 325 - "Community 325"
 Cohesion: 0.36
 Nodes (9): aggregateSkuDays(), computeRange(), computeRequestKey(), inclusiveDaySpan(), isValidOperatingDate(), requestRangeCore(), sumDays(), utcMillisForLabel() (+1 more)
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (9): anchorDate(), buildOverviewData(), comparisonBp(), emptySnapshot(), isUnsettled(), readRecentDays(), rebuildStoreOverview(), snapshotForDays() (+1 more)
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.6
 Nodes (9): block(), progress(), sameMetrics(), validDate(), validMetrics(), verifyCheckpointBatch(), verifyInputBatch(), verifyOutputBatch() (+1 more)
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.36
 Nodes (8): buildClassification(), classifyDayResult(), classifyWeekResult(), confirmsClean(), explainMetricDifference(), fingerprintDifferences(), nextStreakState(), partitionDifferences()
-
-### Community 329 - "Community 329"
-Cohesion: 0.33
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.29
@@ -5560,47 +5560,47 @@ Nodes (5): appendContextEventWithCtx(), buildContextEventSemanticEnvelopeHash(),
 
 ### Community 570 - "Community 570"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): getHandler()
 
 ### Community 571 - "Community 571"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 572 - "Community 572"
 Cohesion: 0.47
 Nodes (3): canonical(), isValidBody(), text()
 
-### Community 572 - "Community 572"
+### Community 573 - "Community 573"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 573 - "Community 573"
-Cohesion: 0.4
-Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 574 - "Community 574"
 Cohesion: 0.4
-Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
+Nodes (2): createMutationCtx(), seedTrustedConversionData()
 
 ### Community 575 - "Community 575"
 Cohesion: 0.4
-Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
+Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
 ### Community 576 - "Community 576"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): countFeaturedTargets(), validateFeaturedPlacement()
 
 ### Community 577 - "Community 577"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 578 - "Community 578"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 579 - "Community 579"
 Cohesion: 0.6
 Nodes (5): backfillStoreCurrencyCaseWithCtx(), boundedLimit(), needsNormalization(), storePage(), verifyStoreCurrencyCaseWithCtx()
 
-### Community 579 - "Community 579"
+### Community 580 - "Community 580"
 Cohesion: 0.47
 Nodes (4): findNotificationKind(), getNotificationKind(), isStaleDailyClosePayload(), requireStaleDailyClosePayload()
-
-### Community 580 - "Community 580"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 581 - "Community 581"
 Cohesion: 0.33
@@ -5611,40 +5611,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 583 - "Community 583"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 584 - "Community 584"
 Cohesion: 0.6
 Nodes (4): customerBehaviorRead(), resolveStoreFromStorefrontActor(), storefrontAccountRead(), storefrontRead()
 
-### Community 584 - "Community 584"
+### Community 585 - "Community 585"
 Cohesion: 0.53
 Nodes (4): evaluateOperationTargetGuards(), readIdArg(), resolveOperationTargetExternalRefs(), resolveOperationTargetIds()
 
-### Community 585 - "Community 585"
+### Community 586 - "Community 586"
 Cohesion: 0.47
 Nodes (3): listApprovalsHandler(), listAttentionHandler(), windowFallbackWarning()
 
-### Community 586 - "Community 586"
+### Community 587 - "Community 587"
 Cohesion: 0.53
 Nodes (4): consumeApprovalProofWithCtx(), getValidApprovalProof(), invalidApprovalProofResult(), validateApprovalProofWithCtx()
 
-### Community 587 - "Community 587"
+### Community 588 - "Community 588"
 Cohesion: 0.47
 Nodes (4): buildDailyCloseApprovalSubject(), buildDailyCloseCarryForwardApprovalRequirement(), buildDailyCloseCarryForwardApprovalSubject(), buildDailyCloseCompletionApprovalRequirement()
 
-### Community 588 - "Community 588"
+### Community 589 - "Community 589"
 Cohesion: 0.6
 Nodes (5): buildOnlineOrderOperationalEventMessage(), buildOperationalEventMessage(), buildStockAdjustmentOperationalEventMessage(), formatOnlineOrderLabel(), formatStockAdjustmentSubjectDetail()
 
-### Community 589 - "Community 589"
+### Community 590 - "Community 590"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 590 - "Community 590"
-Cohesion: 0.4
-Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 591 - "Community 591"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): evidenceCoverage(), makeCloseEvidence()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.33
@@ -5660,7 +5660,7 @@ Nodes (0):
 
 ### Community 595 - "Community 595"
 Cohesion: 0.33
-Nodes (1): getHandler()
+Nodes (0):
 
 ### Community 596 - "Community 596"
 Cohesion: 0.33

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -14807,7 +14807,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1856",
+      "source_location": "L1864",
       "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
@@ -14843,7 +14843,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2279",
+      "source_location": "L2287",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -14855,7 +14855,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2365",
+      "source_location": "L2373",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -14867,7 +14867,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquedailycloseitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2295",
+      "source_location": "L2303",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -14879,7 +14879,7 @@
       "relation": "calls",
       "source": "dailyclose_buildapprovalrequestsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2940",
+      "source_location": "L2948",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14891,7 +14891,7 @@
       "relation": "calls",
       "source": "dailyclose_buildcompletedonlineordertotals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2874",
+      "source_location": "L2882",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14903,7 +14903,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensesessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2995",
+      "source_location": "L3003",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14915,7 +14915,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2887",
+      "source_location": "L2895",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14927,7 +14927,7 @@
       "relation": "calls",
       "source": "dailyclose_buildreadiness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3743",
+      "source_location": "L3751",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14939,7 +14939,7 @@
       "relation": "calls",
       "source": "dailyclose_buildregistersessionsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2988",
+      "source_location": "L2996",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14951,7 +14951,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2803",
+      "source_location": "L2811",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14963,7 +14963,7 @@
       "relation": "calls",
       "source": "dailyclose_buildterminallabelsbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3010",
+      "source_location": "L3018",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14975,7 +14975,7 @@
       "relation": "calls",
       "source": "dailyclose_buildtransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2882",
+      "source_location": "L2890",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14987,7 +14987,7 @@
       "relation": "calls",
       "source": "dailyclose_cashdeltasbyregistersessionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2985",
+      "source_location": "L2993",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -14999,7 +14999,7 @@
       "relation": "calls",
       "source": "dailyclose_completesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2781",
+      "source_location": "L2789",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15011,7 +15011,7 @@
       "relation": "calls",
       "source": "dailyclose_emptysummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2775",
+      "source_location": "L2783",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15023,7 +15023,7 @@
       "relation": "calls",
       "source": "dailyclose_filterregistersessionsbelongingtorange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2928",
+      "source_location": "L2936",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15035,7 +15035,7 @@
       "relation": "calls",
       "source": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3825",
+      "source_location": "L3833",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15047,7 +15047,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2799",
+      "source_location": "L2807",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15059,7 +15059,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2794",
+      "source_location": "L2802",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15071,7 +15071,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2806",
+      "source_location": "L2814",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15083,7 +15083,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2731",
+      "source_location": "L2739",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15095,7 +15095,7 @@
       "relation": "calls",
       "source": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2849",
+      "source_location": "L2857",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15107,7 +15107,7 @@
       "relation": "calls",
       "source": "dailyclose_listcompletedonlineordersforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2855",
+      "source_location": "L2863",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15119,7 +15119,7 @@
       "relation": "calls",
       "source": "dailyclose_listdepositsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2869",
+      "source_location": "L2877",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15131,7 +15131,7 @@
       "relation": "calls",
       "source": "dailyclose_listexpensesforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2868",
+      "source_location": "L2876",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15143,7 +15143,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenoperationalworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2848",
+      "source_location": "L2856",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15155,7 +15155,7 @@
       "relation": "calls",
       "source": "dailyclose_listopenpossessions",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2847",
+      "source_location": "L2855",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15167,7 +15167,7 @@
       "relation": "calls",
       "source": "dailyclose_listpendingcloseoutapprovals",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2846",
+      "source_location": "L2854",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15179,7 +15179,7 @@
       "relation": "calls",
       "source": "dailyclose_listregistersessionsfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2841",
+      "source_location": "L2849",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15191,7 +15191,7 @@
       "relation": "calls",
       "source": "dailyclose_listtransactionsforday",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2850",
+      "source_location": "L2858",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15203,7 +15203,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2817",
+      "source_location": "L2825",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15215,7 +15215,7 @@
       "relation": "calls",
       "source": "dailyclose_mergesourcecompleteness",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2912",
+      "source_location": "L2920",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15227,7 +15227,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizecompleteddailyclosesnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2807",
+      "source_location": "L2815",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15239,7 +15239,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3814",
+      "source_location": "L3822",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15251,7 +15251,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2730",
+      "source_location": "L2738",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15263,7 +15263,7 @@
       "relation": "calls",
       "source": "dailyclose_sortdailycloseblockers",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3742",
+      "source_location": "L3750",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15275,7 +15275,7 @@
       "relation": "calls",
       "source": "dailyclose_uniquesourcesubjects",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3831",
+      "source_location": "L3839",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -15287,7 +15287,7 @@
       "relation": "calls",
       "source": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1975",
+      "source_location": "L1983",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -15299,7 +15299,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3936",
+      "source_location": "L3944",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -15311,7 +15311,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3968",
+      "source_location": "L3976",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -15323,7 +15323,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3969",
+      "source_location": "L3977",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -15335,7 +15335,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3945",
+      "source_location": "L3953",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -15347,7 +15347,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4892",
+      "source_location": "L4900",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15359,7 +15359,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4687",
+      "source_location": "L4695",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15371,7 +15371,7 @@
       "relation": "calls",
       "source": "dailyclose_completionblockingincompletesources",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4754",
+      "source_location": "L4762",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15383,7 +15383,7 @@
       "relation": "calls",
       "source": "dailyclose_getnonactivedailyclosefordate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4719",
+      "source_location": "L4727",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15395,7 +15395,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4662",
+      "source_location": "L4670",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15407,7 +15407,7 @@
       "relation": "calls",
       "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4808",
+      "source_location": "L4816",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15419,7 +15419,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4843",
+      "source_location": "L4851",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15431,7 +15431,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4923",
+      "source_location": "L4931",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15443,7 +15443,7 @@
       "relation": "calls",
       "source": "dailyclose_observedincompleteoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4811",
+      "source_location": "L4819",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15455,7 +15455,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4959",
+      "source_location": "L4967",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15467,7 +15467,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4965",
+      "source_location": "L4973",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15479,7 +15479,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4954",
+      "source_location": "L4962",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15491,7 +15491,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4678",
+      "source_location": "L4686",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15503,7 +15503,7 @@
       "relation": "calls",
       "source": "dailyclose_validateautomationcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4826",
+      "source_location": "L4834",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15515,7 +15515,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4809",
+      "source_location": "L4817",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -15527,7 +15527,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosereportsnapshot",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4541",
+      "source_location": "L4549",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15539,7 +15539,7 @@
       "relation": "calls",
       "source": "dailyclose_builddailyclosesnapshotwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4363",
+      "source_location": "L4371",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15551,7 +15551,7 @@
       "relation": "calls",
       "source": "dailyclose_completionblockingincompletesources",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4386",
+      "source_location": "L4394",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15563,7 +15563,7 @@
       "relation": "calls",
       "source": "dailyclose_createcarryforwardworkitems",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4460",
+      "source_location": "L4468",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15575,7 +15575,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4338",
+      "source_location": "L4346",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15587,7 +15587,7 @@
       "relation": "calls",
       "source": "dailyclose_hasincompleteoperationalwork",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4502",
+      "source_location": "L4510",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15599,7 +15599,7 @@
       "relation": "calls",
       "source": "dailyclose_logicalcarryforwardselectioncount",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4498",
+      "source_location": "L4506",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15611,7 +15611,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4574",
+      "source_location": "L4582",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15623,7 +15623,7 @@
       "relation": "calls",
       "source": "dailyclose_observedincompleteoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4486",
+      "source_location": "L4494",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15635,7 +15635,7 @@
       "relation": "calls",
       "source": "dailyclose_patchdailyclosecarryforwardworkitemmetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4609",
+      "source_location": "L4617",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15647,7 +15647,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedevent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4615",
+      "source_location": "L4623",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15659,7 +15659,7 @@
       "relation": "calls",
       "source": "dailyclose_recorddailyclosecompletedreportfacts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4604",
+      "source_location": "L4612",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15671,7 +15671,7 @@
       "relation": "calls",
       "source": "dailyclose_resolveoperatingdaterange",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4354",
+      "source_location": "L4362",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15683,7 +15683,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4497",
+      "source_location": "L4505",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15695,7 +15695,7 @@
       "relation": "calls",
       "source": "dailyclose_uniqueoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4406",
+      "source_location": "L4414",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15707,7 +15707,7 @@
       "relation": "calls",
       "source": "dailyclose_validatecarryforwardworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4423",
+      "source_location": "L4431",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15719,7 +15719,7 @@
       "relation": "calls",
       "source": "dailyclose_validateselectedcarryforwardgroups",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4409",
+      "source_location": "L4417",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -15731,7 +15731,7 @@
       "relation": "calls",
       "source": "dailyclose_incompletesourcecompletenessentries",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2435",
+      "source_location": "L2443",
       "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
@@ -15743,7 +15743,7 @@
       "relation": "calls",
       "source": "dailyclose_findcurrentcarryforwardworkitembysource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4124",
+      "source_location": "L4132",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -15755,7 +15755,7 @@
       "relation": "calls",
       "source": "dailyclose_sourceidfromcarryforwardinput",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4121",
+      "source_location": "L4129",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -15767,7 +15767,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4112",
+      "source_location": "L4120",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -15791,7 +15791,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5656",
+      "source_location": "L5664",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -15803,7 +15803,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5659",
+      "source_location": "L5667",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -15815,7 +15815,7 @@
       "relation": "calls",
       "source": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5652",
+      "source_location": "L5660",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -15827,7 +15827,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5682",
+      "source_location": "L5690",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -15839,7 +15839,7 @@
       "relation": "calls",
       "source": "dailyclose_getpriorcompleteddailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5524",
+      "source_location": "L5532",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -15851,7 +15851,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1687",
+      "source_location": "L1695",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -15863,7 +15863,7 @@
       "relation": "calls",
       "source": "dailyclose_buildstaffnamesbyid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5612",
+      "source_location": "L5620",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -15875,7 +15875,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1788",
+      "source_location": "L1796",
       "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
@@ -15887,7 +15887,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2121",
+      "source_location": "L2129",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -15899,7 +15899,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1890",
+      "source_location": "L1898",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -15911,8 +15911,20 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1650",
+      "source_location": "L1658",
       "target": "dailyclose_listopenoperationalworkitems",
+      "weight": 1
+    },
+    {
+      "_src": "dailyclose_listopenpossessions",
+      "_tgt": "dailyclose_isinrange",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1,
+      "relation": "calls",
+      "source": "dailyclose_isinrange",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
+      "source_location": "L1603",
+      "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
     {
@@ -15923,7 +15935,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1615",
+      "source_location": "L1623",
       "target": "dailyclose_listopenpossessions",
       "weight": 1
     },
@@ -15971,7 +15983,7 @@
       "relation": "calls",
       "source": "dailyclose_readcappedsource",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1739",
+      "source_location": "L1747",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -15995,7 +16007,7 @@
       "relation": "calls",
       "source": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2612",
+      "source_location": "L2620",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -16007,7 +16019,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2613",
+      "source_location": "L2621",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -16079,7 +16091,7 @@
       "relation": "calls",
       "source": "dailyclose_observedincompleteoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2401",
+      "source_location": "L2409",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -16091,7 +16103,7 @@
       "relation": "calls",
       "source": "dailyclose_observedincompleteoperationalworkitemids",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2402",
+      "source_location": "L2410",
       "target": "dailyclose_uniqueoperationalworkitemids",
       "weight": 1
     },
@@ -16127,7 +16139,7 @@
       "relation": "calls",
       "source": "dailyclose_sourcecompletenessentry",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1716",
+      "source_location": "L1724",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -16139,7 +16151,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2572",
+      "source_location": "L2580",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -16151,7 +16163,7 @@
       "relation": "calls",
       "source": "dailyclose_normalizedailyclosesummary",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2535",
+      "source_location": "L2543",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -16211,7 +16223,7 @@
       "relation": "calls",
       "source": "dailyclose_markotherdailyclosesnotcurrent",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5449",
+      "source_location": "L5457",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -16223,7 +16235,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5286",
+      "source_location": "L5294",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -16235,7 +16247,7 @@
       "relation": "calls",
       "source": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5945",
+      "source_location": "L5953",
       "target": "dailyclose_resolvedailyclosecarryforwardpublichandler",
       "weight": 1
     },
@@ -16247,7 +16259,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardbusinessdate",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5104",
+      "source_location": "L5112",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16259,7 +16271,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardresolutionvalidationerror",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5061",
+      "source_location": "L5069",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16271,7 +16283,7 @@
       "relation": "calls",
       "source": "dailyclose_carryforwardsourceid",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5131",
+      "source_location": "L5139",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16283,7 +16295,7 @@
       "relation": "calls",
       "source": "dailyclose_getstore",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5035",
+      "source_location": "L5043",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16295,7 +16307,7 @@
       "relation": "calls",
       "source": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5176",
+      "source_location": "L5184",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16307,7 +16319,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5113",
+      "source_location": "L5121",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16319,7 +16331,7 @@
       "relation": "calls",
       "source": "dailyclose_trimoptional",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5026",
+      "source_location": "L5034",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -16355,7 +16367,7 @@
       "relation": "calls",
       "source": "dailyclose_stringfrommetadata",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3957",
+      "source_location": "L3965",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -16379,7 +16391,7 @@
       "relation": "calls",
       "source": "dailyclose_completionattributionfordailyclose",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2625",
+      "source_location": "L2633",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -16391,7 +16403,7 @@
       "relation": "calls",
       "source": "dailyclose_redactdailyclosesummaryforbroadview",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2654",
+      "source_location": "L2662",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -69527,7 +69539,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6447",
+      "source_location": "L6495",
       "target": "dailyclose_test_createcommandargs",
       "weight": 1
     },
@@ -69635,7 +69647,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_test_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L4350",
+      "source_location": "L4398",
       "target": "dailyclose_test_syncedreview",
       "weight": 1
     },
@@ -69695,7 +69707,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1801",
+      "source_location": "L1809",
       "target": "dailyclose_buildcompletedonlineordertotals",
       "weight": 1
     },
@@ -69707,7 +69719,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1985",
+      "source_location": "L1993",
       "target": "dailyclose_builddailycloseexpenseproductevidence",
       "weight": 1
     },
@@ -69731,7 +69743,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2255",
+      "source_location": "L2263",
       "target": "dailyclose_builddailyclosereportsnapshot",
       "weight": 1
     },
@@ -69743,7 +69755,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2718",
+      "source_location": "L2726",
       "target": "dailyclose_builddailyclosesnapshotwithctx",
       "weight": 1
     },
@@ -69767,7 +69779,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1931",
+      "source_location": "L1939",
       "target": "dailyclose_buildexpensetransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -69779,7 +69791,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2152",
+      "source_location": "L2160",
       "target": "dailyclose_buildreadiness",
       "weight": 1
     },
@@ -69827,7 +69839,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1903",
+      "source_location": "L1911",
       "target": "dailyclose_buildtransactionitemcountsbytransactionid",
       "weight": 1
     },
@@ -69839,7 +69851,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3932",
+      "source_location": "L3940",
       "target": "dailyclose_carryforwardbusinessdate",
       "weight": 1
     },
@@ -69851,7 +69863,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3962",
+      "source_location": "L3970",
       "target": "dailyclose_carryforwardmetadatamatches",
       "weight": 1
     },
@@ -69863,7 +69875,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5015",
+      "source_location": "L5023",
       "target": "dailyclose_carryforwardresolutionvalidationerror",
       "weight": 1
     },
@@ -69875,7 +69887,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3941",
+      "source_location": "L3949",
       "target": "dailyclose_carryforwardsourceid",
       "weight": 1
     },
@@ -69887,7 +69899,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4006",
+      "source_location": "L4014",
       "target": "dailyclose_carryforwardworkitemidfromitem",
       "weight": 1
     },
@@ -69899,7 +69911,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2134",
+      "source_location": "L2142",
       "target": "dailyclose_cashdeltasbyregistersessionid",
       "weight": 1
     },
@@ -69923,7 +69935,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4656",
+      "source_location": "L4664",
       "target": "dailyclose_completedailycloseforautomationwithctx",
       "weight": 1
     },
@@ -69935,7 +69947,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4334",
+      "source_location": "L4342",
       "target": "dailyclose_completedailyclosewithctx",
       "weight": 1
     },
@@ -69959,7 +69971,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2446",
+      "source_location": "L2454",
       "target": "dailyclose_completionattributionfordailyclose",
       "weight": 1
     },
@@ -69971,7 +69983,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2434",
+      "source_location": "L2442",
       "target": "dailyclose_completionblockingincompletesources",
       "weight": 1
     },
@@ -69983,7 +69995,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4097",
+      "source_location": "L4105",
       "target": "dailyclose_createcarryforwardworkitems",
       "weight": 1
     },
@@ -69995,7 +70007,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2685",
+      "source_location": "L2693",
       "target": "dailyclose_emptysummary",
       "weight": 1
     },
@@ -70019,7 +70031,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3973",
+      "source_location": "L3981",
       "target": "dailyclose_findcurrentcarryforwardworkitembysource",
       "weight": 1
     },
@@ -70043,7 +70055,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2228",
+      "source_location": "L2236",
       "target": "dailyclose_frozensyncedsaleinventoryreviewgroups",
       "weight": 1
     },
@@ -70055,7 +70067,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5631",
+      "source_location": "L5639",
       "target": "dailyclose_getcompleteddailyclosehistorydetailwithctx",
       "weight": 1
     },
@@ -70067,7 +70079,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2658",
+      "source_location": "L2666",
       "target": "dailyclose_getdailyclosecompletioneventstaffprofileid",
       "weight": 1
     },
@@ -70091,7 +70103,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5517",
+      "source_location": "L5525",
       "target": "dailyclose_getdailycloseopeningcontextwithctx",
       "weight": 1
     },
@@ -70103,7 +70115,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4196",
+      "source_location": "L4204",
       "target": "dailyclose_getnonactivedailyclosefordate",
       "weight": 1
     },
@@ -70139,7 +70151,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2440",
+      "source_location": "L2448",
       "target": "dailyclose_hasincompleteoperationalwork",
       "weight": 1
     },
@@ -70151,7 +70163,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2423",
+      "source_location": "L2431",
       "target": "dailyclose_incompletesourcecompletenessentries",
       "weight": 1
     },
@@ -70163,7 +70175,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5755",
+      "source_location": "L5763",
       "target": "dailyclose_isdailycloseadmissionauthorizationerror",
       "weight": 1
     },
@@ -70199,7 +70211,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2427",
+      "source_location": "L2435",
       "target": "dailyclose_istoleratedincompletedailyclosecompletionsource",
       "weight": 1
     },
@@ -70223,7 +70235,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1667",
+      "source_location": "L1675",
       "target": "dailyclose_listactiveoversizedoperationalworkrepairs",
       "weight": 1
     },
@@ -70235,7 +70247,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5578",
+      "source_location": "L5586",
       "target": "dailyclose_listcompleteddailyclosehistorywithctx",
       "weight": 1
     },
@@ -70247,7 +70259,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1758",
+      "source_location": "L1766",
       "target": "dailyclose_listcompletedonlineordersforday",
       "weight": 1
     },
@@ -70259,7 +70271,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4986",
+      "source_location": "L4994",
       "target": "dailyclose_listdailyopeninghandoffsforcarryforward",
       "weight": 1
     },
@@ -70271,7 +70283,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2096",
+      "source_location": "L2104",
       "target": "dailyclose_listdepositsforday",
       "weight": 1
     },
@@ -70283,7 +70295,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1867",
+      "source_location": "L1875",
       "target": "dailyclose_listexpensesforday",
       "weight": 1
     },
@@ -70295,7 +70307,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1630",
+      "source_location": "L1638",
       "target": "dailyclose_listopenoperationalworkitems",
       "weight": 1
     },
@@ -70343,7 +70355,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1728",
+      "source_location": "L1736",
       "target": "dailyclose_listtransactionsforday",
       "weight": 1
     },
@@ -70355,7 +70367,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3891",
+      "source_location": "L3899",
       "target": "dailyclose_logicalcarryforwardselectioncount",
       "weight": 1
     },
@@ -70379,7 +70391,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4173",
+      "source_location": "L4181",
       "target": "dailyclose_markotherdailyclosesnotcurrent",
       "weight": 1
     },
@@ -70391,7 +70403,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2584",
+      "source_location": "L2592",
       "target": "dailyclose_mayberedactdailyclosesnapshotforbroadview",
       "weight": 1
     },
@@ -70427,7 +70439,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2495",
+      "source_location": "L2503",
       "target": "dailyclose_normalizebroadviewmetadatalabel",
       "weight": 1
     },
@@ -70463,7 +70475,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2398",
+      "source_location": "L2406",
       "target": "dailyclose_observedincompleteoperationalworkitemids",
       "weight": 1
     },
@@ -70499,7 +70511,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1704",
+      "source_location": "L1712",
       "target": "dailyclose_readcappedsource",
       "weight": 1
     },
@@ -70511,7 +70523,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4219",
+      "source_location": "L4227",
       "target": "dailyclose_recorddailyclosecompletedevent",
       "weight": 1
     },
@@ -70523,7 +70535,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4285",
+      "source_location": "L4293",
       "target": "dailyclose_recorddailyclosecompletedreportfacts",
       "weight": 1
     },
@@ -70535,7 +70547,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2499",
+      "source_location": "L2507",
       "target": "dailyclose_redactdailycloseitemforbroadview",
       "weight": 1
     },
@@ -70547,7 +70559,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5553",
+      "source_location": "L5561",
       "target": "dailyclose_redactdailycloseopeningcontextforbroadview",
       "weight": 1
     },
@@ -70559,7 +70571,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2552",
+      "source_location": "L2560",
       "target": "dailyclose_redactdailyclosereportsnapshotforbroadview",
       "weight": 1
     },
@@ -70571,7 +70583,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2532",
+      "source_location": "L2540",
       "target": "dailyclose_redactdailyclosesummaryforbroadview",
       "weight": 1
     },
@@ -70643,7 +70655,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5282",
+      "source_location": "L5290",
       "target": "dailyclose_reopendailyclosewithctx",
       "weight": 1
     },
@@ -70655,7 +70667,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5899",
+      "source_location": "L5907",
       "target": "dailyclose_resolvedailyclosecarryforwardpublichandler",
       "weight": 1
     },
@@ -70667,7 +70679,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5022",
+      "source_location": "L5030",
       "target": "dailyclose_resolvedailyclosecarryforwardwithctx",
       "weight": 1
     },
@@ -70703,7 +70715,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2409",
+      "source_location": "L2417",
       "target": "dailyclose_snapshotrevieweditems",
       "weight": 1
     },
@@ -70739,7 +70751,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3951",
+      "source_location": "L3959",
       "target": "dailyclose_sourceidfromcarryforwardinput",
       "weight": 1
     },
@@ -70751,7 +70763,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3923",
+      "source_location": "L3931",
       "target": "dailyclose_stringfrommetadata",
       "weight": 1
     },
@@ -70763,7 +70775,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2619",
+      "source_location": "L2627",
       "target": "dailyclose_todailyclosehistorylistitem",
       "weight": 1
     },
@@ -70799,7 +70811,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2190",
+      "source_location": "L2198",
       "target": "dailyclose_trustedsyncedsaleinventoryreviewunits",
       "weight": 1
     },
@@ -70811,7 +70823,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2182",
+      "source_location": "L2190",
       "target": "dailyclose_uniquedailycloseitems",
       "weight": 1
     },
@@ -70823,7 +70835,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3917",
+      "source_location": "L3925",
       "target": "dailyclose_uniqueoperationalworkitemids",
       "weight": 1
     },
@@ -70835,7 +70847,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2172",
+      "source_location": "L2180",
       "target": "dailyclose_uniquesourcesubjects",
       "weight": 1
     },
@@ -70847,7 +70859,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4016",
+      "source_location": "L4024",
       "target": "dailyclose_validateautomationcarryforwardworkitems",
       "weight": 1
     },
@@ -70859,7 +70871,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3837",
+      "source_location": "L3845",
       "target": "dailyclose_validatecarryforwardworkitemids",
       "weight": 1
     },
@@ -70871,7 +70883,7 @@
       "relation": "contains",
       "source": "packages_athena_webapp_convex_operations_dailyclose_ts",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3865",
+      "source_location": "L3873",
       "target": "dailyclose_validateselectedcarryforwardgroups",
       "weight": 1
     },
@@ -221833,7 +221845,7 @@
       "label": "buildCompletedOnlineOrderTotals()",
       "norm_label": "buildcompletedonlineordertotals()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1801"
+      "source_location": "L1809"
     },
     {
       "community": 0,
@@ -221842,7 +221854,7 @@
       "label": "buildDailyCloseExpenseProductEvidence()",
       "norm_label": "builddailycloseexpenseproductevidence()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1985"
+      "source_location": "L1993"
     },
     {
       "community": 0,
@@ -221860,7 +221872,7 @@
       "label": "buildDailyCloseReportSnapshot()",
       "norm_label": "builddailyclosereportsnapshot()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2255"
+      "source_location": "L2263"
     },
     {
       "community": 0,
@@ -221869,7 +221881,7 @@
       "label": "buildDailyCloseSnapshotWithCtx()",
       "norm_label": "builddailyclosesnapshotwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2718"
+      "source_location": "L2726"
     },
     {
       "community": 0,
@@ -221887,7 +221899,7 @@
       "label": "buildExpenseTransactionItemCountsByTransactionId()",
       "norm_label": "buildexpensetransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1931"
+      "source_location": "L1939"
     },
     {
       "community": 0,
@@ -221896,7 +221908,7 @@
       "label": "buildReadiness()",
       "norm_label": "buildreadiness()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2152"
+      "source_location": "L2160"
     },
     {
       "community": 0,
@@ -221932,7 +221944,7 @@
       "label": "buildTransactionItemCountsByTransactionId()",
       "norm_label": "buildtransactionitemcountsbytransactionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1903"
+      "source_location": "L1911"
     },
     {
       "community": 0,
@@ -221941,7 +221953,7 @@
       "label": "carryForwardBusinessDate()",
       "norm_label": "carryforwardbusinessdate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3932"
+      "source_location": "L3940"
     },
     {
       "community": 0,
@@ -221950,7 +221962,7 @@
       "label": "carryForwardMetadataMatches()",
       "norm_label": "carryforwardmetadatamatches()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3962"
+      "source_location": "L3970"
     },
     {
       "community": 0,
@@ -221959,7 +221971,7 @@
       "label": "carryForwardResolutionValidationError()",
       "norm_label": "carryforwardresolutionvalidationerror()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5015"
+      "source_location": "L5023"
     },
     {
       "community": 0,
@@ -221968,7 +221980,7 @@
       "label": "carryForwardSourceId()",
       "norm_label": "carryforwardsourceid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3941"
+      "source_location": "L3949"
     },
     {
       "community": 0,
@@ -221977,7 +221989,7 @@
       "label": "carryForwardWorkItemIdFromItem()",
       "norm_label": "carryforwardworkitemidfromitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4006"
+      "source_location": "L4014"
     },
     {
       "community": 0,
@@ -221986,7 +221998,7 @@
       "label": "cashDeltasByRegisterSessionId()",
       "norm_label": "cashdeltasbyregistersessionid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2134"
+      "source_location": "L2142"
     },
     {
       "community": 0,
@@ -222004,7 +222016,7 @@
       "label": "completeDailyCloseForAutomationWithCtx()",
       "norm_label": "completedailycloseforautomationwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4656"
+      "source_location": "L4664"
     },
     {
       "community": 0,
@@ -222013,7 +222025,7 @@
       "label": "completeDailyCloseWithCtx()",
       "norm_label": "completedailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4334"
+      "source_location": "L4342"
     },
     {
       "community": 0,
@@ -222031,7 +222043,7 @@
       "label": "completionAttributionForDailyClose()",
       "norm_label": "completionattributionfordailyclose()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2446"
+      "source_location": "L2454"
     },
     {
       "community": 0,
@@ -222040,7 +222052,7 @@
       "label": "completionBlockingIncompleteSources()",
       "norm_label": "completionblockingincompletesources()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2434"
+      "source_location": "L2442"
     },
     {
       "community": 0,
@@ -222049,7 +222061,7 @@
       "label": "createCarryForwardWorkItems()",
       "norm_label": "createcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4097"
+      "source_location": "L4105"
     },
     {
       "community": 0,
@@ -222058,7 +222070,7 @@
       "label": "emptySummary()",
       "norm_label": "emptysummary()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2685"
+      "source_location": "L2693"
     },
     {
       "community": 0,
@@ -222076,7 +222088,7 @@
       "label": "findCurrentCarryForwardWorkItemBySource()",
       "norm_label": "findcurrentcarryforwardworkitembysource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3973"
+      "source_location": "L3981"
     },
     {
       "community": 0,
@@ -222094,7 +222106,7 @@
       "label": "frozenSyncedSaleInventoryReviewGroups()",
       "norm_label": "frozensyncedsaleinventoryreviewgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2228"
+      "source_location": "L2236"
     },
     {
       "community": 0,
@@ -222103,7 +222115,7 @@
       "label": "getCompletedDailyCloseHistoryDetailWithCtx()",
       "norm_label": "getcompleteddailyclosehistorydetailwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5631"
+      "source_location": "L5639"
     },
     {
       "community": 0,
@@ -222112,7 +222124,7 @@
       "label": "getDailyCloseCompletionEventStaffProfileId()",
       "norm_label": "getdailyclosecompletioneventstaffprofileid()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2658"
+      "source_location": "L2666"
     },
     {
       "community": 0,
@@ -222130,7 +222142,7 @@
       "label": "getDailyCloseOpeningContextWithCtx()",
       "norm_label": "getdailycloseopeningcontextwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5517"
+      "source_location": "L5525"
     },
     {
       "community": 0,
@@ -222139,7 +222151,7 @@
       "label": "getNonActiveDailyCloseForDate()",
       "norm_label": "getnonactivedailyclosefordate()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4196"
+      "source_location": "L4204"
     },
     {
       "community": 0,
@@ -222166,7 +222178,7 @@
       "label": "hasIncompleteOperationalWork()",
       "norm_label": "hasincompleteoperationalwork()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2440"
+      "source_location": "L2448"
     },
     {
       "community": 0,
@@ -222175,7 +222187,7 @@
       "label": "incompleteSourceCompletenessEntries()",
       "norm_label": "incompletesourcecompletenessentries()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2423"
+      "source_location": "L2431"
     },
     {
       "community": 0,
@@ -222184,7 +222196,7 @@
       "label": "isDailyCloseAdmissionAuthorizationError()",
       "norm_label": "isdailycloseadmissionauthorizationerror()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5755"
+      "source_location": "L5763"
     },
     {
       "community": 0,
@@ -222211,7 +222223,7 @@
       "label": "isToleratedIncompleteDailyCloseCompletionSource()",
       "norm_label": "istoleratedincompletedailyclosecompletionsource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2427"
+      "source_location": "L2435"
     },
     {
       "community": 0,
@@ -222229,7 +222241,7 @@
       "label": "listActiveOversizedOperationalWorkRepairs()",
       "norm_label": "listactiveoversizedoperationalworkrepairs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1667"
+      "source_location": "L1675"
     },
     {
       "community": 0,
@@ -222238,7 +222250,7 @@
       "label": "listCompletedDailyCloseHistoryWithCtx()",
       "norm_label": "listcompleteddailyclosehistorywithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5578"
+      "source_location": "L5586"
     },
     {
       "community": 0,
@@ -222247,7 +222259,7 @@
       "label": "listCompletedOnlineOrdersForDay()",
       "norm_label": "listcompletedonlineordersforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1758"
+      "source_location": "L1766"
     },
     {
       "community": 0,
@@ -222256,7 +222268,7 @@
       "label": "listDailyOpeningHandoffsForCarryForward()",
       "norm_label": "listdailyopeninghandoffsforcarryforward()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4986"
+      "source_location": "L4994"
     },
     {
       "community": 0,
@@ -222265,7 +222277,7 @@
       "label": "listDepositsForDay()",
       "norm_label": "listdepositsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2096"
+      "source_location": "L2104"
     },
     {
       "community": 0,
@@ -222274,7 +222286,7 @@
       "label": "listExpensesForDay()",
       "norm_label": "listexpensesforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1867"
+      "source_location": "L1875"
     },
     {
       "community": 0,
@@ -222283,7 +222295,7 @@
       "label": "listOpenOperationalWorkItems()",
       "norm_label": "listopenoperationalworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1630"
+      "source_location": "L1638"
     },
     {
       "community": 0,
@@ -222319,7 +222331,7 @@
       "label": "listTransactionsForDay()",
       "norm_label": "listtransactionsforday()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1728"
+      "source_location": "L1736"
     },
     {
       "community": 0,
@@ -222328,7 +222340,7 @@
       "label": "logicalCarryForwardSelectionCount()",
       "norm_label": "logicalcarryforwardselectioncount()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3891"
+      "source_location": "L3899"
     },
     {
       "community": 0,
@@ -222346,7 +222358,7 @@
       "label": "markOtherDailyClosesNotCurrent()",
       "norm_label": "markotherdailyclosesnotcurrent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4173"
+      "source_location": "L4181"
     },
     {
       "community": 0,
@@ -222355,7 +222367,7 @@
       "label": "maybeRedactDailyCloseSnapshotForBroadView()",
       "norm_label": "mayberedactdailyclosesnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2584"
+      "source_location": "L2592"
     },
     {
       "community": 0,
@@ -222382,7 +222394,7 @@
       "label": "normalizeBroadViewMetadataLabel()",
       "norm_label": "normalizebroadviewmetadatalabel()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2495"
+      "source_location": "L2503"
     },
     {
       "community": 0,
@@ -222409,7 +222421,7 @@
       "label": "observedIncompleteOperationalWorkItemIds()",
       "norm_label": "observedincompleteoperationalworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2398"
+      "source_location": "L2406"
     },
     {
       "community": 0,
@@ -222436,7 +222448,7 @@
       "label": "readCappedSource()",
       "norm_label": "readcappedsource()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L1704"
+      "source_location": "L1712"
     },
     {
       "community": 0,
@@ -222445,7 +222457,7 @@
       "label": "recordDailyCloseCompletedEvent()",
       "norm_label": "recorddailyclosecompletedevent()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4219"
+      "source_location": "L4227"
     },
     {
       "community": 0,
@@ -222454,7 +222466,7 @@
       "label": "recordDailyCloseCompletedReportFacts()",
       "norm_label": "recorddailyclosecompletedreportfacts()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4285"
+      "source_location": "L4293"
     },
     {
       "community": 0,
@@ -222463,7 +222475,7 @@
       "label": "redactDailyCloseItemForBroadView()",
       "norm_label": "redactdailycloseitemforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2499"
+      "source_location": "L2507"
     },
     {
       "community": 0,
@@ -222472,7 +222484,7 @@
       "label": "redactDailyCloseOpeningContextForBroadView()",
       "norm_label": "redactdailycloseopeningcontextforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5553"
+      "source_location": "L5561"
     },
     {
       "community": 0,
@@ -222481,7 +222493,7 @@
       "label": "redactDailyCloseReportSnapshotForBroadView()",
       "norm_label": "redactdailyclosereportsnapshotforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2552"
+      "source_location": "L2560"
     },
     {
       "community": 0,
@@ -222490,7 +222502,7 @@
       "label": "redactDailyCloseSummaryForBroadView()",
       "norm_label": "redactdailyclosesummaryforbroadview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2532"
+      "source_location": "L2540"
     },
     {
       "community": 0,
@@ -222544,7 +222556,7 @@
       "label": "reopenDailyCloseWithCtx()",
       "norm_label": "reopendailyclosewithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5282"
+      "source_location": "L5290"
     },
     {
       "community": 0,
@@ -222553,7 +222565,7 @@
       "label": "resolveDailyCloseCarryForwardPublicHandler()",
       "norm_label": "resolvedailyclosecarryforwardpublichandler()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5899"
+      "source_location": "L5907"
     },
     {
       "community": 0,
@@ -222562,7 +222574,7 @@
       "label": "resolveDailyCloseCarryForwardWithCtx()",
       "norm_label": "resolvedailyclosecarryforwardwithctx()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L5022"
+      "source_location": "L5030"
     },
     {
       "community": 0,
@@ -222589,7 +222601,7 @@
       "label": "snapshotReviewedItems()",
       "norm_label": "snapshotrevieweditems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2409"
+      "source_location": "L2417"
     },
     {
       "community": 0,
@@ -222616,7 +222628,7 @@
       "label": "sourceIdFromCarryForwardInput()",
       "norm_label": "sourceidfromcarryforwardinput()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3951"
+      "source_location": "L3959"
     },
     {
       "community": 0,
@@ -222625,7 +222637,7 @@
       "label": "stringFromMetadata()",
       "norm_label": "stringfrommetadata()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3923"
+      "source_location": "L3931"
     },
     {
       "community": 0,
@@ -222634,7 +222646,7 @@
       "label": "toDailyCloseHistoryListItem()",
       "norm_label": "todailyclosehistorylistitem()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2619"
+      "source_location": "L2627"
     },
     {
       "community": 0,
@@ -222661,7 +222673,7 @@
       "label": "trustedSyncedSaleInventoryReviewUnits()",
       "norm_label": "trustedsyncedsaleinventoryreviewunits()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2190"
+      "source_location": "L2198"
     },
     {
       "community": 0,
@@ -222670,7 +222682,7 @@
       "label": "uniqueDailyCloseItems()",
       "norm_label": "uniquedailycloseitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2182"
+      "source_location": "L2190"
     },
     {
       "community": 0,
@@ -222679,7 +222691,7 @@
       "label": "uniqueOperationalWorkItemIds()",
       "norm_label": "uniqueoperationalworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3917"
+      "source_location": "L3925"
     },
     {
       "community": 0,
@@ -222688,7 +222700,7 @@
       "label": "uniqueSourceSubjects()",
       "norm_label": "uniquesourcesubjects()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L2172"
+      "source_location": "L2180"
     },
     {
       "community": 0,
@@ -222697,7 +222709,7 @@
       "label": "validateAutomationCarryForwardWorkItems()",
       "norm_label": "validateautomationcarryforwardworkitems()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L4016"
+      "source_location": "L4024"
     },
     {
       "community": 0,
@@ -222706,7 +222718,7 @@
       "label": "validateCarryForwardWorkItemIds()",
       "norm_label": "validatecarryforwardworkitemids()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3837"
+      "source_location": "L3845"
     },
     {
       "community": 0,
@@ -222715,7 +222727,7 @@
       "label": "validateSelectedCarryForwardGroups()",
       "norm_label": "validateselectedcarryforwardgroups()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.ts",
-      "source_location": "L3865"
+      "source_location": "L3873"
     },
     {
       "community": 0,
@@ -231324,182 +231336,182 @@
     {
       "community": 113,
       "file_type": "code",
-      "id": "importboundary_test_collectsources",
-      "label": "collectSources()",
-      "norm_label": "collectsources()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L30"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_finddisallowedimports",
-      "label": "findDisallowedImports()",
-      "norm_label": "finddisallowedimports()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findindirectcomponentmountviolations",
-      "label": "findIndirectComponentMountViolations()",
-      "norm_label": "findindirectcomponentmountviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findkernelimportviolations",
-      "label": "findKernelImportViolations()",
-      "norm_label": "findkernelimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L144"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findleafimportviolations",
-      "label": "findLeafImportViolations()",
-      "norm_label": "findleafimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L191"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findproductsurfaceimports",
-      "label": "findProductSurfaceImports()",
-      "norm_label": "findproductsurfaceimports()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findprofileimportviolations",
-      "label": "findProfileImportViolations()",
-      "norm_label": "findprofileimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L338"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findregistrationshimviolations",
-      "label": "findRegistrationShimViolations()",
-      "norm_label": "findregistrationshimviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L264"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findrootconvexconfigviolations",
-      "label": "findRootConvexConfigViolations()",
-      "norm_label": "findrootconvexconfigviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L251"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findruntimenativeidentifierviolations",
-      "label": "findRuntimeNativeIdentifierViolations()",
-      "norm_label": "findruntimenativeidentifierviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L286"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findruntimenativeimportviolations",
-      "label": "findRuntimeNativeImportViolations()",
-      "norm_label": "findruntimenativeimportviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L237"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findruntimenativeviolations",
-      "label": "findRuntimeNativeViolations()",
-      "norm_label": "findruntimenativeviolations()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L128"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_findsharedcontractviolations",
-      "label": "findSharedContractViolations()",
-      "norm_label": "findsharedcontractviolations()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L305"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_fixture",
-      "label": "fixture()",
-      "norm_label": "fixture()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_importsof",
-      "label": "importsOf()",
-      "norm_label": "importsof()",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L46"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_iscompositionroot",
-      "label": "isCompositionRoot()",
-      "norm_label": "iscompositionroot()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L126"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_iskernelmodule",
-      "label": "isKernelModule()",
-      "norm_label": "iskernelmodule()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L130"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "importboundary_test_isruntimenativespecifier",
-      "label": "isRuntimeNativeSpecifier()",
-      "norm_label": "isruntimenativespecifier()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
-      "source_location": "L233"
-    },
-    {
-      "community": 113,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_importboundary_test_ts",
-      "label": "importBoundary.test.ts",
-      "norm_label": "importboundary.test.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "id": "packages_athena_webapp_convex_agentharness_readports_ts",
+      "label": "readPorts.ts",
+      "norm_label": "readports.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
       "source_location": "L1"
     },
     {
       "community": 113,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_agent_importboundary_test_ts",
-      "label": "importBoundary.test.ts",
-      "norm_label": "importboundary.test.ts",
-      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
-      "source_location": "L1"
+      "id": "readports_agentreadportbindingerror",
+      "label": "AgentReadPortBindingError",
+      "norm_label": "agentreadportbindingerror",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L170"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_agentreadportbindingerror_constructor",
+      "label": ".constructor()",
+      "norm_label": ".constructor()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L174"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_computereadresulthash",
+      "label": "computeReadResultHash()",
+      "norm_label": "computereadresulthash()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L428"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_contractviolation",
+      "label": "contractViolation()",
+      "norm_label": "contractviolation()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L422"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_createagentreadportquerydefiner",
+      "label": "createAgentReadPortQueryDefiner()",
+      "norm_label": "createagentreadportquerydefiner()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L586"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_createagentreadportregistry",
+      "label": "createAgentReadPortRegistry()",
+      "norm_label": "createagentreadportregistry()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L211"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_cursorbindingdigest",
+      "label": "cursorBindingDigest()",
+      "norm_label": "cursorbindingdigest()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L311"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_dispatchagentreadport",
+      "label": "dispatchAgentReadPort()",
+      "norm_label": "dispatchagentreadport()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L276"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_filtervaluevalid",
+      "label": "filterValueValid()",
+      "norm_label": "filtervaluevalid()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L344"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_finishagentreadenvelope",
+      "label": "finishAgentReadEnvelope()",
+      "norm_label": "finishagentreadenvelope()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L448"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_fromhex",
+      "label": "fromHex()",
+      "norm_label": "fromhex()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L298"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_functionnameof",
+      "label": "functionNameOf()",
+      "norm_label": "functionnameof()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L196"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_invalidinvocation",
+      "label": "invalidInvocation()",
+      "norm_label": "invalidinvocation()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_mintagentcursor",
+      "label": "mintAgentCursor()",
+      "norm_label": "mintagentcursor()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L315"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_refusedresponse",
+      "label": "refusedResponse()",
+      "norm_label": "refusedresponse()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L569"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_resolveagentcursor",
+      "label": "resolveAgentCursor()",
+      "norm_label": "resolveagentcursor()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L320"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_resolveagentreadporthandler",
+      "label": "resolveAgentReadPortHandler()",
+      "norm_label": "resolveagentreadporthandler()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L258"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_tohex",
+      "label": "toHex()",
+      "norm_label": "tohex()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L294"
+    },
+    {
+      "community": 113,
+      "file_type": "code",
+      "id": "readports_validateagentreadrequestargs",
+      "label": "validateAgentReadRequestArgs()",
+      "norm_label": "validateagentreadrequestargs()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "source_location": "L363"
     },
     {
       "community": 1130,
@@ -231774,182 +231786,182 @@
     {
       "community": 114,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_agentharness_readports_ts",
-      "label": "readPorts.ts",
-      "norm_label": "readports.ts",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
+      "id": "actions_buildproviderregistry",
+      "label": "buildProviderRegistry()",
+      "norm_label": "buildproviderregistry()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L455"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_createintelligencerun",
+      "label": "createIntelligenceRun()",
+      "norm_label": "createintelligencerun()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L469"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_defaultfakeoutput",
+      "label": "defaultFakeOutput()",
+      "norm_label": "defaultfakeoutput()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L653"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_failedgenerationresult",
+      "label": "failedGenerationResult()",
+      "norm_label": "failedgenerationresult()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L646"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_failrunbesteffort",
+      "label": "failRunBestEffort()",
+      "norm_label": "failrunbesteffort()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L625"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_getbundlesnapshotfields",
+      "label": "getBundleSnapshotFields()",
+      "norm_label": "getbundlesnapshotfields()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L666"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_getstoreinsightssnapshotfallback",
+      "label": "getStoreInsightsSnapshotFallback()",
+      "norm_label": "getstoreinsightssnapshotfallback()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L679"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_isactivitytrend",
+      "label": "isActivityTrend()",
+      "norm_label": "isactivitytrend()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L706"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_isdevicedistribution",
+      "label": "isDeviceDistribution()",
+      "norm_label": "isdevicedistribution()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L691"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_isinsightgenerationinprogresserror",
+      "label": "isInsightGenerationInProgressError()",
+      "norm_label": "isinsightgenerationinprogresserror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L496"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_recordproviderfailure",
+      "label": "recordProviderFailure()",
+      "norm_label": "recordproviderfailure()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L589"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_recordproviderstarted",
+      "label": "recordProviderStarted()",
+      "norm_label": "recordproviderstarted()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L551"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_recordprovidersucceeded",
+      "label": "recordProviderSucceeded()",
+      "norm_label": "recordprovidersucceeded()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L572"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_resolveproviderid",
+      "label": "resolveProviderId()",
+      "norm_label": "resolveproviderid()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L447"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_resolveprovidermodel",
+      "label": "resolveProviderModel()",
+      "norm_label": "resolveprovidermodel()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L451"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_rungeneratestoreinsights",
+      "label": "runGenerateStoreInsights()",
+      "norm_label": "rungeneratestoreinsights()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L171"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_rungenerateuserinsights",
+      "label": "runGenerateUserInsights()",
+      "norm_label": "rungenerateuserinsights()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L309"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_runstructuredprovider",
+      "label": "runStructuredProvider()",
+      "norm_label": "runstructuredprovider()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L503"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "actions_topersistedintelligenceerror",
+      "label": "toPersistedIntelligenceError()",
+      "norm_label": "topersistedintelligenceerror()",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "source_location": "L614"
+    },
+    {
+      "community": 114,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_ts",
+      "label": "actions.ts",
+      "norm_label": "actions.ts",
+      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_agentreadportbindingerror",
-      "label": "AgentReadPortBindingError",
-      "norm_label": "agentreadportbindingerror",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L170"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_agentreadportbindingerror_constructor",
-      "label": ".constructor()",
-      "norm_label": ".constructor()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L174"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_computereadresulthash",
-      "label": "computeReadResultHash()",
-      "norm_label": "computereadresulthash()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L428"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_contractviolation",
-      "label": "contractViolation()",
-      "norm_label": "contractviolation()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L422"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_createagentreadportquerydefiner",
-      "label": "createAgentReadPortQueryDefiner()",
-      "norm_label": "createagentreadportquerydefiner()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L586"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_createagentreadportregistry",
-      "label": "createAgentReadPortRegistry()",
-      "norm_label": "createagentreadportregistry()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L211"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_cursorbindingdigest",
-      "label": "cursorBindingDigest()",
-      "norm_label": "cursorbindingdigest()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L311"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_dispatchagentreadport",
-      "label": "dispatchAgentReadPort()",
-      "norm_label": "dispatchagentreadport()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L276"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_filtervaluevalid",
-      "label": "filterValueValid()",
-      "norm_label": "filtervaluevalid()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L344"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_finishagentreadenvelope",
-      "label": "finishAgentReadEnvelope()",
-      "norm_label": "finishagentreadenvelope()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L448"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_fromhex",
-      "label": "fromHex()",
-      "norm_label": "fromhex()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L298"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_functionnameof",
-      "label": "functionNameOf()",
-      "norm_label": "functionnameof()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L196"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_invalidinvocation",
-      "label": "invalidInvocation()",
-      "norm_label": "invalidinvocation()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L573"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_mintagentcursor",
-      "label": "mintAgentCursor()",
-      "norm_label": "mintagentcursor()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L315"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_refusedresponse",
-      "label": "refusedResponse()",
-      "norm_label": "refusedresponse()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L569"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_resolveagentcursor",
-      "label": "resolveAgentCursor()",
-      "norm_label": "resolveagentcursor()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L320"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_resolveagentreadporthandler",
-      "label": "resolveAgentReadPortHandler()",
-      "norm_label": "resolveagentreadporthandler()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_tohex",
-      "label": "toHex()",
-      "norm_label": "tohex()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L294"
-    },
-    {
-      "community": 114,
-      "file_type": "code",
-      "id": "readports_validateagentreadrequestargs",
-      "label": "validateAgentReadRequestArgs()",
-      "norm_label": "validateagentreadrequestargs()",
-      "source_file": "packages/athena-webapp/convex/agentHarness/readPorts.ts",
-      "source_location": "L363"
     },
     {
       "community": 1140,
@@ -232224,182 +232236,182 @@
     {
       "community": 115,
       "file_type": "code",
-      "id": "actions_buildproviderregistry",
-      "label": "buildProviderRegistry()",
-      "norm_label": "buildproviderregistry()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L455"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_createintelligencerun",
-      "label": "createIntelligenceRun()",
-      "norm_label": "createintelligencerun()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L469"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_defaultfakeoutput",
-      "label": "defaultFakeOutput()",
-      "norm_label": "defaultfakeoutput()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L653"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_failedgenerationresult",
-      "label": "failedGenerationResult()",
-      "norm_label": "failedgenerationresult()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L646"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_failrunbesteffort",
-      "label": "failRunBestEffort()",
-      "norm_label": "failrunbesteffort()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L625"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_getbundlesnapshotfields",
-      "label": "getBundleSnapshotFields()",
-      "norm_label": "getbundlesnapshotfields()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L666"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_getstoreinsightssnapshotfallback",
-      "label": "getStoreInsightsSnapshotFallback()",
-      "norm_label": "getstoreinsightssnapshotfallback()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L679"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_isactivitytrend",
-      "label": "isActivityTrend()",
-      "norm_label": "isactivitytrend()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L706"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_isdevicedistribution",
-      "label": "isDeviceDistribution()",
-      "norm_label": "isdevicedistribution()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L691"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_isinsightgenerationinprogresserror",
-      "label": "isInsightGenerationInProgressError()",
-      "norm_label": "isinsightgenerationinprogresserror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L496"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_recordproviderfailure",
-      "label": "recordProviderFailure()",
-      "norm_label": "recordproviderfailure()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L589"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_recordproviderstarted",
-      "label": "recordProviderStarted()",
-      "norm_label": "recordproviderstarted()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L551"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_recordprovidersucceeded",
-      "label": "recordProviderSucceeded()",
-      "norm_label": "recordprovidersucceeded()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L572"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_resolveproviderid",
-      "label": "resolveProviderId()",
-      "norm_label": "resolveproviderid()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L447"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_resolveprovidermodel",
-      "label": "resolveProviderModel()",
-      "norm_label": "resolveprovidermodel()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L451"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_rungeneratestoreinsights",
-      "label": "runGenerateStoreInsights()",
-      "norm_label": "rungeneratestoreinsights()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L171"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_rungenerateuserinsights",
-      "label": "runGenerateUserInsights()",
-      "norm_label": "rungenerateuserinsights()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L309"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_runstructuredprovider",
-      "label": "runStructuredProvider()",
-      "norm_label": "runstructuredprovider()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L503"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "actions_topersistedintelligenceerror",
-      "label": "toPersistedIntelligenceError()",
-      "norm_label": "topersistedintelligenceerror()",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
-      "source_location": "L614"
-    },
-    {
-      "community": 115,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_intelligence_capabilities_actions_ts",
-      "label": "actions.ts",
-      "norm_label": "actions.ts",
-      "source_file": "packages/athena-webapp/convex/intelligence/capabilities/actions.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sync_registersessionsyncreview_ts",
+      "label": "registerSessionSyncReview.ts",
+      "norm_label": "registersessionsyncreview.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_arraydetail",
+      "label": "arrayDetail()",
+      "norm_label": "arraydetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L423"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_buildinventoryreviewdetail",
+      "label": "buildInventoryReviewDetail()",
+      "norm_label": "buildinventoryreviewdetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L431"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_buildregistersessionlocalsyncstatus",
+      "label": "buildRegisterSessionLocalSyncStatus()",
+      "norm_label": "buildregistersessionlocalsyncstatus()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L768"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_buildsyncsalesummary",
+      "label": "buildSyncSaleSummary()",
+      "norm_label": "buildsyncsalesummary()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L487"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_classifyregistersessionsyncreview",
+      "label": "classifyRegisterSessionSyncReview()",
+      "norm_label": "classifyregistersessionsyncreview()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L151"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_findprojectedregistersessionidforrepairablemissingmapping",
+      "label": "findProjectedRegisterSessionIdForRepairableMissingMapping()",
+      "norm_label": "findprojectedregistersessionidforrepairablemissingmapping()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L573"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_findtransactionidforsyncevent",
+      "label": "findTransactionIdForSyncEvent()",
+      "norm_label": "findtransactionidforsyncevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L536"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_getsyncconflictreconciliationtype",
+      "label": "getSyncConflictReconciliationType()",
+      "norm_label": "getsyncconflictreconciliationtype()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L128"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_hasinventoryreviewworkitemforprojectedsale",
+      "label": "hasInventoryReviewWorkItemForProjectedSale()",
+      "norm_label": "hasinventoryreviewworkitemforprojectedsale()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L313"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_isnonsalemissingregistersessionmappingconflict",
+      "label": "isNonSaleMissingRegisterSessionMappingConflict()",
+      "norm_label": "isnonsalemissingregistersessionmappingconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L391"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersession",
+      "label": "listOpenLocalSyncConflictsByRegisterSession()",
+      "norm_label": "listopenlocalsyncconflictsbyregistersession()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L1159"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersessionwithcompleteness",
+      "label": "listOpenLocalSyncConflictsByRegisterSessionWithCompleteness()",
+      "norm_label": "listopenlocalsyncconflictsbyregistersessionwithcompleteness()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L820"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_listtargetregistersessionsyncfacts",
+      "label": "listTargetRegisterSessionSyncFacts()",
+      "norm_label": "listtargetregistersessionsyncfacts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L641"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_numberdetail",
+      "label": "numberDetail()",
+      "norm_label": "numberdetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L289"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_recorddetail",
+      "label": "recordDetail()",
+      "norm_label": "recorddetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L417"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_stringdetail",
+      "label": "stringDetail()",
+      "norm_label": "stringdetail()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L298"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_summarizesaleitems",
+      "label": "summarizeSaleItems()",
+      "norm_label": "summarizesaleitems()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L456"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_syncconflicteventkey",
+      "label": "syncConflictEventKey()",
+      "norm_label": "syncconflicteventkey()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L307"
+    },
+    {
+      "community": 115,
+      "file_type": "code",
+      "id": "registersessionsyncreview_uniquebyid",
+      "label": "uniqueById()",
+      "norm_label": "uniquebyid()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "source_location": "L632"
     },
     {
       "community": 1150,
@@ -232674,182 +232686,182 @@
     {
       "community": 116,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_registersessionsyncreview_ts",
-      "label": "registerSessionSyncReview.ts",
-      "norm_label": "registersessionsyncreview.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
+      "id": "packages_athena_webapp_convex_reports_verificationsweep_test_ts",
+      "label": "verificationSweep.test.ts",
+      "norm_label": "verificationsweep.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
       "source_location": "L1"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_arraydetail",
-      "label": "arrayDetail()",
-      "norm_label": "arraydetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L423"
+      "id": "verificationsweep_test_allowlist",
+      "label": "allowlist()",
+      "norm_label": "allowlist()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L75"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_buildinventoryreviewdetail",
-      "label": "buildInventoryReviewDetail()",
-      "norm_label": "buildinventoryreviewdetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L431"
+      "id": "verificationsweep_test_expecteddedupekey",
+      "label": "expectedDedupeKey()",
+      "norm_label": "expecteddedupekey()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L228"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_buildregistersessionlocalsyncstatus",
-      "label": "buildRegisterSessionLocalSyncStatus()",
-      "norm_label": "buildregistersessionlocalsyncstatus()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L768"
+      "id": "verificationsweep_test_insertexcludedfact",
+      "label": "insertExcludedFact()",
+      "norm_label": "insertexcludedfact()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L275"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_buildsyncsalesummary",
-      "label": "buildSyncSaleSummary()",
-      "norm_label": "buildsyncsalesummary()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L487"
+      "id": "verificationsweep_test_insertreportday",
+      "label": "insertReportDay()",
+      "norm_label": "insertreportday()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L112"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_classifyregistersessionsyncreview",
-      "label": "classifyRegisterSessionSyncReview()",
-      "norm_label": "classifyregistersessionsyncreview()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L151"
+      "id": "verificationsweep_test_insertvoidfact",
+      "label": "insertVoidFact()",
+      "norm_label": "insertvoidfact()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L247"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_findprojectedregistersessionidforrepairablemissingmapping",
-      "label": "findProjectedRegisterSessionIdForRepairableMissingMapping()",
-      "norm_label": "findprojectedregistersessionidforrepairablemissingmapping()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L573"
+      "id": "verificationsweep_test_metrics",
+      "label": "metrics()",
+      "norm_label": "metrics()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1630"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_findtransactionidforsyncevent",
-      "label": "findTransactionIdForSyncEvent()",
-      "norm_label": "findtransactionidforsyncevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L536"
+      "id": "verificationsweep_test_missingdayresult",
+      "label": "missingDayResult()",
+      "norm_label": "missingdayresult()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1664"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_getsyncconflictreconciliationtype",
-      "label": "getSyncConflictReconciliationType()",
-      "norm_label": "getsyncconflictreconciliationtype()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L128"
+      "id": "verificationsweep_test_notificationintentsfor",
+      "label": "notificationIntentsFor()",
+      "norm_label": "notificationintentsfor()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L211"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_hasinventoryreviewworkitemforprojectedsale",
-      "label": "hasInventoryReviewWorkItemForProjectedSale()",
-      "norm_label": "hasinventoryreviewworkitemforprojectedsale()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L313"
+      "id": "verificationsweep_test_operationaleventsfor",
+      "label": "operationalEventsFor()",
+      "norm_label": "operationaleventsfor()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L193"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_isnonsalemissingregistersessionmappingconflict",
-      "label": "isNonSaleMissingRegisterSessionMappingConflict()",
-      "norm_label": "isnonsalemissingregistersessionmappingconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L391"
+      "id": "verificationsweep_test_patchday",
+      "label": "patchDay()",
+      "norm_label": "patchday()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L156"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersession",
-      "label": "listOpenLocalSyncConflictsByRegisterSession()",
-      "norm_label": "listopenlocalsyncconflictsbyregistersession()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L1159"
+      "id": "verificationsweep_test_posture",
+      "label": "posture()",
+      "norm_label": "posture()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1644"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_listopenlocalsyncconflictsbyregistersessionwithcompleteness",
-      "label": "listOpenLocalSyncConflictsByRegisterSessionWithCompleteness()",
-      "norm_label": "listopenlocalsyncconflictsbyregistersessionwithcompleteness()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L820"
+      "id": "verificationsweep_test_runrow",
+      "label": "runRow()",
+      "norm_label": "runrow()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L174"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_listtargetregistersessionsyncfacts",
-      "label": "listTargetRegisterSessionSyncFacts()",
-      "norm_label": "listtargetregistersessionsyncfacts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L641"
+      "id": "verificationsweep_test_seedfleet",
+      "label": "seedFleet()",
+      "norm_label": "seedfleet()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1736"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_numberdetail",
-      "label": "numberDetail()",
-      "norm_label": "numberdetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L289"
+      "id": "verificationsweep_test_seedstorewithday",
+      "label": "seedStoreWithDay()",
+      "norm_label": "seedstorewithday()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L309"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_recorddetail",
-      "label": "recordDetail()",
-      "norm_label": "recorddetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L417"
+      "id": "verificationsweep_test_seedweekcurrent",
+      "label": "seedWeekCurrent()",
+      "norm_label": "seedweekcurrent()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L885"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_stringdetail",
-      "label": "stringDetail()",
-      "norm_label": "stringdetail()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L298"
+      "id": "verificationsweep_test_seedweeklystore",
+      "label": "seedWeeklyStore()",
+      "norm_label": "seedweeklystore()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L2172"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_summarizesaleitems",
-      "label": "summarizeSaleItems()",
-      "norm_label": "summarizesaleitems()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L456"
+      "id": "verificationsweep_test_sweepctx",
+      "label": "sweepCtx()",
+      "norm_label": "sweepctx()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L84"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_syncconflicteventkey",
-      "label": "syncConflictEventKey()",
-      "norm_label": "syncconflicteventkey()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L307"
+      "id": "verificationsweep_test_verifiedats",
+      "label": "verifiedAts()",
+      "norm_label": "verifiedats()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1400"
     },
     {
       "community": 116,
       "file_type": "code",
-      "id": "registersessionsyncreview_uniquebyid",
-      "label": "uniqueById()",
-      "norm_label": "uniquebyid()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts",
-      "source_location": "L632"
+      "id": "verificationsweep_test_windowsoverticks",
+      "label": "windowsOverTicks()",
+      "norm_label": "windowsoverticks()",
+      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "source_location": "L1764"
     },
     {
       "community": 1160,
@@ -233124,182 +233136,182 @@
     {
       "community": 117,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_verificationsweep_test_ts",
-      "label": "verificationSweep.test.ts",
-      "norm_label": "verificationsweep.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
+      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
+      "label": "weekly.test.ts",
+      "norm_label": "weekly.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
       "source_location": "L1"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_allowlist",
-      "label": "allowlist()",
-      "norm_label": "allowlist()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L75"
+      "id": "weekly_test_baselineof",
+      "label": "baselineOf()",
+      "norm_label": "baselineof()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L1009"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_expecteddedupekey",
-      "label": "expectedDedupeKey()",
-      "norm_label": "expecteddedupekey()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L228"
+      "id": "weekly_test_cashonlymix",
+      "label": "cashOnlyMix()",
+      "norm_label": "cashonlymix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L983"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_insertexcludedfact",
-      "label": "insertExcludedFact()",
-      "norm_label": "insertexcludedfact()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L275"
+      "id": "weekly_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L136"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_insertreportday",
-      "label": "insertReportDay()",
-      "norm_label": "insertreportday()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L112"
+      "id": "weekly_test_fact",
+      "label": "fact()",
+      "norm_label": "fact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L169"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_insertvoidfact",
-      "label": "insertVoidFact()",
-      "norm_label": "insertvoidfact()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L247"
+      "id": "weekly_test_insertcompletedclose",
+      "label": "insertCompletedClose()",
+      "norm_label": "insertcompletedclose()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L502"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_metrics",
-      "label": "metrics()",
-      "norm_label": "metrics()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1630"
+      "id": "weekly_test_insertfact",
+      "label": "insertFact()",
+      "norm_label": "insertfact()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L473"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_missingdayresult",
-      "label": "missingDayResult()",
-      "norm_label": "missingdayresult()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1664"
+      "id": "weekly_test_insertfoldedcloseday",
+      "label": "insertFoldedCloseDay()",
+      "norm_label": "insertfoldedcloseday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L582"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_notificationintentsfor",
-      "label": "notificationIntentsFor()",
-      "norm_label": "notificationintentsfor()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L211"
+      "id": "weekly_test_inserthistoricalweekdays",
+      "label": "insertHistoricalWeekDays()",
+      "norm_label": "inserthistoricalweekdays()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L610"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_operationaleventsfor",
-      "label": "operationalEventsFor()",
-      "norm_label": "operationaleventsfor()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L193"
+      "id": "weekly_test_lanemix",
+      "label": "laneMix()",
+      "norm_label": "lanemix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L1349"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_patchday",
-      "label": "patchDay()",
-      "norm_label": "patchday()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L156"
+      "id": "weekly_test_linkclosetoday",
+      "label": "linkCloseToDay()",
+      "norm_label": "linkclosetoday()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3650"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_posture",
-      "label": "posture()",
-      "norm_label": "posture()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1644"
+      "id": "weekly_test_mix",
+      "label": "mix()",
+      "norm_label": "mix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L287"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_runrow",
-      "label": "runRow()",
-      "norm_label": "runrow()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L174"
+      "id": "weekly_test_patchscheduleexceptions",
+      "label": "patchScheduleExceptions()",
+      "norm_label": "patchscheduleexceptions()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3629"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_seedfleet",
-      "label": "seedFleet()",
-      "norm_label": "seedfleet()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1736"
+      "id": "weekly_test_period",
+      "label": "period()",
+      "norm_label": "period()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L118"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_seedstorewithday",
-      "label": "seedStoreWithDay()",
-      "norm_label": "seedstorewithday()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L309"
+      "id": "weekly_test_readbaseline",
+      "label": "readBaseline()",
+      "norm_label": "readbaseline()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3140"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_seedweekcurrent",
-      "label": "seedWeekCurrent()",
-      "norm_label": "seedweekcurrent()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L885"
+      "id": "weekly_test_readweekmark",
+      "label": "readWeekMark()",
+      "norm_label": "readweekmark()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L3131"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_seedweeklystore",
-      "label": "seedWeeklyStore()",
-      "norm_label": "seedweeklystore()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L2172"
+      "id": "weekly_test_receipt",
+      "label": "receipt()",
+      "norm_label": "receipt()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L916"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_sweepctx",
-      "label": "sweepCtx()",
-      "norm_label": "sweepctx()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L84"
+      "id": "weekly_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L434"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_verifiedats",
-      "label": "verifiedAts()",
-      "norm_label": "verifiedats()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1400"
+      "id": "weekly_test_seteverydaymix",
+      "label": "setEveryDayMix()",
+      "norm_label": "seteverydaymix()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L1356"
     },
     {
       "community": 117,
       "file_type": "code",
-      "id": "verificationsweep_test_windowsoverticks",
-      "label": "windowsOverTicks()",
-      "norm_label": "windowsoverticks()",
-      "source_file": "packages/athena-webapp/convex/reports/verificationSweep.test.ts",
-      "source_location": "L1764"
+      "id": "weekly_test_withcloses",
+      "label": "withCloses()",
+      "norm_label": "withcloses()",
+      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "source_location": "L635"
     },
     {
       "community": 1170,
@@ -233574,182 +233586,182 @@
     {
       "community": 118,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_weekly_test_ts",
-      "label": "weekly.test.ts",
-      "norm_label": "weekly.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
+      "id": "packages_athena_webapp_convex_shareddemo_provision_ts",
+      "label": "provision.ts",
+      "norm_label": "provision.ts",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
       "source_location": "L1"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_baselineof",
-      "label": "baselineOf()",
-      "norm_label": "baselineof()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L1009"
+      "id": "provision_buildshareddemocontinuitymigrationstatepatch",
+      "label": "buildSharedDemoContinuityMigrationStatePatch()",
+      "norm_label": "buildshareddemocontinuitymigrationstatepatch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L125"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_cashonlymix",
-      "label": "cashOnlyMix()",
-      "norm_label": "cashonlymix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L983"
+      "id": "provision_ensuredemocredentialwithctx",
+      "label": "ensureDemoCredentialWithCtx()",
+      "norm_label": "ensuredemocredentialwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L481"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L136"
+      "id": "provision_ensuredemoroleassignmentwithctx",
+      "label": "ensureDemoRoleAssignmentWithCtx()",
+      "norm_label": "ensuredemoroleassignmentwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L441"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_fact",
-      "label": "fact()",
-      "norm_label": "fact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L169"
+      "id": "provision_ensuredemostaffaccesswithctx",
+      "label": "ensureDemoStaffAccessWithCtx()",
+      "norm_label": "ensuredemostaffaccesswithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L518"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_insertcompletedclose",
-      "label": "insertCompletedClose()",
-      "norm_label": "insertcompletedclose()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L502"
+      "id": "provision_ensureshareddemoregisterfoundationwithctx",
+      "label": "ensureSharedDemoRegisterFoundationWithCtx()",
+      "norm_label": "ensureshareddemoregisterfoundationwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L980"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_insertfact",
-      "label": "insertFact()",
-      "norm_label": "insertfact()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L473"
+      "id": "provision_ensureshareddemoseededterminalwithctx",
+      "label": "ensureSharedDemoSeededTerminalWithCtx()",
+      "norm_label": "ensureshareddemoseededterminalwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L864"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_insertfoldedcloseday",
-      "label": "insertFoldedCloseDay()",
-      "norm_label": "insertfoldedcloseday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L582"
+      "id": "provision_migrateshareddemostorywithctx",
+      "label": "migrateSharedDemoStoryWithCtx()",
+      "norm_label": "migrateshareddemostorywithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L714"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_inserthistoricalweekdays",
-      "label": "insertHistoricalWeekDays()",
-      "norm_label": "inserthistoricalweekdays()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L610"
+      "id": "provision_planshareddemomigration",
+      "label": "planSharedDemoMigration()",
+      "norm_label": "planshareddemomigration()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L91"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_lanemix",
-      "label": "laneMix()",
-      "norm_label": "lanemix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L1349"
+      "id": "provision_reconcileshareddemocatalogwithctx",
+      "label": "reconcileSharedDemoCatalogWithCtx()",
+      "norm_label": "reconcileshareddemocatalogwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L583"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_linkclosetoday",
-      "label": "linkCloseToDay()",
-      "norm_label": "linkclosetoday()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3650"
+      "id": "provision_repairshareddemoseededterminalbindingwithctx",
+      "label": "repairSharedDemoSeededTerminalBindingWithCtx()",
+      "norm_label": "repairshareddemoseededterminalbindingwithctx()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L926"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_mix",
-      "label": "mix()",
-      "norm_label": "mix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L287"
+      "id": "provision_shareddemobootstrapseedmatches",
+      "label": "sharedDemoBootstrapSeedMatches()",
+      "norm_label": "shareddemobootstrapseedmatches()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L245"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_patchscheduleexceptions",
-      "label": "patchScheduleExceptions()",
-      "norm_label": "patchscheduleexceptions()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3629"
+      "id": "provision_shareddemocheckoutsessionmatchesorder",
+      "label": "sharedDemoCheckoutSessionMatchesOrder()",
+      "norm_label": "shareddemocheckoutsessionmatchesorder()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L420"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_period",
-      "label": "period()",
-      "norm_label": "period()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L118"
+      "id": "provision_shareddemomigrationskiptables",
+      "label": "sharedDemoMigrationSkipTables()",
+      "norm_label": "shareddemomigrationskiptables()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L84"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_readbaseline",
-      "label": "readBaseline()",
-      "norm_label": "readbaseline()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3140"
+      "id": "provision_shareddemopristinetablecountsmatch",
+      "label": "sharedDemoPristineTableCountsMatch()",
+      "norm_label": "shareddemopristinetablecountsmatch()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L405"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_readweekmark",
-      "label": "readWeekMark()",
-      "norm_label": "readweekmark()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L3131"
+      "id": "provision_shareddemoproductimages",
+      "label": "sharedDemoProductImages()",
+      "norm_label": "shareddemoproductimages()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L430"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_receipt",
-      "label": "receipt()",
-      "norm_label": "receipt()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L916"
+      "id": "provision_transformshareddemocatalogimagebaselinedocument",
+      "label": "transformSharedDemoCatalogImageBaselineDocument()",
+      "norm_label": "transformshareddemocatalogimagebaselinedocument()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L178"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L434"
+      "id": "provision_transformshareddemopickuporderbaselinedocument",
+      "label": "transformSharedDemoPickupOrderBaselineDocument()",
+      "norm_label": "transformshareddemopickuporderbaselinedocument()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L202"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_seteverydaymix",
-      "label": "setEveryDayMix()",
-      "norm_label": "seteverydaymix()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L1356"
+      "id": "provision_transformshareddemostaffstorybaselinedocument",
+      "label": "transformSharedDemoStaffStoryBaselineDocument()",
+      "norm_label": "transformshareddemostaffstorybaselinedocument()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L132"
     },
     {
       "community": 118,
       "file_type": "code",
-      "id": "weekly_test_withcloses",
-      "label": "withCloses()",
-      "norm_label": "withcloses()",
-      "source_file": "packages/athena-webapp/convex/reports/weekly.test.ts",
-      "source_location": "L635"
+      "id": "provision_validateshareddemoseed",
+      "label": "validateSharedDemoSeed()",
+      "norm_label": "validateshareddemoseed()",
+      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "source_location": "L235"
     },
     {
       "community": 1180,
@@ -234024,182 +234036,182 @@
     {
       "community": 119,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_shareddemo_provision_ts",
-      "label": "provision.ts",
-      "norm_label": "provision.ts",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
+      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
+      "label": "replenishment.ts",
+      "norm_label": "replenishment.ts",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
       "source_location": "L1"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_buildshareddemocontinuitymigrationstatepatch",
-      "label": "buildSharedDemoContinuityMigrationStatePatch()",
-      "norm_label": "buildshareddemocontinuitymigrationstatepatch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L125"
+      "id": "replenishment_buildguidance",
+      "label": "buildGuidance()",
+      "norm_label": "buildguidance()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L103"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_ensuredemocredentialwithctx",
-      "label": "ensureDemoCredentialWithCtx()",
-      "norm_label": "ensuredemocredentialwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L481"
+      "id": "replenishment_buildskucontinuitycontextbyid",
+      "label": "buildSkuContinuityContextById()",
+      "norm_label": "buildskucontinuitycontextbyid()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L339"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_ensuredemoroleassignmentwithctx",
-      "label": "ensureDemoRoleAssignmentWithCtx()",
-      "norm_label": "ensuredemoroleassignmentwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L441"
+      "id": "replenishment_derivecontinuitystatus",
+      "label": "deriveContinuityStatus()",
+      "norm_label": "derivecontinuitystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L493"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_ensuredemostaffaccesswithctx",
-      "label": "ensureDemoStaffAccessWithCtx()",
-      "norm_label": "ensuredemostaffaccesswithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L518"
+      "id": "replenishment_deriverecommendationstatus",
+      "label": "deriveRecommendationStatus()",
+      "norm_label": "deriverecommendationstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L482"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_ensureshareddemoregisterfoundationwithctx",
-      "label": "ensureSharedDemoRegisterFoundationWithCtx()",
-      "norm_label": "ensureshareddemoregisterfoundationwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L980"
+      "id": "replenishment_getcontinuitystatusrank",
+      "label": "getContinuityStatusRank()",
+      "norm_label": "getcontinuitystatusrank()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L78"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_ensureshareddemoseededterminalwithctx",
-      "label": "ensureSharedDemoSeededTerminalWithCtx()",
-      "norm_label": "ensureshareddemoseededterminalwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L864"
+      "id": "replenishment_getplannedactionat",
+      "label": "getPlannedActionAt()",
+      "norm_label": "getplannedactionat()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L265"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_migrateshareddemostorywithctx",
-      "label": "migrateSharedDemoStoryWithCtx()",
-      "norm_label": "migrateshareddemostorywithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L714"
+      "id": "replenishment_getstartofcurrentday",
+      "label": "getStartOfCurrentDay()",
+      "norm_label": "getstartofcurrentday()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L277"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_planshareddemomigration",
-      "label": "planSharedDemoMigration()",
-      "norm_label": "planshareddemomigration()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L91"
+      "id": "replenishment_haslateinbound",
+      "label": "hasLateInbound()",
+      "norm_label": "haslateinbound()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L295"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_reconcileshareddemocatalogwithctx",
-      "label": "reconcileSharedDemoCatalogWithCtx()",
-      "norm_label": "reconcileshareddemocatalogwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L583"
+      "id": "replenishment_hasrelatedpurchaseordercontext",
+      "label": "hasRelatedPurchaseOrderContext()",
+      "norm_label": "hasrelatedpurchaseordercontext()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L473"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_repairshareddemoseededterminalbindingwithctx",
-      "label": "repairSharedDemoSeededTerminalBindingWithCtx()",
-      "norm_label": "repairshareddemoseededterminalbindingwithctx()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L926"
+      "id": "replenishment_hasstaleplannedaction",
+      "label": "hasStalePlannedAction()",
+      "norm_label": "hasstaleplannedaction()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L287"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_shareddemobootstrapseedmatches",
-      "label": "sharedDemoBootstrapSeedMatches()",
-      "norm_label": "shareddemobootstrapseedmatches()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L245"
+      "id": "replenishment_isinboundstatus",
+      "label": "isInboundStatus()",
+      "norm_label": "isinboundstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L259"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_shareddemocheckoutsessionmatchesorder",
-      "label": "sharedDemoCheckoutSessionMatchesOrder()",
-      "norm_label": "shareddemocheckoutsessionmatchesorder()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L420"
+      "id": "replenishment_isplannedstatus",
+      "label": "isPlannedStatus()",
+      "norm_label": "isplannedstatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L253"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_shareddemomigrationskiptables",
-      "label": "sharedDemoMigrationSkipTables()",
-      "norm_label": "shareddemomigrationskiptables()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L84"
+      "id": "replenishment_listactivestorevendors",
+      "label": "listActiveStoreVendors()",
+      "norm_label": "listactivestorevendors()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L210"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_shareddemopristinetablecountsmatch",
-      "label": "sharedDemoPristineTableCountsMatch()",
-      "norm_label": "shareddemopristinetablecountsmatch()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L405"
+      "id": "replenishment_listboundedreplenishmentrecommendationswithctx",
+      "label": "listBoundedReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listboundedreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L572"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_shareddemoproductimages",
-      "label": "sharedDemoProductImages()",
-      "norm_label": "shareddemoproductimages()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L430"
+      "id": "replenishment_listpurchaseorderlineitems",
+      "label": "listPurchaseOrderLineItems()",
+      "norm_label": "listpurchaseorderlineitems()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L229"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_transformshareddemocatalogimagebaselinedocument",
-      "label": "transformSharedDemoCatalogImageBaselineDocument()",
-      "norm_label": "transformshareddemocatalogimagebaselinedocument()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L178"
+      "id": "replenishment_listreplenishmentrecommendationswithctx",
+      "label": "listReplenishmentRecommendationsWithCtx()",
+      "norm_label": "listreplenishmentrecommendationswithctx()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L550"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_transformshareddemopickuporderbaselinedocument",
-      "label": "transformSharedDemoPickupOrderBaselineDocument()",
-      "norm_label": "transformshareddemopickuporderbaselinedocument()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L202"
+      "id": "replenishment_liststoreproductskus",
+      "label": "listStoreProductSkus()",
+      "norm_label": "liststoreproductskus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L153"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_transformshareddemostaffstorybaselinedocument",
-      "label": "transformSharedDemoStaffStoryBaselineDocument()",
-      "norm_label": "transformshareddemostaffstorybaselinedocument()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L132"
+      "id": "replenishment_liststorepurchaseordersbystatus",
+      "label": "listStorePurchaseOrdersByStatus()",
+      "norm_label": "liststorepurchaseordersbystatus()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L183"
     },
     {
       "community": 119,
       "file_type": "code",
-      "id": "provision_validateshareddemoseed",
-      "label": "validateSharedDemoSeed()",
-      "norm_label": "validateshareddemoseed()",
-      "source_file": "packages/athena-webapp/convex/sharedDemo/provision.ts",
-      "source_location": "L235"
+      "id": "replenishment_sortpurchaseordercontexts",
+      "label": "sortPurchaseOrderContexts()",
+      "norm_label": "sortpurchaseordercontexts()",
+      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "source_location": "L306"
     },
     {
       "community": 1190,
@@ -234915,182 +234927,182 @@
     {
       "community": 120,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_stockops_replenishment_ts",
-      "label": "replenishment.ts",
-      "norm_label": "replenishment.ts",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
+      "id": "athenaagentpresentationadapter_composeathenathreadkey",
+      "label": "composeAthenaThreadKey()",
+      "norm_label": "composeathenathreadkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenacontext",
+      "label": "describeAthenaContext()",
+      "norm_label": "describeathenacontext()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L126"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenadenial",
+      "label": "describeAthenaDenial()",
+      "norm_label": "describeathenadenial()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L324"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenafailure",
+      "label": "describeAthenaFailure()",
+      "norm_label": "describeathenafailure()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L503"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenamilestone",
+      "label": "describeAthenaMilestone()",
+      "norm_label": "describeathenamilestone()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L532"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenaprovisionalcue",
+      "label": "describeAthenaProvisionalCue()",
+      "norm_label": "describeathenaprovisionalcue()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L548"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenaprovisionaltimelineempty",
+      "label": "describeAthenaProvisionalTimelineEmpty()",
+      "norm_label": "describeathenaprovisionaltimelineempty()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L553"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenashortenednotice",
+      "label": "describeAthenaShortenedNotice()",
+      "norm_label": "describeathenashortenednotice()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L558"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenatrailunavailable",
+      "label": "describeAthenaTrailUnavailable()",
+      "norm_label": "describeathenatrailunavailable()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L390"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeathenaunavailable",
+      "label": "describeAthenaUnavailable()",
+      "norm_label": "describeathenaunavailable()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L401"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_describeprovisionalwithdrawal",
+      "label": "describeProvisionalWithdrawal()",
+      "norm_label": "describeprovisionalwithdrawal()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L605"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_displayvalueforcontextkey",
+      "label": "displayValueForContextKey()",
+      "norm_label": "displayvalueforcontextkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L119"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_encodethreadkey",
+      "label": "encodeThreadKey()",
+      "norm_label": "encodethreadkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L64"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_hashtoken",
+      "label": "hashToken()",
+      "norm_label": "hashtoken()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_isthreadkeysafecharacter",
+      "label": "isThreadKeySafeCharacter()",
+      "norm_label": "isthreadkeysafecharacter()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L46"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_labelforcontextkey",
+      "label": "labelForContextKey()",
+      "norm_label": "labelforcontextkey()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L112"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_resolveathenasourcelink",
+      "label": "resolveAthenaSourceLink()",
+      "norm_label": "resolveathenasourcelink()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L214"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_snapshotathenacontext",
+      "label": "snapshotAthenaContext()",
+      "norm_label": "snapshotathenacontext()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L168"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "athenaagentpresentationadapter_truncatetobytes",
+      "label": "truncateToBytes()",
+      "norm_label": "truncatetobytes()",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 120,
+      "file_type": "code",
+      "id": "packages_athena_webapp_src_components_agent_athenaagentpresentationadapter_ts",
+      "label": "AthenaAgentPresentationAdapter.ts",
+      "norm_label": "athenaagentpresentationadapter.ts",
+      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_buildguidance",
-      "label": "buildGuidance()",
-      "norm_label": "buildguidance()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L103"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_buildskucontinuitycontextbyid",
-      "label": "buildSkuContinuityContextById()",
-      "norm_label": "buildskucontinuitycontextbyid()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L339"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_derivecontinuitystatus",
-      "label": "deriveContinuityStatus()",
-      "norm_label": "derivecontinuitystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L493"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_deriverecommendationstatus",
-      "label": "deriveRecommendationStatus()",
-      "norm_label": "deriverecommendationstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L482"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_getcontinuitystatusrank",
-      "label": "getContinuityStatusRank()",
-      "norm_label": "getcontinuitystatusrank()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L78"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_getplannedactionat",
-      "label": "getPlannedActionAt()",
-      "norm_label": "getplannedactionat()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_getstartofcurrentday",
-      "label": "getStartOfCurrentDay()",
-      "norm_label": "getstartofcurrentday()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L277"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_haslateinbound",
-      "label": "hasLateInbound()",
-      "norm_label": "haslateinbound()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L295"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_hasrelatedpurchaseordercontext",
-      "label": "hasRelatedPurchaseOrderContext()",
-      "norm_label": "hasrelatedpurchaseordercontext()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L473"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_hasstaleplannedaction",
-      "label": "hasStalePlannedAction()",
-      "norm_label": "hasstaleplannedaction()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L287"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_isinboundstatus",
-      "label": "isInboundStatus()",
-      "norm_label": "isinboundstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L259"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_isplannedstatus",
-      "label": "isPlannedStatus()",
-      "norm_label": "isplannedstatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L253"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_listactivestorevendors",
-      "label": "listActiveStoreVendors()",
-      "norm_label": "listactivestorevendors()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L210"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_listboundedreplenishmentrecommendationswithctx",
-      "label": "listBoundedReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listboundedreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L572"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_listpurchaseorderlineitems",
-      "label": "listPurchaseOrderLineItems()",
-      "norm_label": "listpurchaseorderlineitems()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_listreplenishmentrecommendationswithctx",
-      "label": "listReplenishmentRecommendationsWithCtx()",
-      "norm_label": "listreplenishmentrecommendationswithctx()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L550"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_liststoreproductskus",
-      "label": "listStoreProductSkus()",
-      "norm_label": "liststoreproductskus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L153"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_liststorepurchaseordersbystatus",
-      "label": "listStorePurchaseOrdersByStatus()",
-      "norm_label": "liststorepurchaseordersbystatus()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L183"
-    },
-    {
-      "community": 120,
-      "file_type": "code",
-      "id": "replenishment_sortpurchaseordercontexts",
-      "label": "sortPurchaseOrderContexts()",
-      "norm_label": "sortpurchaseordercontexts()",
-      "source_file": "packages/athena-webapp/convex/stockOps/replenishment.ts",
-      "source_location": "L306"
     },
     {
       "community": 1200,
@@ -235365,181 +235377,181 @@
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_composeathenathreadkey",
-      "label": "composeAthenaThreadKey()",
-      "norm_label": "composeathenathreadkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L85"
+      "id": "importboundary_test_collectsources",
+      "label": "collectSources()",
+      "norm_label": "collectsources()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L30"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenacontext",
-      "label": "describeAthenaContext()",
-      "norm_label": "describeathenacontext()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L126"
+      "id": "importboundary_test_finddisallowedimports",
+      "label": "findDisallowedImports()",
+      "norm_label": "finddisallowedimports()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L102"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenadenial",
-      "label": "describeAthenaDenial()",
-      "norm_label": "describeathenadenial()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L324"
+      "id": "importboundary_test_findindirectcomponentmountviolations",
+      "label": "findIndirectComponentMountViolations()",
+      "norm_label": "findindirectcomponentmountviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L273"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenafailure",
-      "label": "describeAthenaFailure()",
-      "norm_label": "describeathenafailure()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L503"
+      "id": "importboundary_test_findkernelimportviolations",
+      "label": "findKernelImportViolations()",
+      "norm_label": "findkernelimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L144"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenamilestone",
-      "label": "describeAthenaMilestone()",
-      "norm_label": "describeathenamilestone()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L532"
+      "id": "importboundary_test_findleafimportviolations",
+      "label": "findLeafImportViolations()",
+      "norm_label": "findleafimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L191"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenaprovisionalcue",
-      "label": "describeAthenaProvisionalCue()",
-      "norm_label": "describeathenaprovisionalcue()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L548"
+      "id": "importboundary_test_findproductsurfaceimports",
+      "label": "findProductSurfaceImports()",
+      "norm_label": "findproductsurfaceimports()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L116"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenaprovisionaltimelineempty",
-      "label": "describeAthenaProvisionalTimelineEmpty()",
-      "norm_label": "describeathenaprovisionaltimelineempty()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L553"
+      "id": "importboundary_test_findprofileimportviolations",
+      "label": "findProfileImportViolations()",
+      "norm_label": "findprofileimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L338"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenashortenednotice",
-      "label": "describeAthenaShortenedNotice()",
-      "norm_label": "describeathenashortenednotice()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L558"
+      "id": "importboundary_test_findregistrationshimviolations",
+      "label": "findRegistrationShimViolations()",
+      "norm_label": "findregistrationshimviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L264"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenatrailunavailable",
-      "label": "describeAthenaTrailUnavailable()",
-      "norm_label": "describeathenatrailunavailable()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L390"
+      "id": "importboundary_test_findrootconvexconfigviolations",
+      "label": "findRootConvexConfigViolations()",
+      "norm_label": "findrootconvexconfigviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L251"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeathenaunavailable",
-      "label": "describeAthenaUnavailable()",
-      "norm_label": "describeathenaunavailable()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L401"
+      "id": "importboundary_test_findruntimenativeidentifierviolations",
+      "label": "findRuntimeNativeIdentifierViolations()",
+      "norm_label": "findruntimenativeidentifierviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L286"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_describeprovisionalwithdrawal",
-      "label": "describeProvisionalWithdrawal()",
-      "norm_label": "describeprovisionalwithdrawal()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L605"
+      "id": "importboundary_test_findruntimenativeimportviolations",
+      "label": "findRuntimeNativeImportViolations()",
+      "norm_label": "findruntimenativeimportviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L237"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_displayvalueforcontextkey",
-      "label": "displayValueForContextKey()",
-      "norm_label": "displayvalueforcontextkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L119"
+      "id": "importboundary_test_findruntimenativeviolations",
+      "label": "findRuntimeNativeViolations()",
+      "norm_label": "findruntimenativeviolations()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
+      "source_location": "L128"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_encodethreadkey",
-      "label": "encodeThreadKey()",
-      "norm_label": "encodethreadkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L64"
+      "id": "importboundary_test_findsharedcontractviolations",
+      "label": "findSharedContractViolations()",
+      "norm_label": "findsharedcontractviolations()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L305"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_hashtoken",
-      "label": "hashToken()",
-      "norm_label": "hashtoken()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L50"
+      "id": "importboundary_test_fixture",
+      "label": "fixture()",
+      "norm_label": "fixture()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L358"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_isthreadkeysafecharacter",
-      "label": "isThreadKeySafeCharacter()",
-      "norm_label": "isthreadkeysafecharacter()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "id": "importboundary_test_importsof",
+      "label": "importsOf()",
+      "norm_label": "importsof()",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
       "source_location": "L46"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_labelforcontextkey",
-      "label": "labelForContextKey()",
-      "norm_label": "labelforcontextkey()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L112"
+      "id": "importboundary_test_iscompositionroot",
+      "label": "isCompositionRoot()",
+      "norm_label": "iscompositionroot()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L126"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_resolveathenasourcelink",
-      "label": "resolveAthenaSourceLink()",
-      "norm_label": "resolveathenasourcelink()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L214"
+      "id": "importboundary_test_iskernelmodule",
+      "label": "isKernelModule()",
+      "norm_label": "iskernelmodule()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L130"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_snapshotathenacontext",
-      "label": "snapshotAthenaContext()",
-      "norm_label": "snapshotathenacontext()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L168"
+      "id": "importboundary_test_isruntimenativespecifier",
+      "label": "isRuntimeNativeSpecifier()",
+      "norm_label": "isruntimenativespecifier()",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L233"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "athenaagentpresentationadapter_truncatetobytes",
-      "label": "truncateToBytes()",
-      "norm_label": "truncatetobytes()",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
-      "source_location": "L154"
+      "id": "packages_athena_webapp_convex_agentharness_importboundary_test_ts",
+      "label": "importBoundary.test.ts",
+      "norm_label": "importboundary.test.ts",
+      "source_file": "packages/athena-webapp/convex/agentHarness/importBoundary.test.ts",
+      "source_location": "L1"
     },
     {
       "community": 121,
       "file_type": "code",
-      "id": "packages_athena_webapp_src_components_agent_athenaagentpresentationadapter_ts",
-      "label": "AthenaAgentPresentationAdapter.ts",
-      "norm_label": "athenaagentpresentationadapter.ts",
-      "source_file": "packages/athena-webapp/src/components/agent/AthenaAgentPresentationAdapter.ts",
+      "id": "packages_athena_webapp_src_components_agent_importboundary_test_ts",
+      "label": "importBoundary.test.ts",
+      "norm_label": "importboundary.test.ts",
+      "source_file": "packages/athena-webapp/src/components/agent/importBoundary.test.ts",
       "source_location": "L1"
     },
     {
@@ -270973,7 +270985,7 @@
       "label": "createCommandArgs()",
       "norm_label": "createcommandargs()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L6447"
+      "source_location": "L6495"
     },
     {
       "community": 210,
@@ -271054,7 +271066,7 @@
       "label": "syncedReview()",
       "norm_label": "syncedreview()",
       "source_file": "packages/athena-webapp/convex/operations/dailyClose.test.ts",
-      "source_location": "L1932"
+      "source_location": "L1980"
     },
     {
       "community": 210,
@@ -296358,92 +296370,92 @@
     {
       "community": 316,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
-      "label": "walkthroughConfig.ts",
-      "norm_label": "walkthroughconfig.ts",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "id": "index_resolveverificationcoderecipient",
+      "label": "resolveVerificationCodeRecipient()",
+      "norm_label": "resolveverificationcoderecipient()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L19"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_senddailymanagerreportemail",
+      "label": "sendDailyManagerReportEmail()",
+      "norm_label": "senddailymanagerreportemail()",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
+      "source_location": "L377"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_senddiscountcodeemail",
+      "label": "sendDiscountCodeEmail()",
+      "norm_label": "senddiscountcodeemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L255"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_senddiscountreminderemail",
+      "label": "sendDiscountReminderEmail()",
+      "norm_label": "senddiscountreminderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L334"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_sendfeedbackrequestemail",
+      "label": "sendFeedbackRequestEmail()",
+      "norm_label": "sendfeedbackrequestemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L167"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_sendneworderemail",
+      "label": "sendNewOrderEmail()",
+      "norm_label": "sendneworderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L117"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_sendorderemail",
+      "label": "sendOrderEmail()",
+      "norm_label": "sendorderemail()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L43"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "index_sendverificationcode",
+      "label": "sendVerificationCode()",
+      "norm_label": "sendverificationcode()",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L3"
+    },
+    {
+      "community": 316,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
       "source_location": "L1"
     },
     {
       "community": 316,
       "file_type": "code",
-      "id": "walkthroughconfig_landingfunnelhourlylimit",
-      "label": "landingFunnelHourlyLimit()",
-      "norm_label": "landingfunnelhourlylimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L85"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_parseboundedpositiveinteger",
-      "label": "parseBoundedPositiveInteger()",
-      "norm_label": "parseboundedpositiveinteger()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L8"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
-      "label": "resolveWalkthroughAllowedOrigins()",
-      "norm_label": "resolvewalkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L26"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughallowedorigins",
-      "label": "walkthroughAllowedOrigins()",
-      "norm_label": "walkthroughallowedorigins()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L38"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
-      "label": "walkthroughDailyPerEmailLimit()",
-      "norm_label": "walkthroughdailyperemaillimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L55"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlygloballimit",
-      "label": "walkthroughHourlyGlobalLimit()",
-      "norm_label": "walkthroughhourlygloballimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L65"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
-      "label": "walkthroughHourlyNotificationLimit()",
-      "norm_label": "walkthroughhourlynotificationlimit()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L75"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughmaxbodybytes",
-      "label": "walkthroughMaxBodyBytes()",
-      "norm_label": "walkthroughmaxbodybytes()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L45"
-    },
-    {
-      "community": 316,
-      "file_type": "code",
-      "id": "walkthroughconfig_walkthroughprivacycontact",
-      "label": "walkthroughPrivacyContact()",
-      "norm_label": "walkthroughprivacycontact()",
-      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
-      "source_location": "L95"
+      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
+      "label": "index.tsx",
+      "norm_label": "index.tsx",
+      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
+      "source_location": "L1"
     },
     {
       "community": 3160,
@@ -296538,91 +296550,91 @@
     {
       "community": 317,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operationadmission_domains_storefrontoperator_readdefinitions_ts",
-      "label": "storefrontOperator_readDefinitions.ts",
-      "norm_label": "storefrontoperator_readdefinitions.ts",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "id": "packages_athena_webapp_convex_marketing_walkthroughconfig_ts",
+      "label": "walkthroughConfig.ts",
+      "norm_label": "walkthroughconfig.ts",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L1"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_analyticsread",
-      "label": "analyticsRead()",
-      "norm_label": "analyticsread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L121"
+      "id": "walkthroughconfig_landingfunnelhourlylimit",
+      "label": "landingFunnelHourlyLimit()",
+      "norm_label": "landingfunnelhourlylimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L85"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_checkoutsessionorderscope",
-      "label": "checkoutSessionOrderScope()",
-      "norm_label": "checkoutsessionorderscope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L70"
+      "id": "walkthroughconfig_parseboundedpositiveinteger",
+      "label": "parseBoundedPositiveInteger()",
+      "norm_label": "parseboundedpositiveinteger()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L8"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_externalreferenceorderscope",
-      "label": "externalReferenceOrderScope()",
-      "norm_label": "externalreferenceorderscope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L80"
+      "id": "walkthroughconfig_resolvewalkthroughallowedorigins",
+      "label": "resolveWalkthroughAllowedOrigins()",
+      "norm_label": "resolvewalkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L26"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_idarg",
-      "label": "idArg()",
-      "norm_label": "idarg()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L34"
+      "id": "walkthroughconfig_walkthroughallowedorigins",
+      "label": "walkthroughAllowedOrigins()",
+      "norm_label": "walkthroughallowedorigins()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L38"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_onlineorderread",
-      "label": "onlineOrderRead()",
-      "norm_label": "onlineorderread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L202"
+      "id": "walkthroughconfig_walkthroughdailyperemaillimit",
+      "label": "walkthroughDailyPerEmailLimit()",
+      "norm_label": "walkthroughdailyperemaillimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L55"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_reviewread",
-      "label": "reviewRead()",
-      "norm_label": "reviewread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L263"
+      "id": "walkthroughconfig_walkthroughhourlygloballimit",
+      "label": "walkthroughHourlyGlobalLimit()",
+      "norm_label": "walkthroughhourlygloballimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L65"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_rowstorescope",
-      "label": "rowStoreScope()",
-      "norm_label": "rowstorescope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L40"
+      "id": "walkthroughconfig_walkthroughhourlynotificationlimit",
+      "label": "walkthroughHourlyNotificationLimit()",
+      "norm_label": "walkthroughhourlynotificationlimit()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L75"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_storefrontactorstorescope",
-      "label": "storeFrontActorStoreScope()",
-      "norm_label": "storefrontactorstorescope()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
-      "source_location": "L52"
+      "id": "walkthroughconfig_walkthroughmaxbodybytes",
+      "label": "walkthroughMaxBodyBytes()",
+      "norm_label": "walkthroughmaxbodybytes()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
+      "source_location": "L45"
     },
     {
       "community": 317,
       "file_type": "code",
-      "id": "storefrontoperator_readdefinitions_storefrontread",
-      "label": "storeFrontRead()",
-      "norm_label": "storefrontread()",
-      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "id": "walkthroughconfig_walkthroughprivacycontact",
+      "label": "walkthroughPrivacyContact()",
+      "norm_label": "walkthroughprivacycontact()",
+      "source_file": "packages/athena-webapp/convex/marketing/walkthroughConfig.ts",
       "source_location": "L95"
     },
     {
@@ -296718,92 +296730,92 @@
     {
       "community": 318,
       "file_type": "code",
-      "id": "adjustmentreports_adjustmentappliedat",
-      "label": "adjustmentAppliedAt()",
-      "norm_label": "adjustmentappliedat()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L101"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentsalesdelta",
-      "label": "adjustmentSalesDelta()",
-      "norm_label": "adjustmentsalesdelta()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L116"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmentsettlementamount",
-      "label": "adjustmentSettlementAmount()",
-      "norm_label": "adjustmentsettlementamount()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L143"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_adjustmenttransactionid",
-      "label": "adjustmentTransactionId()",
-      "norm_label": "adjustmenttransactionid()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L110"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentpaymenttotals",
-      "label": "buildAdjustmentPaymentTotals()",
-      "norm_label": "buildadjustmentpaymenttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L242"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_buildadjustmentreporttotals",
-      "label": "buildAdjustmentReportTotals()",
-      "norm_label": "buildadjustmentreporttotals()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L275"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
-      "label": "listAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "listappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L229"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
-      "label": "readAppliedTransactionAdjustmentsForDay()",
-      "norm_label": "readappliedtransactionadjustmentsforday()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L173"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "adjustmentreports_sourcecompletenessentry",
-      "label": "sourceCompletenessEntry()",
-      "norm_label": "sourcecompletenessentry()",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
-      "source_location": "L76"
-    },
-    {
-      "community": 318,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
-      "label": "adjustmentReports.ts",
-      "norm_label": "adjustmentreports.ts",
-      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "id": "packages_athena_webapp_convex_operationadmission_domains_storefrontoperator_readdefinitions_ts",
+      "label": "storefrontOperator_readDefinitions.ts",
+      "norm_label": "storefrontoperator_readdefinitions.ts",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_analyticsread",
+      "label": "analyticsRead()",
+      "norm_label": "analyticsread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L121"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_checkoutsessionorderscope",
+      "label": "checkoutSessionOrderScope()",
+      "norm_label": "checkoutsessionorderscope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L70"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_externalreferenceorderscope",
+      "label": "externalReferenceOrderScope()",
+      "norm_label": "externalreferenceorderscope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L80"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_idarg",
+      "label": "idArg()",
+      "norm_label": "idarg()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L34"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_onlineorderread",
+      "label": "onlineOrderRead()",
+      "norm_label": "onlineorderread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L202"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_reviewread",
+      "label": "reviewRead()",
+      "norm_label": "reviewread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L263"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_rowstorescope",
+      "label": "rowStoreScope()",
+      "norm_label": "rowstorescope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_storefrontactorstorescope",
+      "label": "storeFrontActorStoreScope()",
+      "norm_label": "storefrontactorstorescope()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L52"
+    },
+    {
+      "community": 318,
+      "file_type": "code",
+      "id": "storefrontoperator_readdefinitions_storefrontread",
+      "label": "storeFrontRead()",
+      "norm_label": "storefrontread()",
+      "source_file": "packages/athena-webapp/convex/operationAdmission/domains/storefrontOperator_readDefinitions.ts",
+      "source_location": "L95"
     },
     {
       "community": 3180,
@@ -296898,91 +296910,91 @@
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_assertnobusinesseventconflict",
-      "label": "assertNoBusinessEventConflict()",
-      "norm_label": "assertnobusinesseventconflict()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L178"
+      "id": "adjustmentreports_adjustmentappliedat",
+      "label": "adjustmentAppliedAt()",
+      "norm_label": "adjustmentappliedat()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L101"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_buildinventorymovement",
-      "label": "buildInventoryMovement()",
-      "norm_label": "buildinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L124"
+      "id": "adjustmentreports_adjustmentsalesdelta",
+      "label": "adjustmentSalesDelta()",
+      "norm_label": "adjustmentsalesdelta()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L116"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_buildskuactivityforinventorymovement",
-      "label": "buildSkuActivityForInventoryMovement()",
-      "norm_label": "buildskuactivityforinventorymovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L66"
+      "id": "adjustmentreports_adjustmentsettlementamount",
+      "label": "adjustmentSettlementAmount()",
+      "norm_label": "adjustmentsettlementamount()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L143"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_getskuactivitytypeformovement",
-      "label": "getSkuActivityTypeForMovement()",
-      "norm_label": "getskuactivitytypeformovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L49"
+      "id": "adjustmentreports_adjustmenttransactionid",
+      "label": "adjustmentTransactionId()",
+      "norm_label": "adjustmenttransactionid()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L110"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_matchesexistingmovement",
-      "label": "matchesExistingMovement()",
-      "norm_label": "matchesexistingmovement()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L150"
+      "id": "adjustmentreports_buildadjustmentpaymenttotals",
+      "label": "buildAdjustmentPaymentTotals()",
+      "norm_label": "buildadjustmentpaymenttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L242"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithctx",
-      "label": "recordInventoryMovementWithCtx()",
-      "norm_label": "recordinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L200"
+      "id": "adjustmentreports_buildadjustmentreporttotals",
+      "label": "buildAdjustmentReportTotals()",
+      "norm_label": "buildadjustmentreporttotals()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L275"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
-      "label": "recordInventoryMovementWithDispositionWithCtx()",
-      "norm_label": "recordinventorymovementwithdispositionwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L245"
+      "id": "adjustmentreports_listappliedtransactionadjustmentsforday",
+      "label": "listAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "listappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L229"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
-      "label": "recordSkuActivityForInventoryMovementWithCtx()",
-      "norm_label": "recordskuactivityforinventorymovementwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L111"
+      "id": "adjustmentreports_readappliedtransactionadjustmentsforday",
+      "label": "readAppliedTransactionAdjustmentsForDay()",
+      "norm_label": "readappliedtransactionadjustmentsforday()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L173"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "inventorymovements_summarizeinventorymovements",
-      "label": "summarizeInventoryMovements()",
-      "norm_label": "summarizeinventorymovements()",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
-      "source_location": "L135"
+      "id": "adjustmentreports_sourcecompletenessentry",
+      "label": "sourceCompletenessEntry()",
+      "norm_label": "sourcecompletenessentry()",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
+      "source_location": "L76"
     },
     {
       "community": 319,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
-      "label": "inventoryMovements.ts",
-      "norm_label": "inventorymovements.ts",
-      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "id": "packages_athena_webapp_convex_operations_dailyclose_adjustmentreports_ts",
+      "label": "adjustmentReports.ts",
+      "norm_label": "adjustmentreports.ts",
+      "source_file": "packages/athena-webapp/convex/operations/dailyClose/adjustmentReports.ts",
       "source_location": "L1"
     },
     {
@@ -297411,91 +297423,91 @@
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
-      "label": "amendRepairWithCtx()",
-      "norm_label": "amendrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L434"
+      "id": "inventorymovements_assertnobusinesseventconflict",
+      "label": "assertNoBusinessEventConflict()",
+      "norm_label": "assertnobusinesseventconflict()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L178"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_createrepairwithctx",
-      "label": "createRepairWithCtx()",
-      "norm_label": "createrepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L161"
+      "id": "inventorymovements_buildinventorymovement",
+      "label": "buildInventoryMovement()",
+      "norm_label": "buildinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L124"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_pauserepair",
-      "label": "pauseRepair()",
-      "norm_label": "pauserepair()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L235"
+      "id": "inventorymovements_buildskuactivityforinventorymovement",
+      "label": "buildSkuActivityForInventoryMovement()",
+      "norm_label": "buildskuactivityforinventorymovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L66"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
-      "label": "processRepairBatchWithCtx()",
-      "norm_label": "processrepairbatchwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L253"
+      "id": "inventorymovements_getskuactivitytypeformovement",
+      "label": "getSkuActivityTypeForMovement()",
+      "norm_label": "getskuactivitytypeformovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L49"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_readcurrentgroup",
-      "label": "readCurrentGroup()",
-      "norm_label": "readcurrentgroup()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L50"
+      "id": "inventorymovements_matchesexistingmovement",
+      "label": "matchesExistingMovement()",
+      "norm_label": "matchesexistingmovement()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L150"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
-      "label": "recordRepairAuditEvent()",
-      "norm_label": "recordrepairauditevent()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L86"
+      "id": "inventorymovements_recordinventorymovementwithctx",
+      "label": "recordInventoryMovementWithCtx()",
+      "norm_label": "recordinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L200"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_requireevidence",
-      "label": "requireEvidence()",
-      "norm_label": "requireevidence()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L38"
+      "id": "inventorymovements_recordinventorymovementwithdispositionwithctx",
+      "label": "recordInventoryMovementWithDispositionWithCtx()",
+      "norm_label": "recordinventorymovementwithdispositionwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L245"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
-      "label": "resumeRepairWithCtx()",
-      "norm_label": "resumerepairwithctx()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L476"
+      "id": "inventorymovements_recordskuactivityforinventorymovementwithctx",
+      "label": "recordSkuActivityForInventoryMovementWithCtx()",
+      "norm_label": "recordskuactivityforinventorymovementwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L111"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "oversizedoperationalworkrepair_schedulenextbatch",
-      "label": "scheduleNextBatch()",
-      "norm_label": "schedulenextbatch()",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
-      "source_location": "L154"
+      "id": "inventorymovements_summarizeinventorymovements",
+      "label": "summarizeInventoryMovements()",
+      "norm_label": "summarizeinventorymovements()",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
+      "source_location": "L135"
     },
     {
       "community": 320,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
-      "label": "oversizedOperationalWorkRepair.ts",
-      "norm_label": "oversizedoperationalworkrepair.ts",
-      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "id": "packages_athena_webapp_convex_operations_inventorymovements_ts",
+      "label": "inventoryMovements.ts",
+      "norm_label": "inventorymovements.ts",
+      "source_file": "packages/athena-webapp/convex/operations/inventoryMovements.ts",
       "source_location": "L1"
     },
     {
@@ -297591,92 +297603,92 @@
     {
       "community": 321,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
-      "label": "registerSessionTracing.ts",
-      "norm_label": "registersessiontracing.ts",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "id": "oversizedoperationalworkrepair_amendrepairwithctx",
+      "label": "amendRepairWithCtx()",
+      "norm_label": "amendrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L434"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_createrepairwithctx",
+      "label": "createRepairWithCtx()",
+      "norm_label": "createrepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L161"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_pauserepair",
+      "label": "pauseRepair()",
+      "norm_label": "pauserepair()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L235"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_processrepairbatchwithctx",
+      "label": "processRepairBatchWithCtx()",
+      "norm_label": "processrepairbatchwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L253"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_readcurrentgroup",
+      "label": "readCurrentGroup()",
+      "norm_label": "readcurrentgroup()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_recordrepairauditevent",
+      "label": "recordRepairAuditEvent()",
+      "norm_label": "recordrepairauditevent()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L86"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_requireevidence",
+      "label": "requireEvidence()",
+      "norm_label": "requireevidence()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L38"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_resumerepairwithctx",
+      "label": "resumeRepairWithCtx()",
+      "norm_label": "resumerepairwithctx()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L476"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "oversizedoperationalworkrepair_schedulenextbatch",
+      "label": "scheduleNextBatch()",
+      "norm_label": "schedulenextbatch()",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
+      "source_location": "L154"
+    },
+    {
+      "community": 321,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_oversizedoperationalworkrepair_ts",
+      "label": "oversizedOperationalWorkRepair.ts",
+      "norm_label": "oversizedoperationalworkrepair.ts",
+      "source_file": "packages/athena-webapp/convex/operations/oversizedOperationalWorkRepair.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_buildactorrefs",
-      "label": "buildActorRefs()",
-      "norm_label": "buildactorrefs()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L102"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtraceevent",
-      "label": "buildTraceEvent()",
-      "norm_label": "buildtraceevent()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L197"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_buildtracerecord",
-      "label": "buildTraceRecord()",
-      "norm_label": "buildtracerecord()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L162"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_displaytraceamount",
-      "label": "displayTraceAmount()",
-      "norm_label": "displaytraceamount()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L115"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_formattransactionlabel",
-      "label": "formatTransactionLabel()",
-      "norm_label": "formattransactionlabel()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L133"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_recordregistersessiontracebesteffort",
-      "label": "recordRegisterSessionTraceBestEffort()",
-      "norm_label": "recordregistersessiontracebesteffort()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L415"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_resolveoccurredat",
-      "label": "resolveOccurredAt()",
-      "norm_label": "resolveoccurredat()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L77"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_resolvestorecurrency",
-      "label": "resolveStoreCurrency()",
-      "norm_label": "resolvestorecurrency()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L147"
-    },
-    {
-      "community": 321,
-      "file_type": "code",
-      "id": "registersessiontracing_safetracewrite",
-      "label": "safeTraceWrite()",
-      "norm_label": "safetracewrite()",
-      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
-      "source_location": "L93"
     },
     {
       "community": 3210,
@@ -297771,92 +297783,92 @@
     {
       "community": 322,
       "file_type": "code",
-      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
-      "label": "classifyFinalizedLineageRepairConflicts()",
-      "norm_label": "classifyfinalizedlineagerepairconflicts()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L222"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_classifyrepaircandidate",
-      "label": "classifyRepairCandidate()",
-      "norm_label": "classifyrepaircandidate()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L164"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
-      "label": "countRepairableFinalizedLineageLines()",
-      "norm_label": "countrepairablefinalizedlineagelines()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L284"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_getprovisionalimportsku",
-      "label": "getProvisionalImportSku()",
-      "norm_label": "getprovisionalimportsku()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L318"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
-      "label": "isClosedRegisterRepairReplayConflict()",
-      "norm_label": "isclosedregisterrepairreplayconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L273"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
-      "label": "isFinalizedLineageRepairConflict()",
-      "norm_label": "isfinalizedlineagerepairconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L258"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
-      "label": "isProvisionalRowChangedConflict()",
-      "norm_label": "isprovisionalrowchangedconflict()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L265"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
-      "label": "recordFinalizedLineageRepairEvent()",
-      "norm_label": "recordfinalizedlineagerepairevent()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L358"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "finalizedlineageremediation_skipped",
-      "label": "skipped()",
-      "norm_label": "skipped()",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
-      "source_location": "L346"
-    },
-    {
-      "community": 322,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
-      "label": "finalizedLineageRemediation.ts",
-      "norm_label": "finalizedlineageremediation.ts",
-      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "id": "packages_athena_webapp_convex_operations_registersessiontracing_ts",
+      "label": "registerSessionTracing.ts",
+      "norm_label": "registersessiontracing.ts",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
       "source_location": "L1"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_buildactorrefs",
+      "label": "buildActorRefs()",
+      "norm_label": "buildactorrefs()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtraceevent",
+      "label": "buildTraceEvent()",
+      "norm_label": "buildtraceevent()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L197"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_buildtracerecord",
+      "label": "buildTraceRecord()",
+      "norm_label": "buildtracerecord()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L162"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_displaytraceamount",
+      "label": "displayTraceAmount()",
+      "norm_label": "displaytraceamount()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L115"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_formattransactionlabel",
+      "label": "formatTransactionLabel()",
+      "norm_label": "formattransactionlabel()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L133"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_recordregistersessiontracebesteffort",
+      "label": "recordRegisterSessionTraceBestEffort()",
+      "norm_label": "recordregistersessiontracebesteffort()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L415"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_resolveoccurredat",
+      "label": "resolveOccurredAt()",
+      "norm_label": "resolveoccurredat()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L77"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_resolvestorecurrency",
+      "label": "resolveStoreCurrency()",
+      "norm_label": "resolvestorecurrency()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L147"
+    },
+    {
+      "community": 322,
+      "file_type": "code",
+      "id": "registersessiontracing_safetracewrite",
+      "label": "safeTraceWrite()",
+      "norm_label": "safetracewrite()",
+      "source_file": "packages/athena-webapp/convex/operations/registerSessionTracing.ts",
+      "source_location": "L93"
     },
     {
       "community": 3220,
@@ -297951,91 +297963,91 @@
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_day",
-      "label": "day()",
-      "norm_label": "day()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1308"
+      "id": "finalizedlineageremediation_classifyfinalizedlineagerepairconflicts",
+      "label": "classifyFinalizedLineageRepairConflicts()",
+      "norm_label": "classifyfinalizedlineagerepairconflicts()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L222"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_fieldsof",
-      "label": "fieldsOf()",
-      "norm_label": "fieldsof()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L86"
+      "id": "finalizedlineageremediation_classifyrepaircandidate",
+      "label": "classifyRepairCandidate()",
+      "norm_label": "classifyrepaircandidate()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L164"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_headerfor",
-      "label": "headerFor()",
-      "norm_label": "headerfor()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L972"
+      "id": "finalizedlineageremediation_countrepairablefinalizedlineagelines",
+      "label": "countRepairableFinalizedLineageLines()",
+      "norm_label": "countrepairablefinalizedlineagelines()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L284"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_inclusivedays",
-      "label": "inclusiveDays()",
-      "norm_label": "inclusivedays()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1216"
+      "id": "finalizedlineageremediation_getprovisionalimportsku",
+      "label": "getProvisionalImportSku()",
+      "norm_label": "getprovisionalimportsku()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L318"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_movementidentityargs",
-      "label": "movementIdentityArgs()",
-      "norm_label": "movementidentityargs()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L602"
+      "id": "finalizedlineageremediation_isclosedregisterrepairreplayconflict",
+      "label": "isClosedRegisterRepairReplayConflict()",
+      "norm_label": "isclosedregisterrepairreplayconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L273"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_probe",
-      "label": "probe()",
-      "norm_label": "probe()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L1312"
+      "id": "finalizedlineageremediation_isfinalizedlineagerepairconflict",
+      "label": "isFinalizedLineageRepairConflict()",
+      "norm_label": "isfinalizedlineagerepairconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L258"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_seedproductsku",
-      "label": "seedProductSku()",
-      "norm_label": "seedproductsku()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L561"
+      "id": "finalizedlineageremediation_isprovisionalrowchangedconflict",
+      "label": "isProvisionalRowChangedConflict()",
+      "norm_label": "isprovisionalrowchangedconflict()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L265"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_seedstore",
-      "label": "seedStore()",
-      "norm_label": "seedstore()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L542"
+      "id": "finalizedlineageremediation_recordfinalizedlineagerepairevent",
+      "label": "recordFinalizedLineageRepairEvent()",
+      "norm_label": "recordfinalizedlineagerepairevent()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L358"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "contract_test_unionliterals",
-      "label": "unionLiterals()",
-      "norm_label": "unionliterals()",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
-      "source_location": "L92"
+      "id": "finalizedlineageremediation_skipped",
+      "label": "skipped()",
+      "norm_label": "skipped()",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
+      "source_location": "L346"
     },
     {
       "community": 323,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
-      "label": "contract.test.ts",
-      "norm_label": "contract.test.ts",
-      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "id": "packages_athena_webapp_convex_pos_application_sync_finalizedlineageremediation_ts",
+      "label": "finalizedLineageRemediation.ts",
+      "norm_label": "finalizedlineageremediation.ts",
+      "source_file": "packages/athena-webapp/convex/pos/application/sync/finalizedLineageRemediation.ts",
       "source_location": "L1"
     },
     {
@@ -298131,91 +298143,91 @@
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_aggregateskudays",
-      "label": "aggregateSkuDays()",
-      "norm_label": "aggregateskudays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L241"
+      "id": "contract_test_day",
+      "label": "day()",
+      "norm_label": "day()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1308"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_computerange",
-      "label": "computeRange()",
-      "norm_label": "computerange()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L277"
+      "id": "contract_test_fieldsof",
+      "label": "fieldsOf()",
+      "norm_label": "fieldsof()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L86"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_computerequestkey",
-      "label": "computeRequestKey()",
-      "norm_label": "computerequestkey()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L85"
+      "id": "contract_test_headerfor",
+      "label": "headerFor()",
+      "norm_label": "headerfor()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L972"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_inclusivedayspan",
-      "label": "inclusiveDaySpan()",
-      "norm_label": "inclusivedayspan()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L56"
+      "id": "contract_test_inclusivedays",
+      "label": "inclusiveDays()",
+      "norm_label": "inclusivedays()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1216"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_isvalidoperatingdate",
-      "label": "isValidOperatingDate()",
-      "norm_label": "isvalidoperatingdate()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L39"
+      "id": "contract_test_movementidentityargs",
+      "label": "movementIdentityArgs()",
+      "norm_label": "movementidentityargs()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L602"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_requestrangecore",
-      "label": "requestRangeCore()",
-      "norm_label": "requestrangecore()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L113"
+      "id": "contract_test_probe",
+      "label": "probe()",
+      "norm_label": "probe()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L1312"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_sumdays",
-      "label": "sumDays()",
-      "norm_label": "sumdays()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L213"
+      "id": "contract_test_seedproductsku",
+      "label": "seedProductSku()",
+      "norm_label": "seedproductsku()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L561"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_utcmillisforlabel",
-      "label": "utcMillisForLabel()",
-      "norm_label": "utcmillisforlabel()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L50"
+      "id": "contract_test_seedstore",
+      "label": "seedStore()",
+      "norm_label": "seedstore()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L542"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "customrange_validaterangeargs",
-      "label": "validateRangeArgs()",
-      "norm_label": "validaterangeargs()",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
-      "source_location": "L62"
+      "id": "contract_test_unionliterals",
+      "label": "unionLiterals()",
+      "norm_label": "unionliterals()",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
+      "source_location": "L92"
     },
     {
       "community": 324,
       "file_type": "code",
-      "id": "packages_athena_webapp_convex_reports_customrange_ts",
-      "label": "customRange.ts",
-      "norm_label": "customrange.ts",
-      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "id": "packages_athena_webapp_convex_reports_contract_test_ts",
+      "label": "contract.test.ts",
+      "norm_label": "contract.test.ts",
+      "source_file": "packages/athena-webapp/convex/reports/contract.test.ts",
       "source_location": "L1"
     },
     {
@@ -298230,6 +298242,96 @@
     {
       "community": 325,
       "file_type": "code",
+      "id": "customrange_aggregateskudays",
+      "label": "aggregateSkuDays()",
+      "norm_label": "aggregateskudays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L241"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_computerange",
+      "label": "computeRange()",
+      "norm_label": "computerange()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L277"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_computerequestkey",
+      "label": "computeRequestKey()",
+      "norm_label": "computerequestkey()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L85"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_inclusivedayspan",
+      "label": "inclusiveDaySpan()",
+      "norm_label": "inclusivedayspan()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L56"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_isvalidoperatingdate",
+      "label": "isValidOperatingDate()",
+      "norm_label": "isvalidoperatingdate()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L39"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_requestrangecore",
+      "label": "requestRangeCore()",
+      "norm_label": "requestrangecore()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L113"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_sumdays",
+      "label": "sumDays()",
+      "norm_label": "sumdays()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L213"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_utcmillisforlabel",
+      "label": "utcMillisForLabel()",
+      "norm_label": "utcmillisforlabel()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L50"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "customrange_validaterangeargs",
+      "label": "validateRangeArgs()",
+      "norm_label": "validaterangeargs()",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L62"
+    },
+    {
+      "community": 325,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_reports_customrange_ts",
+      "label": "customRange.ts",
+      "norm_label": "customrange.ts",
+      "source_file": "packages/athena-webapp/convex/reports/customRange.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 326,
+      "file_type": "code",
       "id": "overview_anchordate",
       "label": "anchorDate()",
       "norm_label": "anchordate()",
@@ -298237,7 +298339,7 @@
       "source_location": "L156"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_buildoverviewdata",
       "label": "buildOverviewData()",
@@ -298246,7 +298348,7 @@
       "source_location": "L166"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_comparisonbp",
       "label": "comparisonBp()",
@@ -298255,7 +298357,7 @@
       "source_location": "L122"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_emptysnapshot",
       "label": "emptySnapshot()",
@@ -298264,7 +298366,7 @@
       "source_location": "L56"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_isunsettled",
       "label": "isUnsettled()",
@@ -298273,7 +298375,7 @@
       "source_location": "L67"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_readrecentdays",
       "label": "readRecentDays()",
@@ -298282,7 +298384,7 @@
       "source_location": "L303"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_rebuildstoreoverview",
       "label": "rebuildStoreOverview()",
@@ -298291,7 +298393,7 @@
       "source_location": "L317"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_snapshotfordays",
       "label": "snapshotForDays()",
@@ -298300,7 +298402,7 @@
       "source_location": "L83"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "overview_trustsummaryfordays",
       "label": "trustSummaryForDays()",
@@ -298309,7 +298411,7 @@
       "source_location": "L127"
     },
     {
-      "community": 325,
+      "community": 326,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_overview_ts",
       "label": "overview.ts",
@@ -298318,7 +298420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_rangesnapshotlifecycle_test_ts",
       "label": "rangeSnapshotLifecycle.test.ts",
@@ -298327,7 +298429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_allow",
       "label": "allow()",
@@ -298336,7 +298438,7 @@
       "source_location": "L53"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_certifyday",
       "label": "certifyDay()",
@@ -298345,7 +298447,7 @@
       "source_location": "L109"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_consume",
       "label": "consume()",
@@ -298354,7 +298456,7 @@
       "source_location": "L296"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_drive",
       "label": "drive()",
@@ -298363,7 +298465,7 @@
       "source_location": "L247"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_ensuresynthetic",
       "label": "ensureSynthetic()",
@@ -298372,7 +298474,7 @@
       "source_location": "L208"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_headerbykey",
       "label": "headerByKey()",
@@ -298381,7 +298483,7 @@
       "source_location": "L230"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_insertkindedheader",
       "label": "insertKindedHeader()",
@@ -298390,7 +298492,7 @@
       "source_location": "L612"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_seedstore",
       "label": "seedStore()",
@@ -298399,7 +298501,7 @@
       "source_location": "L73"
     },
     {
-      "community": 326,
+      "community": 327,
       "file_type": "code",
       "id": "rangesnapshotlifecycle_test_synthetickind",
       "label": "syntheticKind()",
@@ -298408,7 +298510,7 @@
       "source_location": "L150"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_rollupparity_ts",
       "label": "rollupParity.ts",
@@ -298417,7 +298519,7 @@
       "source_location": "L1"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_block",
       "label": "block()",
@@ -298426,7 +298528,7 @@
       "source_location": "L43"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_progress",
       "label": "progress()",
@@ -298435,7 +298537,7 @@
       "source_location": "L56"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_samemetrics",
       "label": "sameMetrics()",
@@ -298444,7 +298546,7 @@
       "source_location": "L32"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_validdate",
       "label": "validDate()",
@@ -298453,7 +298555,7 @@
       "source_location": "L35"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_validmetrics",
       "label": "validMetrics()",
@@ -298462,7 +298564,7 @@
       "source_location": "L29"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_verifycheckpointbatch",
       "label": "verifyCheckpointBatch()",
@@ -298471,7 +298573,7 @@
       "source_location": "L318"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_verifyinputbatch",
       "label": "verifyInputBatch()",
@@ -298480,7 +298582,7 @@
       "source_location": "L150"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_verifyoutputbatch",
       "label": "verifyOutputBatch()",
@@ -298489,7 +298591,7 @@
       "source_location": "L370"
     },
     {
-      "community": 327,
+      "community": 328,
       "file_type": "code",
       "id": "rollupparity_verifyrollupparitybatchwithctx",
       "label": "verifyRollupParityBatchWithCtx()",
@@ -298498,7 +298600,7 @@
       "source_location": "L75"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_reports_verificationclassify_ts",
       "label": "verificationClassify.ts",
@@ -298507,7 +298609,7 @@
       "source_location": "L1"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_buildclassification",
       "label": "buildClassification()",
@@ -298516,7 +298618,7 @@
       "source_location": "L448"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_classifydayresult",
       "label": "classifyDayResult()",
@@ -298525,7 +298627,7 @@
       "source_location": "L481"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_classifyweekresult",
       "label": "classifyWeekResult()",
@@ -298534,7 +298636,7 @@
       "source_location": "L562"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_confirmsclean",
       "label": "confirmsClean()",
@@ -298543,7 +298645,7 @@
       "source_location": "L681"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_explainmetricdifference",
       "label": "explainMetricDifference()",
@@ -298552,7 +298654,7 @@
       "source_location": "L378"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_fingerprintdifferences",
       "label": "fingerprintDifferences()",
@@ -298561,7 +298663,7 @@
       "source_location": "L354"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_initialstreakstate",
       "label": "initialStreakState()",
@@ -298570,7 +298672,7 @@
       "source_location": "L658"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_nextstreakstate",
       "label": "nextStreakState()",
@@ -298579,103 +298681,13 @@
       "source_location": "L707"
     },
     {
-      "community": 328,
+      "community": 329,
       "file_type": "code",
       "id": "verificationclassify_partitiondifferences",
       "label": "partitionDifferences()",
       "norm_label": "partitiondifferences()",
       "source_file": "packages/athena-webapp/convex/reports/verificationClassify.ts",
       "source_location": "L434"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_resolveverificationcoderecipient",
-      "label": "resolveVerificationCodeRecipient()",
-      "norm_label": "resolveverificationcoderecipient()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L19"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_senddailymanagerreportemail",
-      "label": "sendDailyManagerReportEmail()",
-      "norm_label": "senddailymanagerreportemail()",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L377"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_senddiscountcodeemail",
-      "label": "sendDiscountCodeEmail()",
-      "norm_label": "senddiscountcodeemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L255"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_senddiscountreminderemail",
-      "label": "sendDiscountReminderEmail()",
-      "norm_label": "senddiscountreminderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L334"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_sendfeedbackrequestemail",
-      "label": "sendFeedbackRequestEmail()",
-      "norm_label": "sendfeedbackrequestemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L167"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_sendneworderemail",
-      "label": "sendNewOrderEmail()",
-      "norm_label": "sendneworderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L117"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_sendorderemail",
-      "label": "sendOrderEmail()",
-      "norm_label": "sendorderemail()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L43"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "index_sendverificationcode",
-      "label": "sendVerificationCode()",
-      "norm_label": "sendverificationcode()",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L3"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_mailersend_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/mailersend/index.tsx",
-      "source_location": "L1"
-    },
-    {
-      "community": 329,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_sendgrid_index_tsx",
-      "label": "index.tsx",
-      "norm_label": "index.tsx",
-      "source_file": "packages/athena-webapp/convex/sendgrid/index.tsx",
-      "source_location": "L1"
     },
     {
       "community": 33,
@@ -324393,6 +324405,60 @@
     {
       "community": 570,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
+      "label": "public.test.ts",
+      "norm_label": "public.test.ts",
+      "source_file": "packages/athena-webapp/convex/customerMessaging/public.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "packages_athena_webapp_convex_remoteassist_public_test_ts",
+      "label": "public.test.ts",
+      "norm_label": "public.test.ts",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "public_test_admittedctx",
+      "label": "admittedCtx()",
+      "norm_label": "admittedctx()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
+      "source_location": "L60"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "public_test_buildclient",
+      "label": "buildClient()",
+      "norm_label": "buildclient()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
+      "source_location": "L353"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "public_test_buildsession",
+      "label": "buildSession()",
+      "norm_label": "buildsession()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
+      "source_location": "L378"
+    },
+    {
+      "community": 570,
+      "file_type": "code",
+      "id": "public_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
+      "source_location": "L45"
+    },
+    {
+      "community": 571,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_emails_registercloseoutvariancealert_tsx",
       "label": "RegisterCloseoutVarianceAlert.tsx",
       "norm_label": "registercloseoutvariancealert.tsx",
@@ -324400,7 +324466,7 @@
       "source_location": "L1"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealert",
       "label": "RegisterCloseoutVarianceAlert()",
@@ -324409,7 +324475,7 @@
       "source_location": "L60"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registercloseoutvariancealert_registercloseoutvariancealertemailpreview",
       "label": "RegisterCloseoutVarianceAlertEmailPreview()",
@@ -324418,7 +324484,7 @@
       "source_location": "L186"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registercloseoutvariancealert_sectionheading",
       "label": "SectionHeading()",
@@ -324427,7 +324493,7 @@
       "source_location": "L194"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registercloseoutvariancealert_statusbadge",
       "label": "StatusBadge()",
@@ -324436,7 +324502,7 @@
       "source_location": "L204"
     },
     {
-      "community": 570,
+      "community": 571,
       "file_type": "code",
       "id": "registercloseoutvariancealert_summaryvaluestylefor",
       "label": "summaryValueStyleFor()",
@@ -324445,7 +324511,7 @@
       "source_location": "L232"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_core_routes_walkthroughrequests_ts",
       "label": "walkthroughRequests.ts",
@@ -324454,7 +324520,7 @@
       "source_location": "L1"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "walkthroughrequests_canonical",
       "label": "canonical()",
@@ -324463,7 +324529,7 @@
       "source_location": "L26"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "walkthroughrequests_evaluatewalkthroughingress",
       "label": "evaluateWalkthroughIngress()",
@@ -324472,7 +324538,7 @@
       "source_location": "L18"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "walkthroughrequests_isvalidbody",
       "label": "isValidBody()",
@@ -324481,7 +324547,7 @@
       "source_location": "L28"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "walkthroughrequests_sha256",
       "label": "sha256()",
@@ -324490,7 +324556,7 @@
       "source_location": "L27"
     },
     {
-      "community": 571,
+      "community": 572,
       "file_type": "code",
       "id": "walkthroughrequests_text",
       "label": "text()",
@@ -324499,7 +324565,7 @@
       "source_location": "L25"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_http_domains_customerchannel_routes_security_ts",
       "label": "security.ts",
@@ -324508,7 +324574,7 @@
       "source_location": "L1"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "security_buildcanonicalcheckoutproducts",
       "label": "buildCanonicalCheckoutProducts()",
@@ -324517,7 +324583,7 @@
       "source_location": "L42"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "security_hasvalidpositivequantity",
       "label": "hasValidPositiveQuantity()",
@@ -324526,7 +324592,7 @@
       "source_location": "L27"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "security_isamounttampered",
       "label": "isAmountTampered()",
@@ -324535,7 +324601,7 @@
       "source_location": "L65"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "security_isauthorizedresourceowner",
       "label": "isAuthorizedResourceOwner()",
@@ -324544,7 +324610,7 @@
       "source_location": "L31"
     },
     {
-      "community": 572,
+      "community": 573,
       "file_type": "code",
       "id": "security_isduplicatechargesuccess",
       "label": "isDuplicateChargeSuccess()",
@@ -324553,7 +324619,7 @@
       "source_location": "L76"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "catalogimport_test_buildtrustedconversionargs",
       "label": "buildTrustedConversionArgs()",
@@ -324562,7 +324628,7 @@
       "source_location": "L397"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "catalogimport_test_createmutationctx",
       "label": "createMutationCtx()",
@@ -324571,7 +324637,7 @@
       "source_location": "L144"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "catalogimport_test_gethandler",
       "label": "getHandler()",
@@ -324580,7 +324646,7 @@
       "source_location": "L140"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "catalogimport_test_readtrustedconversionbinding",
       "label": "readTrustedConversionBinding()",
@@ -324589,7 +324655,7 @@
       "source_location": "L383"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "catalogimport_test_seedtrustedconversiondata",
       "label": "seedTrustedConversionData()",
@@ -324598,7 +324664,7 @@
       "source_location": "L289"
     },
     {
-      "community": 573,
+      "community": 574,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_catalogimport_test_ts",
       "label": "catalogImport.test.ts",
@@ -324607,7 +324673,7 @@
       "source_location": "L1"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "expensesessions_expensesessionerror",
       "label": "expenseSessionError()",
@@ -324616,7 +324682,7 @@
       "source_location": "L72"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "expensesessions_loadexpensesessionitems",
       "label": "loadExpenseSessionItems()",
@@ -324625,7 +324691,7 @@
       "source_location": "L139"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "expensesessions_mapexpensesessionvalidationerror",
       "label": "mapExpenseSessionValidationError()",
@@ -324634,7 +324700,7 @@
       "source_location": "L120"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "expensesessions_recordexpensesessionlifecycletrace",
       "label": "recordExpenseSessionLifecycleTrace()",
@@ -324643,7 +324709,7 @@
       "source_location": "L164"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "expensesessions_usererrorfromexpensesessioncommandfailure",
       "label": "userErrorFromExpenseSessionCommandFailure()",
@@ -324652,7 +324718,7 @@
       "source_location": "L86"
     },
     {
-      "community": 574,
+      "community": 575,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_expensesessions_ts",
       "label": "expenseSessions.ts",
@@ -324661,7 +324727,7 @@
       "source_location": "L1"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "featureditem_countfeaturedtargets",
       "label": "countFeaturedTargets()",
@@ -324670,7 +324736,7 @@
       "source_location": "L61"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "featureditem_getnextfeatureditemrank",
       "label": "getNextFeaturedItemRank()",
@@ -324679,7 +324745,7 @@
       "source_location": "L121"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "featureditem_listfeatureditemswithctx",
       "label": "listFeaturedItemsWithCtx()",
@@ -324688,7 +324754,7 @@
       "source_location": "L241"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "featureditem_requirehomepagestoreadmin",
       "label": "requireHomepageStoreAdmin()",
@@ -324697,7 +324763,7 @@
       "source_location": "L41"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "featureditem_validatefeaturedplacement",
       "label": "validateFeaturedPlacement()",
@@ -324706,7 +324772,7 @@
       "source_location": "L70"
     },
     {
-      "community": 575,
+      "community": 576,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventory_featureditem_ts",
       "label": "featuredItem.ts",
@@ -324715,7 +324781,7 @@
       "source_location": "L1"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "corrections_test_asadmitted",
       "label": "asAdmitted()",
@@ -324724,7 +324790,7 @@
       "source_location": "L48"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "corrections_test_correctionargs",
       "label": "correctionArgs()",
@@ -324733,7 +324799,7 @@
       "source_location": "L144"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "corrections_test_countcorrections",
       "label": "countCorrections()",
@@ -324742,7 +324808,7 @@
       "source_location": "L157"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "corrections_test_gethandler",
       "label": "getHandler()",
@@ -324751,7 +324817,7 @@
       "source_location": "L40"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "corrections_test_seedfixture",
       "label": "seedFixture()",
@@ -324760,7 +324826,7 @@
       "source_location": "L66"
     },
     {
-      "community": 576,
+      "community": 577,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_inventoryledger_corrections_test_ts",
       "label": "corrections.test.ts",
@@ -324769,7 +324835,7 @@
       "source_location": "L1"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createctx",
       "label": "createCtx()",
@@ -324778,7 +324844,7 @@
       "source_location": "L20"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_createstoreverificationctx",
       "label": "createStoreVerificationCtx()",
@@ -324787,7 +324853,7 @@
       "source_location": "L58"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishbackfill",
       "label": "finishBackfill()",
@@ -324796,7 +324862,7 @@
       "source_location": "L96"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_finishverification",
       "label": "finishVerification()",
@@ -324805,7 +324871,7 @@
       "source_location": "L116"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "backfillreportfactobservedat_test_observedatfield",
       "label": "observedAtField()",
@@ -324814,7 +324880,7 @@
       "source_location": "L264"
     },
     {
-      "community": 577,
+      "community": 578,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillreportfactobservedat_test_ts",
       "label": "backfillReportFactObservedAt.test.ts",
@@ -324823,7 +324889,7 @@
       "source_location": "L1"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "backfillstorecurrencycase_backfillstorecurrencycasewithctx",
       "label": "backfillStoreCurrencyCaseWithCtx()",
@@ -324832,7 +324898,7 @@
       "source_location": "L70"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "backfillstorecurrencycase_boundedlimit",
       "label": "boundedLimit()",
@@ -324841,7 +324907,7 @@
       "source_location": "L43"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "backfillstorecurrencycase_needsnormalization",
       "label": "needsNormalization()",
@@ -324850,7 +324916,7 @@
       "source_location": "L66"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "backfillstorecurrencycase_storepage",
       "label": "storePage()",
@@ -324859,7 +324925,7 @@
       "source_location": "L50"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "backfillstorecurrencycase_verifystorecurrencycasewithctx",
       "label": "verifyStoreCurrencyCaseWithCtx()",
@@ -324868,67 +324934,13 @@
       "source_location": "L133"
     },
     {
-      "community": 578,
+      "community": 579,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_migrations_backfillstorecurrencycase_ts",
       "label": "backfillStoreCurrencyCase.ts",
       "norm_label": "backfillstorecurrencycase.ts",
       "source_file": "packages/athena-webapp/convex/migrations/backfillStoreCurrencyCase.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_notifications_registry_ts",
-      "label": "registry.ts",
-      "norm_label": "registry.ts",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "registry_findnotificationkind",
-      "label": "findNotificationKind()",
-      "norm_label": "findnotificationkind()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L421"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "registry_getnotificationkind",
-      "label": "getNotificationKind()",
-      "norm_label": "getnotificationkind()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L431"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "registry_isstaledailyclosepayload",
-      "label": "isStaleDailyClosePayload()",
-      "norm_label": "isstaledailyclosepayload()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L88"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "registry_listnotificationkinds",
-      "label": "listNotificationKinds()",
-      "norm_label": "listnotificationkinds()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L439"
-    },
-    {
-      "community": 579,
-      "file_type": "code",
-      "id": "registry_requirestaledailyclosepayload",
-      "label": "requireStaleDailyClosePayload()",
-      "norm_label": "requirestaledailyclosepayload()",
-      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
-      "source_location": "L102"
     },
     {
       "community": 58,
@@ -325194,6 +325206,60 @@
     {
       "community": 580,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_notifications_registry_ts",
+      "label": "registry.ts",
+      "norm_label": "registry.ts",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "registry_findnotificationkind",
+      "label": "findNotificationKind()",
+      "norm_label": "findnotificationkind()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L421"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "registry_getnotificationkind",
+      "label": "getNotificationKind()",
+      "norm_label": "getnotificationkind()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L431"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "registry_isstaledailyclosepayload",
+      "label": "isStaleDailyClosePayload()",
+      "norm_label": "isstaledailyclosepayload()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L88"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "registry_listnotificationkinds",
+      "label": "listNotificationKinds()",
+      "norm_label": "listnotificationkinds()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L439"
+    },
+    {
+      "community": 580,
+      "file_type": "code",
+      "id": "registry_requirestaledailyclosepayload",
+      "label": "requireStaleDailyClosePayload()",
+      "norm_label": "requirestaledailyclosepayload()",
+      "source_file": "packages/athena-webapp/convex/notifications/registry.ts",
+      "source_location": "L102"
+    },
+    {
+      "community": 581,
+      "file_type": "code",
       "id": "definitions_costoverlaystorewriteoperation",
       "label": "costOverlayStoreWriteOperation()",
       "norm_label": "costoverlaystorewriteoperation()",
@@ -325201,7 +325267,7 @@
       "source_location": "L619"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "definitions_cyclecountdraftstorewriteoperation",
       "label": "cycleCountDraftStoreWriteOperation()",
@@ -325210,7 +325276,7 @@
       "source_location": "L405"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "definitions_inventoryimportreviewpayloadwriteoperation",
       "label": "inventoryImportReviewPayloadWriteOperation()",
@@ -325219,7 +325285,7 @@
       "source_location": "L589"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "definitions_notificationsubscriptionrowwriteoperation",
       "label": "notificationSubscriptionRowWriteOperation()",
@@ -325228,7 +325294,7 @@
       "source_location": "L695"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "definitions_validateoperationdefinition",
       "label": "validateOperationDefinition()",
@@ -325237,7 +325303,7 @@
       "source_location": "L834"
     },
     {
-      "community": 580,
+      "community": 581,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_definitions_ts",
       "label": "definitions.ts",
@@ -325246,7 +325312,7 @@
       "source_location": "L1"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "inventorycatalog_definitions_idarg",
       "label": "idArg()",
@@ -325255,7 +325321,7 @@
       "source_location": "L30"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "inventorycatalog_definitions_inventoryimportstorewrite",
       "label": "inventoryImportStoreWrite()",
@@ -325264,7 +325330,7 @@
       "source_location": "L170"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "inventorycatalog_definitions_rankedrowsstorescope",
       "label": "rankedRowsStoreScope()",
@@ -325273,7 +325339,7 @@
       "source_location": "L78"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "inventorycatalog_definitions_rowstorescope",
       "label": "rowStoreScope()",
@@ -325282,7 +325348,7 @@
       "source_location": "L39"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "inventorycatalog_definitions_rowstoretarget",
       "label": "rowStoreTarget()",
@@ -325291,7 +325357,7 @@
       "source_location": "L54"
     },
     {
-      "community": 581,
+      "community": 582,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_domains_inventorycatalog_definitions_ts",
       "label": "inventoryCatalog_definitions.ts",
@@ -325300,7 +325366,7 @@
       "source_location": "L1"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "inventoryidentity_definitions_expensewriteoperation",
       "label": "expenseWriteOperation()",
@@ -325309,7 +325375,7 @@
       "source_location": "L66"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "inventoryidentity_definitions_possessionwriteoperation",
       "label": "posSessionWriteOperation()",
@@ -325318,7 +325384,7 @@
       "source_location": "L91"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "inventoryidentity_definitions_resolveexpensesessionstore",
       "label": "resolveExpenseSessionStore()",
@@ -325327,7 +325393,7 @@
       "source_location": "L35"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "inventoryidentity_definitions_resolvepossessionstore",
       "label": "resolvePosSessionStore()",
@@ -325336,7 +325402,7 @@
       "source_location": "L45"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "inventoryidentity_definitions_storeprovideraction",
       "label": "storeProviderAction()",
@@ -325345,7 +325411,7 @@
       "source_location": "L594"
     },
     {
-      "community": 582,
+      "community": 583,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_domains_inventoryidentity_definitions_ts",
       "label": "inventoryIdentity_definitions.ts",
@@ -325354,7 +325420,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_domains_storefrontcustomer_readdefinitions_ts",
       "label": "storefrontCustomer_readDefinitions.ts",
@@ -325363,7 +325429,7 @@
       "source_location": "L1"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_customerbehaviorread",
       "label": "customerBehaviorRead()",
@@ -325372,7 +325438,7 @@
       "source_location": "L161"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_resolvestorefromrow",
       "label": "resolveStoreFromRow()",
@@ -325381,7 +325447,7 @@
       "source_location": "L36"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_resolvestorefromstorefrontactor",
       "label": "resolveStoreFromStorefrontActor()",
@@ -325390,7 +325456,7 @@
       "source_location": "L55"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_storefrontaccountread",
       "label": "storefrontAccountRead()",
@@ -325399,7 +325465,7 @@
       "source_location": "L269"
     },
     {
-      "community": 583,
+      "community": 584,
       "file_type": "code",
       "id": "storefrontcustomer_readdefinitions_storefrontread",
       "label": "storefrontRead()",
@@ -325408,7 +325474,7 @@
       "source_location": "L73"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operationadmission_resourceguards_ts",
       "label": "resourceGuards.ts",
@@ -325417,7 +325483,7 @@
       "source_location": "L1"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "resourceguards_evaluateoperationtargetguards",
       "label": "evaluateOperationTargetGuards()",
@@ -325426,7 +325492,7 @@
       "source_location": "L72"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "resourceguards_readidarg",
       "label": "readIdArg()",
@@ -325435,7 +325501,7 @@
       "source_location": "L10"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "resourceguards_resolveoperationtargetexternalrefs",
       "label": "resolveOperationTargetExternalRefs()",
@@ -325444,7 +325510,7 @@
       "source_location": "L47"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "resourceguards_resolveoperationtargetids",
       "label": "resolveOperationTargetIds()",
@@ -325453,7 +325519,7 @@
       "source_location": "L19"
     },
     {
-      "community": 584,
+      "community": 585,
       "file_type": "code",
       "id": "resourceguards_validateoperationtarget",
       "label": "validateOperationTarget()",
@@ -325462,7 +325528,7 @@
       "source_location": "L102"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_agentcapabilities_workports_ts",
       "label": "workPorts.ts",
@@ -325471,7 +325537,7 @@
       "source_location": "L1"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "workports_approvalproofof",
       "label": "approvalProofOf()",
@@ -325480,7 +325546,7 @@
       "source_location": "L131"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "workports_approvalstateversion",
       "label": "approvalStateVersion()",
@@ -325489,7 +325555,7 @@
       "source_location": "L127"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "workports_listapprovalshandler",
       "label": "listApprovalsHandler()",
@@ -325498,7 +325564,7 @@
       "source_location": "L143"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "workports_listattentionhandler",
       "label": "listAttentionHandler()",
@@ -325507,7 +325573,7 @@
       "source_location": "L49"
     },
     {
-      "community": 585,
+      "community": 586,
       "file_type": "code",
       "id": "workports_windowfallbackwarning",
       "label": "windowFallbackWarning()",
@@ -325516,7 +325582,7 @@
       "source_location": "L40"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "approvalproofs_consumeapprovalproofwithctx",
       "label": "consumeApprovalProofWithCtx()",
@@ -325525,7 +325591,7 @@
       "source_location": "L152"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "approvalproofs_createapprovalproofwithctx",
       "label": "createApprovalProofWithCtx()",
@@ -325534,7 +325600,7 @@
       "source_location": "L110"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "approvalproofs_getvalidapprovalproof",
       "label": "getValidApprovalProof()",
@@ -325543,7 +325609,7 @@
       "source_location": "L49"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "approvalproofs_invalidapprovalproofresult",
       "label": "invalidApprovalProofResult()",
@@ -325552,7 +325618,7 @@
       "source_location": "L103"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "approvalproofs_validateapprovalproofwithctx",
       "label": "validateApprovalProofWithCtx()",
@@ -325561,7 +325627,7 @@
       "source_location": "L88"
     },
     {
-      "community": 586,
+      "community": 587,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_approvalproofs_ts",
       "label": "approvalProofs.ts",
@@ -325570,7 +325636,7 @@
       "source_location": "L1"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "approval_builddailycloseapprovalsubject",
       "label": "buildDailyCloseApprovalSubject()",
@@ -325579,7 +325645,7 @@
       "source_location": "L15"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalrequirement",
       "label": "buildDailyCloseCarryForwardApprovalRequirement()",
@@ -325588,7 +325654,7 @@
       "source_location": "L101"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "approval_builddailyclosecarryforwardapprovalsubject",
       "label": "buildDailyCloseCarryForwardApprovalSubject()",
@@ -325597,7 +325663,7 @@
       "source_location": "L88"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "approval_builddailyclosecompletionapprovalrequirement",
       "label": "buildDailyCloseCompletionApprovalRequirement()",
@@ -325606,7 +325672,7 @@
       "source_location": "L26"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "approval_builddailyclosereopenapprovalrequirement",
       "label": "buildDailyCloseReopenApprovalRequirement()",
@@ -325615,7 +325681,7 @@
       "source_location": "L54"
     },
     {
-      "community": 587,
+      "community": 588,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_dailyclose_approval_ts",
       "label": "approval.ts",
@@ -325624,7 +325690,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "eventbuilders_buildonlineorderoperationaleventmessage",
       "label": "buildOnlineOrderOperationalEventMessage()",
@@ -325633,7 +325699,7 @@
       "source_location": "L68"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "eventbuilders_buildoperationaleventmessage",
       "label": "buildOperationalEventMessage()",
@@ -325642,7 +325708,7 @@
       "source_location": "L1"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "eventbuilders_buildstockadjustmentoperationaleventmessage",
       "label": "buildStockAdjustmentOperationalEventMessage()",
@@ -325651,7 +325717,7 @@
       "source_location": "L93"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "eventbuilders_formatonlineorderlabel",
       "label": "formatOnlineOrderLabel()",
@@ -325660,7 +325726,7 @@
       "source_location": "L112"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "eventbuilders_formatstockadjustmentsubjectdetail",
       "label": "formatStockAdjustmentSubjectDetail()",
@@ -325669,67 +325735,13 @@
       "source_location": "L106"
     },
     {
-      "community": 588,
+      "community": 589,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_helpers_eventbuilders_ts",
       "label": "eventBuilders.ts",
       "norm_label": "eventbuilders.ts",
       "source_file": "packages/athena-webapp/convex/operations/helpers/eventBuilders.ts",
       "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
-      "label": "serviceIntake.test.ts",
-      "norm_label": "serviceintake.test.ts",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "serviceintake_test_buildcreateserviceintakeargs",
-      "label": "buildCreateServiceIntakeArgs()",
-      "norm_label": "buildcreateserviceintakeargs()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L40"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "serviceintake_test_createmutationctx",
-      "label": "createMutationCtx()",
-      "norm_label": "createmutationctx()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L54"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "serviceintake_test_createserviceintakebehaviorctx",
-      "label": "createServiceIntakeBehaviorCtx()",
-      "norm_label": "createserviceintakebehaviorctx()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L98"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "serviceintake_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L36"
-    },
-    {
-      "community": 589,
-      "file_type": "code",
-      "id": "serviceintake_test_getsource",
-      "label": "getSource()",
-      "norm_label": "getsource()",
-      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
-      "source_location": "L32"
     },
     {
       "community": 59,
@@ -325995,6 +326007,60 @@
     {
       "community": 590,
       "file_type": "code",
+      "id": "packages_athena_webapp_convex_operations_serviceintake_test_ts",
+      "label": "serviceIntake.test.ts",
+      "norm_label": "serviceintake.test.ts",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L1"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "serviceintake_test_buildcreateserviceintakeargs",
+      "label": "buildCreateServiceIntakeArgs()",
+      "norm_label": "buildcreateserviceintakeargs()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L40"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "serviceintake_test_createmutationctx",
+      "label": "createMutationCtx()",
+      "norm_label": "createmutationctx()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L54"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "serviceintake_test_createserviceintakebehaviorctx",
+      "label": "createServiceIntakeBehaviorCtx()",
+      "norm_label": "createserviceintakebehaviorctx()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L98"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "serviceintake_test_gethandler",
+      "label": "getHandler()",
+      "norm_label": "gethandler()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L36"
+    },
+    {
+      "community": 590,
+      "file_type": "code",
+      "id": "serviceintake_test_getsource",
+      "label": "getSource()",
+      "norm_label": "getsource()",
+      "source_file": "packages/athena-webapp/convex/operations/serviceIntake.test.ts",
+      "source_location": "L32"
+    },
+    {
+      "community": 591,
+      "file_type": "code",
       "id": "packages_athena_webapp_convex_operations_weeklymanagerreportemail_test_ts",
       "label": "weeklyManagerReportEmail.test.ts",
       "norm_label": "weeklymanagerreportemail.test.ts",
@@ -326002,7 +326068,7 @@
       "source_location": "L1"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_buildpayload",
       "label": "buildPayload()",
@@ -326011,7 +326077,7 @@
       "source_location": "L128"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_countedcashsection",
       "label": "countedCashSection()",
@@ -326020,7 +326086,7 @@
       "source_location": "L234"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_evidencecoverage",
       "label": "evidenceCoverage()",
@@ -326029,7 +326095,7 @@
       "source_location": "L61"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_lineageday",
       "label": "lineageDay()",
@@ -326038,7 +326104,7 @@
       "source_location": "L117"
     },
     {
-      "community": 590,
+      "community": 591,
       "file_type": "code",
       "id": "weeklymanagerreportemail_test_makecloseevidence",
       "label": "makeCloseEvidence()",
@@ -326047,7 +326113,7 @@
       "source_location": "L69"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "completetransaction_test_createvoidctx",
       "label": "createVoidCtx()",
@@ -326056,7 +326122,7 @@
       "source_location": "L219"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "completetransaction_test_expectnocompletionsideeffects",
       "label": "expectNoCompletionSideEffects()",
@@ -326065,7 +326131,7 @@
       "source_location": "L197"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "completetransaction_test_expectnovoidbusinesssideeffects",
       "label": "expectNoVoidBusinessSideEffects()",
@@ -326074,7 +326140,7 @@
       "source_location": "L211"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "completetransaction_test_seeddirect",
       "label": "seedDirect()",
@@ -326083,7 +326149,7 @@
       "source_location": "L4983"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "completetransaction_test_seeddirecthappypath",
       "label": "seedDirectHappyPath()",
@@ -326092,7 +326158,7 @@
       "source_location": "L4826"
     },
     {
-      "community": 591,
+      "community": 592,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_completetransaction_test_ts",
       "label": "completeTransaction.test.ts",
@@ -326101,7 +326167,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_application_queries_registerlifecycleauthority_test_ts",
       "label": "registerLifecycleAuthority.test.ts",
@@ -326110,7 +326176,7 @@
       "source_location": "L1"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_createrepository",
       "label": "createRepository()",
@@ -326119,7 +326185,7 @@
       "source_location": "L675"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mapping",
       "label": "mapping()",
@@ -326128,7 +326194,7 @@
       "source_location": "L741"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_mappingauthority",
       "label": "mappingAuthority()",
@@ -326137,7 +326203,7 @@
       "source_location": "L708"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_registersession",
       "label": "registerSession()",
@@ -326146,7 +326212,7 @@
       "source_location": "L760"
     },
     {
-      "community": 592,
+      "community": 593,
       "file_type": "code",
       "id": "registerlifecycleauthority_test_terminal",
       "label": "terminal()",
@@ -326155,7 +326221,7 @@
       "source_location": "L726"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "localsyncrepository_areconflictdetailsequivalent",
       "label": "areConflictDetailsEquivalent()",
@@ -326164,7 +326230,7 @@
       "source_location": "L67"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "localsyncrepository_createconvexlocalsyncrepository",
       "label": "createConvexLocalSyncRepository()",
@@ -326173,7 +326239,7 @@
       "source_location": "L157"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "localsyncrepository_omitundefined",
       "label": "omitUndefined()",
@@ -326182,7 +326248,7 @@
       "source_location": "L61"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "localsyncrepository_reportfactsfromlocalsyncingressargs",
       "label": "reportFactsFromLocalSyncIngressArgs()",
@@ -326191,7 +326257,7 @@
       "source_location": "L112"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "localsyncrepository_trimoptional",
       "label": "trimOptional()",
@@ -326200,7 +326266,7 @@
       "source_location": "L97"
     },
     {
-      "community": 593,
+      "community": 594,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_infrastructure_repositories_localsyncrepository_ts",
       "label": "localSyncRepository.ts",
@@ -326209,7 +326275,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "packages_athena_webapp_convex_pos_public_telemetry_test_ts",
       "label": "telemetry.test.ts",
@@ -326218,7 +326284,7 @@
       "source_location": "L1"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "telemetry_test_baseevent",
       "label": "baseEvent()",
@@ -326227,7 +326293,7 @@
       "source_location": "L108"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "telemetry_test_createctx",
       "label": "createCtx()",
@@ -326236,7 +326302,7 @@
       "source_location": "L34"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "telemetry_test_gethandler",
       "label": "getHandler()",
@@ -326245,7 +326311,7 @@
       "source_location": "L24"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "telemetry_test_storedevent",
       "label": "storedEvent()",
@@ -326254,67 +326320,13 @@
       "source_location": "L528"
     },
     {
-      "community": 594,
+      "community": 595,
       "file_type": "code",
       "id": "telemetry_test_v2event",
       "label": "v2Event()",
       "norm_label": "v2event()",
       "source_file": "packages/athena-webapp/convex/pos/public/telemetry.test.ts",
       "source_location": "L120"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_customermessaging_public_test_ts",
-      "label": "public.test.ts",
-      "norm_label": "public.test.ts",
-      "source_file": "packages/athena-webapp/convex/customerMessaging/public.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "packages_athena_webapp_convex_remoteassist_public_test_ts",
-      "label": "public.test.ts",
-      "norm_label": "public.test.ts",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
-      "source_location": "L1"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "public_test_admittedctx",
-      "label": "admittedCtx()",
-      "norm_label": "admittedctx()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
-      "source_location": "L60"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "public_test_buildclient",
-      "label": "buildClient()",
-      "norm_label": "buildclient()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
-      "source_location": "L353"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "public_test_buildsession",
-      "label": "buildSession()",
-      "norm_label": "buildsession()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
-      "source_location": "L378"
-    },
-    {
-      "community": 595,
-      "file_type": "code",
-      "id": "public_test_gethandler",
-      "label": "getHandler()",
-      "norm_label": "gethandler()",
-      "source_file": "packages/athena-webapp/convex/remoteAssist/public.test.ts",
-      "source_location": "L45"
     },
     {
       "community": 596,

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -9,7 +9,7 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 ## Repo Summary
 - Code files discovered: 3317
 - Graph nodes: 14828
-- Graph edges: 18482
+- Graph edges: 18483
 - Communities: 3241
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/operations/dailyClose.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.test.ts
@@ -1863,6 +1863,54 @@ describe("end-of-day review backend foundation", () => {
     );
   });
 
+  it("keeps open POS session blockers on a historic operating date long after the sessions expired", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 6, 19, 12));
+
+    const { db } = createDb({
+      posSession: [
+        {
+          _id: "pos-historic-held",
+          createdAt: Date.UTC(2026, 4, 7, 14),
+          expiresAt: Date.UTC(2026, 4, 7, 20),
+          registerNumber: "A1",
+          sessionNumber: "SES-HIST",
+          status: "held",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          updatedAt: Date.UTC(2026, 4, 7, 14),
+        },
+        {
+          _id: "pos-other-day",
+          createdAt: Date.UTC(2026, 4, 9, 14),
+          expiresAt: Date.UTC(2026, 4, 9, 20),
+          sessionNumber: "SES-OTHER",
+          status: "held",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          updatedAt: Date.UTC(2026, 4, 9, 14),
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal-1",
+          displayName: "Front counter terminal",
+          storeId: "store-1",
+        },
+      ],
+      store: [store],
+    });
+
+    const snapshot = await buildDailyCloseSnapshotWithCtx(
+      { db } as unknown as QueryCtx,
+      { operatingDate: "2026-05-07", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.blockers.map((item) => item.key)).toEqual([
+      "pos_session:pos-historic-held:held",
+    ]);
+    expect(snapshot.readiness.blockerCount).toBeGreaterThan(0);
+    expect(snapshot.readiness.status).not.toBe("ready");
+  });
   it("preserves active register blocker context on the exported snapshot query", async () => {
     mockDailyCloseSnapshotAccess("pos_only");
     const { db } = createDb({

--- a/packages/athena-webapp/convex/operations/dailyClose.ts
+++ b/packages/athena-webapp/convex/operations/dailyClose.ts
@@ -1593,7 +1593,14 @@ async function listOpenPosSessions(
   },
 ): Promise<DailyCloseSourceRead<Doc<"posSession">>> {
   const range = { startAt: args.startAt, endAt: args.endAt };
+  // A POS session counts for an operating day when it intersects that day's
+  // range. On a day that is still in progress, sessions whose hold has already
+  // lapsed are additionally suppressed, because an operator can no longer act
+  // on them. That suppression is anchored to the requested day, not to the
+  // reader's clock: for a day that has already ended, the wall clock is past
+  // every session's expiry and would erase the day's blockers entirely.
   const now = Date.now();
+  const requestedDayIsInProgress = isInRange(now, range.startAt, range.endAt);
   const sessionPages = await Promise.all(
     OPEN_POS_SESSION_STATUSES.map((status) =>
       ctx.db
@@ -1610,7 +1617,8 @@ async function listOpenPosSessions(
       .flat()
       .filter(
         (session) =>
-          session.expiresAt >= now && posSessionIntersectsRange(session, args),
+          (!requestedDayIsInProgress || session.expiresAt >= now) &&
+          posSessionIntersectsRange(session, args),
       ),
     completeness: sourceCompletenessEntry({
       source: "pos_session",

--- a/telemetry/delivery-runs/2026-09-02T04-28-12-347Z-codex-v26-1082-daily-close-pos-session-clock.json
+++ b/telemetry/delivery-runs/2026-09-02T04-28-12-347Z-codex-v26-1082-daily-close-pos-session-clock.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-09-02T04:28:12.347Z",
+  "branch": "codex/V26-1082-daily-close-pos-session-clock",
+  "headSha": "1abb06d6450b9cffb342a8011e83e74c926ecc47",
+  "deliverableDiffFingerprint": "4d88d6335564c9ce42862f88274f1969009a899c5688a182c6a4e074bbe863cc",
+  "status": "pass",
+  "proofState": "proof_recorded",
+  "summary": {
+    "commandCount": 5,
+    "failedCommandCount": 0,
+    "duplicateCommandCount": 0,
+    "duplicatePackageSuiteCount": 0,
+    "providerSkippedCount": 5,
+    "gateDecisionCount": 2,
+    "totalDurationMs": 1022553.240499
+  },
+  "reviewLoop": {
+    "providerId": "execute",
+    "runId": "v26-1082-r1",
+    "finalPassId": "pass-1",
+    "recordedAt": "2026-09-02T04:11:06.366Z",
+    "iterationCount": 1,
+    "findingCounts": {
+      "P0": 0,
+      "P1": 0,
+      "P2": 0,
+      "P3": 0
+    },
+    "deferredExpansionCount": 0,
+    "deferredIssueIds": []
+  }
+}


### PR DESCRIPTION
## Summary

`listOpenPosSessions` filtered open POS sessions with a wall-clock test (`session.expiresAt >= Date.now()`) layered on top of the date-relative range test that `posSessionIntersectsRange` already applies. On any operating date other than today the wall clock is past every session's expiry, so the filter returned zero rows unconditionally.

This anchors the lapsed-hold suppression to the requested operating day rather than to the reader's clock: it applies only while the requested day is still in progress, which is the current-day case it was written for. Current-day behavior is byte-for-byte unchanged; historic days now return the sessions that were actually open.

## Why

Surviving rows from that filter become hard blockers. With the filter returning nothing, a historic Daily Close silently under-reported `readiness.blockerCount`, dropped the `pos_session` blocker category entirely, and could flip `status` from `blocked` to `ready` — the day looked more closeable than it was. The path is reachable from all three operations workspaces via `buildDailyOperationsSnapshotWithCtx` -> `buildDailyCloseSnapshotWithCtx` -> `listOpenPosSessions`, not just EOD Review.

The two overlapping filters also disagreed about their reference point. There is now one rule: a session counts for a day when it intersects that day's range, and on a day still in progress a session whose hold has already lapsed is additionally suppressed because an operator can no longer act on it.

## Validation

Posture: `characterization-first`. The existing current-day test (`classifies blockers, review items, carry-forward items, ready items, and summary totals`, which mocks `Date.now()` inside the operating day and covers the boundary session whose `expiresAt` is inside the range but before now) was captured green before the predicate changed. The historic-replay regression guard was then added and confirmed red before the fix.

- `bun run test -- convex/operations/dailyClose.test.ts` — 104/104 pass
- `bun run test -- convex/operations/dailyOperations.test.ts dailyOperationsAutomation.test.ts dailyOpening.test.ts` — 231/231 pass
- `bun run --filter '@athena/webapp' typecheck` — clean
- `audit:convex`, `lint:convex:changed` — clean
- `git diff --check` — clean
- `bun run pr:athena` — `status=pass proof=proof_recorded commands=5 failed=0 duplicates=0`
- Review checkpoint: provider `execute`, run `v26-1082-r1`, 3 lenses (`correctness`, `test-integrity`, `convex-read-path`), 1 iteration, unanimous approval, P0=0 P1=0 P2=0 P3=0, 0 deferred. Recorded via `bun run harness:review-evidence`. The `test-integrity` lens independently verified the new guard fails when the fix is reverted.
- `bun run delivery:telemetry-record` — committed

https://linear.app/v26-labs/issue/V26-1082/daily-close-open-pos-session-blocker-is-filtered-by-wall-clock-erasing
